### PR TITLE
Build family onboarding with create-family and join-code flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ If either environment variable is missing or invalid, the server fails fast duri
 - Users can now register with name, e-post, and password
 - Users can log in and out with a signed cookie session
 - Protected routes redirect unauthenticated requests to `/login`
-- The first protected route lives at `/app`
-- Authenticated users can create a family or join one with a family code
+- The first protected route lives at `/app` and acts as the current family onboarding and landing state
+- Authenticated users can create a family or join one with a family code from that protected flow
 
 ## Useful Commands
 

--- a/app/lib/family.server.test.ts
+++ b/app/lib/family.server.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, randomIntMock, txMock } = vi.hoisted(() => {
+  const tx = {
+    family: {
+      create: vi.fn(),
+    },
+    familyMembership: {
+      create: vi.fn(),
+    },
+  };
+
+  const db = {
+    family: {
+      findUnique: vi.fn(),
+    },
+    familyMembership: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  };
+
+  return {
+    dbMock: db,
+    randomIntMock: vi.fn(),
+    txMock: tx,
+  };
+});
+
+vi.mock("node:crypto", async () => {
+  const actual = await vi.importActual<typeof import("node:crypto")>("node:crypto");
+
+  return {
+    ...actual,
+    randomInt: randomIntMock,
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+import { createFamilyForUser, joinFamilyByCode } from "./family.server";
+
+describe("family.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.$transaction.mockImplementation(async (callback: (tx: typeof txMock) => unknown) => {
+      return callback(txMock);
+    });
+  });
+
+  it("creates a family, retries join-code collisions, and adds the creator as admin", async () => {
+    randomIntMock
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(1);
+
+    dbMock.family.findUnique.mockResolvedValueOnce({ id: "family-existing" }).mockResolvedValueOnce(null);
+    txMock.family.create.mockResolvedValue({
+      id: "family-1",
+      joinCode: "BBBBBB",
+      name: "Solberg",
+    });
+    txMock.familyMembership.create.mockResolvedValue({
+      familyId: "family-1",
+      id: "membership-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+
+    const result = await createFamilyForUser({
+      name: " Solberg ",
+      userId: "user-1",
+    });
+
+    expect(dbMock.family.findUnique).toHaveBeenNthCalledWith(1, {
+      where: { joinCode: "AAAAAA" },
+      select: { id: true },
+    });
+    expect(dbMock.family.findUnique).toHaveBeenNthCalledWith(2, {
+      where: { joinCode: "BBBBBB" },
+      select: { id: true },
+    });
+    expect(txMock.family.create).toHaveBeenCalledWith({
+      data: {
+        createdByUserId: "user-1",
+        joinCode: "BBBBBB",
+        name: "Solberg",
+      },
+      select: {
+        id: true,
+        joinCode: true,
+        name: true,
+      },
+    });
+    expect(txMock.familyMembership.create).toHaveBeenCalledWith({
+      data: {
+        familyId: "family-1",
+        role: "ADMIN",
+        userId: "user-1",
+      },
+    });
+    expect(result).toEqual({
+      id: "family-1",
+      joinCode: "BBBBBB",
+      name: "Solberg",
+    });
+  });
+
+  it("returns NOT_FOUND when the join code does not match a family", async () => {
+    dbMock.family.findUnique.mockResolvedValue(null);
+
+    const result = await joinFamilyByCode({
+      joinCode: "ABC123",
+      userId: "user-1",
+    });
+
+    expect(dbMock.family.findUnique).toHaveBeenCalledWith({
+      where: { joinCode: "ABC123" },
+      select: {
+        id: true,
+        joinCode: true,
+        name: true,
+      },
+    });
+    expect(result).toEqual({
+      status: "NOT_FOUND",
+    });
+    expect(dbMock.familyMembership.findUnique).not.toHaveBeenCalled();
+    expect(dbMock.familyMembership.create).not.toHaveBeenCalled();
+  });
+
+  it("returns ALREADY_MEMBER without creating a duplicate membership", async () => {
+    dbMock.family.findUnique.mockResolvedValue({
+      id: "family-1",
+      joinCode: "ABC123",
+      name: "Solberg",
+    });
+    dbMock.familyMembership.findUnique.mockResolvedValue({
+      id: "membership-1",
+    });
+
+    const result = await joinFamilyByCode({
+      joinCode: "ABC123",
+      userId: "user-1",
+    });
+
+    expect(dbMock.familyMembership.create).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "ALREADY_MEMBER",
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+    });
+  });
+
+  it("normalizes join codes before creating a new family membership", async () => {
+    dbMock.family.findUnique.mockResolvedValue({
+      id: "family-1",
+      joinCode: "ABC123",
+      name: "Solberg",
+    });
+    dbMock.familyMembership.findUnique.mockResolvedValue(null);
+    dbMock.familyMembership.create.mockResolvedValue({
+      familyId: "family-1",
+      id: "membership-1",
+      role: "MEMBER",
+      userId: "user-1",
+    });
+
+    const result = await joinFamilyByCode({
+      joinCode: " abc123 ",
+      userId: "user-1",
+    });
+
+    expect(dbMock.family.findUnique).toHaveBeenCalledWith({
+      where: { joinCode: "ABC123" },
+      select: {
+        id: true,
+        joinCode: true,
+        name: true,
+      },
+    });
+    expect(dbMock.familyMembership.create).toHaveBeenCalledWith({
+      data: {
+        familyId: "family-1",
+        role: "MEMBER",
+        userId: "user-1",
+      },
+    });
+    expect(result).toEqual({
+      status: "JOINED",
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+    });
+  });
+});

--- a/app/routes/app.action.test.ts
+++ b/app/routes/app.action.test.ts
@@ -18,8 +18,22 @@ vi.mock("../lib/family.server", () => {
 });
 
 import { requireUser } from "../lib/auth.server";
-import { createFamilyForUser } from "../lib/family.server";
+import { createFamilyForUser, joinFamilyByCode } from "../lib/family.server";
 import { action } from "./app";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(formData: FormData) {
+  return new Request("http://localhost/app", {
+    body: formData,
+    method: "POST",
+  });
+}
 
 describe("app route action", () => {
   afterEach(() => {
@@ -27,21 +41,12 @@ describe("app route action", () => {
   });
 
   it("returns onboarding validation errors when a family name is missing", async () => {
-    vi.mocked(requireUser).mockResolvedValue({
-      displayName: "Ola",
-      email: "ola@example.com",
-      id: "user-1",
-      isGlobalAdmin: false,
-    });
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
 
     const formData = new FormData();
     formData.set("intent", "create-family");
     formData.set("familyName", "");
-
-    const request = new Request("http://localhost/app", {
-      body: formData,
-      method: "POST",
-    });
+    const request = buildRequest(formData);
 
     const result = await action({
       params: {},
@@ -56,5 +61,141 @@ describe("app route action", () => {
       intent: "create-family",
     });
     expect(createFamilyForUser).not.toHaveBeenCalled();
+  });
+
+  it("creates a family and redirects with an explicit success notice", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createFamilyForUser).mockResolvedValue({
+      id: "family-1",
+      joinCode: "ABC123",
+      name: "Solberg",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-family");
+    formData.set("familyName", "Solberg");
+
+    const result = await action({
+      params: {},
+      request: buildRequest(formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(createFamilyForUser).toHaveBeenCalledWith({
+      name: "Solberg",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("http://localhost/app?notice=family-created");
+  });
+
+  it("returns onboarding validation errors when a join code is missing", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+
+    const formData = new FormData();
+    formData.set("intent", "join-family");
+    formData.set("joinCode", "");
+
+    const result = await action({
+      params: {},
+      request: buildRequest(formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(result).toMatchObject({
+      fieldErrors: {
+        joinCode: "Skriv inn familiekoden.",
+      },
+      intent: "join-family",
+    });
+    expect(joinFamilyByCode).not.toHaveBeenCalled();
+  });
+
+  it("returns a form error when the join code does not match a family", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(joinFamilyByCode).mockResolvedValue({
+      status: "NOT_FOUND",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "join-family");
+    formData.set("joinCode", "ABC123");
+
+    const result = await action({
+      params: {},
+      request: buildRequest(formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(joinFamilyByCode).toHaveBeenCalledWith({
+      joinCode: "ABC123",
+      userId: "user-1",
+    });
+    expect(result).toMatchObject({
+      formError: "Fant ingen familie med denne koden.",
+      intent: "join-family",
+      values: {
+        joinCode: "ABC123",
+      },
+    });
+  });
+
+  it("redirects with an explicit notice when the user is already a member", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(joinFamilyByCode).mockResolvedValue({
+      status: "ALREADY_MEMBER",
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "join-family");
+    formData.set("joinCode", "ABC123");
+
+    const result = await action({
+      params: {},
+      request: buildRequest(formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("http://localhost/app?notice=family-already-member");
+  });
+
+  it("redirects with an explicit success notice when a family is joined", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(joinFamilyByCode).mockResolvedValue({
+      status: "JOINED",
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "join-family");
+    formData.set("joinCode", "ABC123");
+
+    const result = await action({
+      params: {},
+      request: buildRequest(formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("http://localhost/app?notice=family-joined");
   });
 });

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -8,6 +8,8 @@ import {
   joinFamilyByCode,
 } from "../lib/family.server";
 
+type AppNotice = "family-already-member" | "family-created" | "family-joined";
+
 interface AppActionData {
   fieldErrors?: {
     familyName?: string;
@@ -19,6 +21,43 @@ interface AppActionData {
     familyName?: string;
     joinCode?: string;
   };
+}
+
+function getAppNotice(request: Request): AppNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (notice === "family-created" || notice === "family-joined" || notice === "family-already-member") {
+    return notice;
+  }
+
+  return null;
+}
+
+function buildAppRedirect(request: Request, notice: AppNotice) {
+  const url = new URL("/app", request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function getNoticeContent(notice: AppNotice) {
+  switch (notice) {
+    case "family-created":
+      return {
+        description: "Du opprettet en familie og ble lagt til som administrator.",
+        title: "Familien er klar",
+      };
+    case "family-joined":
+      return {
+        description: "Du er lagt til i familien og kan fortsette i den beskyttede appen.",
+        title: "Du ble med i familien",
+      };
+    case "family-already-member":
+      return {
+        description: "Du hadde allerede tilgang til denne familien, sa vi viste deg oversikten i stedet.",
+        title: "Du er allerede medlem",
+      };
+  }
 }
 
 export const meta: Route.MetaFunction = () => {
@@ -34,6 +73,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   return {
     memberships,
+    notice: getAppNotice(request),
     user,
   };
 }
@@ -63,7 +103,7 @@ export async function action({ request }: Route.ActionArgs) {
       userId: user.id,
     });
 
-    return Response.redirect(new URL("/app", request.url), 302);
+    return buildAppRedirect(request, "family-created");
   }
 
   if (intent === "join-family") {
@@ -96,7 +136,11 @@ export async function action({ request }: Route.ActionArgs) {
       } satisfies AppActionData;
     }
 
-    return Response.redirect(new URL("/app", request.url), 302);
+    if (result.status === "ALREADY_MEMBER") {
+      return buildAppRedirect(request, "family-already-member");
+    }
+
+    return buildAppRedirect(request, "family-joined");
   }
 
   return {
@@ -108,6 +152,7 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
   const hasFamilies = loaderData.memberships.length > 0;
+  const noticeContent = loaderData.notice ? getNoticeContent(loaderData.notice) : null;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -121,8 +166,8 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
               <h1 className="mt-4 text-4xl font-semibold tracking-tight">Hei, {loaderData.user.displayName}</h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
                 {hasFamilies
-                  ? "Du er logget inn og klar for neste steg i produksjonsappen."
-                  : "Du er logget inn. Opprett en familie eller bli med i en eksisterende familie for a komme videre."}
+                  ? "Dette er den beskyttede familieoversikten din, klar for videre arbeid med ukeplaner og handlelister."
+                  : "Dette er den beskyttede inngangen til appen. Opprett en familie eller bli med i en eksisterende familie for a komme videre."}
               </p>
             </div>
 
@@ -145,10 +190,25 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
           </div>
         </section>
 
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+          </section>
+        ) : null}
+
         {hasFamilies ? (
           <>
+            <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+              <h2 className="text-lg font-semibold text-slate-950">Familier du har tilgang til</h2>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                Dette er den forste beskyttede familieflaten i produksjonsappen. Hver familie er klar som
+                utgangspunkt for neste steg med ukeplaner, handlelister og samarbeid.
+              </p>
+            </section>
+
             <section className="grid gap-4 md:grid-cols-3">
-              {loaderData.memberships.map((membership) => (
+              {loaderData.memberships.map((membership: (typeof loaderData.memberships)[number]) => (
                 <article
                   key={membership.id}
                   className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
@@ -163,7 +223,9 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
                     Familiekode: <span className="font-semibold text-slate-900">{membership.family.joinCode}</span>
                   </p>
                   <p className="mt-2 text-sm leading-6 text-slate-600">
-                    Denne delen er klar for videre arbeid med ukeplaner, handlelister og samarbeid.
+                    {membership.role === "ADMIN"
+                      ? "Du er administrator for denne familien og kan dele koden for a invitere flere senere."
+                      : "Du har tilgang til denne familien og er klar for videre arbeid med ukeplaner og samarbeid."}
                   </p>
                 </article>
               ))}
@@ -172,8 +234,8 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
             <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
               <h2 className="text-lg font-semibold text-slate-950">Hva kommer na</h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                Auth, session og beskyttede ruter er pa plass. Neste steg er a bygge ukeplaner, familievisning
-                og handleliste pa toppen av ekte serverdata.
+                Familieonboarding, auth, session og beskyttede ruter er pa plass. Neste steg er a bygge
+                familievisning, ukeplaner og handleliste pa toppen av ekte serverdata.
               </p>
             </section>
           </>


### PR DESCRIPTION
## Summary
- make the protected `/app` onboarding flow return explicit notices for family creation, joining, and already-member cases
- improve the first authenticated family landing copy so `/app` reads as the current protected onboarding and landing state
- add focused route and server tests for create and join flows, join-code normalization, and admin membership creation

Closes #5.

## Test plan
- [x] `npm run test -- --run app/routes/app.action.test.ts app/lib/family.server.test.ts app/routes/app.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`