### PR TITLE
Add family member authorization and management flow

### DIFF
--- a/app/lib/auth.server.test.ts
+++ b/app/lib/auth.server.test.ts
@@ -1,8 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getSafeRedirectTo, hashPassword, requireUser, verifyPassword } from "./auth.server";
+const { dbMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      user: {
+        findUnique: vi.fn(),
+      },
+    },
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+import { getSafeRedirectTo, hashPassword, requireAnonymous, requireUser, verifyPassword } from "./auth.server";
+import { getSession, sessionStorage } from "./session.server";
 
 describe("auth.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("hashes and verifies passwords", async () => {
     const passwordHash = await hashPassword("super-secret-password");
 
@@ -31,5 +52,23 @@ describe("auth.server", () => {
       expect(response.status).toBe(302);
       expect(response.headers.get("Location")).toBe("/login?redirectTo=%2Fapp%3Ftab%3Doverview");
     }
+  });
+
+  it("treats stale session cookies as anonymous users", async () => {
+    const request = new Request("http://localhost/login");
+    const session = await getSession(request);
+    session.set("userId", "missing-user");
+
+    dbMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(
+      requireAnonymous(
+        new Request("http://localhost/login", {
+          headers: {
+            Cookie: await sessionStorage.commitSession(session),
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -95,9 +95,9 @@ export async function requireUser(request: Request) {
 }
 
 export async function requireAnonymous(request: Request) {
-  const userId = await getUserId(request);
+  const user = await getCurrentUser(request);
 
-  if (!userId) {
+  if (!user) {
     return;
   }
 

--- a/app/lib/family.server.test.ts
+++ b/app/lib/family.server.test.ts
@@ -16,6 +16,7 @@ const { dbMock, randomIntMock, txMock } = vi.hoisted(() => {
     },
     familyMembership: {
       create: vi.fn(),
+      delete: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
     },
@@ -44,7 +45,15 @@ vi.mock("./db.server", () => {
   };
 });
 
-import { createFamilyForUser, joinFamilyByCode } from "./family.server";
+import {
+  createFamilyForUser,
+  getFamilyMembershipForUser,
+  joinFamilyByCode,
+  listFamilyMembers,
+  removeFamilyMember,
+  requireFamilyAdmin,
+  requireFamilyMembership,
+} from "./family.server";
 
 describe("family.server", () => {
   beforeEach(() => {
@@ -211,6 +220,274 @@ describe("family.server", () => {
         joinCode: "ABC123",
         name: "Solberg",
       },
+    });
+  });
+
+  it("looks up a family membership by family and user id", async () => {
+    dbMock.familyMembership.findUnique.mockResolvedValue({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      id: "membership-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+
+    const result = await getFamilyMembershipForUser({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.familyMembership.findUnique).toHaveBeenCalledWith({
+      where: {
+        familyId_userId: {
+          familyId: "family-1",
+          userId: "user-1",
+        },
+      },
+      select: {
+        id: true,
+        familyId: true,
+        role: true,
+        userId: true,
+        family: {
+          select: {
+            id: true,
+            joinCode: true,
+            name: true,
+          },
+        },
+      },
+    });
+    expect(result).toEqual({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      id: "membership-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+  });
+
+  it("throws a not found response when the user is not part of the family", async () => {
+    dbMock.familyMembership.findUnique.mockResolvedValue(null);
+
+    await expect(
+      requireFamilyMembership({
+        familyId: "family-1",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+
+  it("throws a forbidden response when a family member is not an admin", async () => {
+    dbMock.familyMembership.findUnique.mockResolvedValue({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      id: "membership-1",
+      role: "MEMBER",
+      userId: "user-1",
+    });
+
+    await expect(
+      requireFamilyAdmin({
+        familyId: "family-1",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      statusText: "Forbidden",
+    });
+  });
+
+  it("lists family members for the management UI", async () => {
+    dbMock.familyMembership.findMany.mockResolvedValue([
+      {
+        id: "membership-1",
+        role: "ADMIN",
+        user: {
+          displayName: "Ola",
+          email: "ola@example.com",
+          id: "user-1",
+        },
+      },
+    ]);
+
+    const result = await listFamilyMembers("family-1");
+
+    expect(dbMock.familyMembership.findMany).toHaveBeenCalledWith({
+      where: { familyId: "family-1" },
+      orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+      select: {
+        id: true,
+        role: true,
+        user: {
+          select: {
+            displayName: true,
+            email: true,
+            id: true,
+          },
+        },
+      },
+    });
+    expect(result).toEqual([
+      {
+        id: "membership-1",
+        role: "ADMIN",
+        user: {
+          displayName: "Ola",
+          email: "ola@example.com",
+          id: "user-1",
+        },
+      },
+    ]);
+  });
+
+  it("removes a non-admin family member when requested by an admin", async () => {
+    dbMock.familyMembership.findUnique
+      .mockResolvedValueOnce({
+        family: {
+          id: "family-1",
+          joinCode: "ABC123",
+          name: "Solberg",
+        },
+        familyId: "family-1",
+        id: "membership-admin",
+        role: "ADMIN",
+        userId: "user-admin",
+      })
+      .mockResolvedValueOnce({
+        id: "membership-member",
+        role: "MEMBER",
+        user: {
+          displayName: "Kari",
+          id: "user-member",
+        },
+      });
+
+    const result = await removeFamilyMember({
+      actorUserId: "user-admin",
+      familyId: "family-1",
+      targetUserId: "user-member",
+    });
+
+    expect(dbMock.familyMembership.delete).toHaveBeenCalledWith({
+      where: { id: "membership-member" },
+    });
+    expect(result).toEqual({
+      status: "REMOVED",
+      removedUser: {
+        displayName: "Kari",
+        id: "user-member",
+      },
+    });
+  });
+
+  it("refuses to remove another admin", async () => {
+    dbMock.familyMembership.findUnique
+      .mockResolvedValueOnce({
+        family: {
+          id: "family-1",
+          joinCode: "ABC123",
+          name: "Solberg",
+        },
+        familyId: "family-1",
+        id: "membership-admin",
+        role: "ADMIN",
+        userId: "user-admin",
+      })
+      .mockResolvedValueOnce({
+        id: "membership-target-admin",
+        role: "ADMIN",
+        user: {
+          displayName: "Kari",
+          id: "user-target-admin",
+        },
+      });
+
+    const result = await removeFamilyMember({
+      actorUserId: "user-admin",
+      familyId: "family-1",
+      targetUserId: "user-target-admin",
+    });
+
+    expect(dbMock.familyMembership.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "CANNOT_REMOVE_ADMIN",
+    });
+  });
+
+  it("refuses to remove the acting admin", async () => {
+    dbMock.familyMembership.findUnique
+      .mockResolvedValueOnce({
+        family: {
+          id: "family-1",
+          joinCode: "ABC123",
+          name: "Solberg",
+        },
+        familyId: "family-1",
+        id: "membership-admin",
+        role: "ADMIN",
+        userId: "user-admin",
+      })
+      .mockResolvedValueOnce({
+        id: "membership-admin",
+        role: "ADMIN",
+        user: {
+          displayName: "Ola",
+          id: "user-admin",
+        },
+      });
+
+    const result = await removeFamilyMember({
+      actorUserId: "user-admin",
+      familyId: "family-1",
+      targetUserId: "user-admin",
+    });
+
+    expect(dbMock.familyMembership.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "CANNOT_REMOVE_SELF",
+    });
+  });
+
+  it("returns NOT_FOUND when the target user is not in the family", async () => {
+    dbMock.familyMembership.findUnique
+      .mockResolvedValueOnce({
+        family: {
+          id: "family-1",
+          joinCode: "ABC123",
+          name: "Solberg",
+        },
+        familyId: "family-1",
+        id: "membership-admin",
+        role: "ADMIN",
+        userId: "user-admin",
+      })
+      .mockResolvedValueOnce(null);
+
+    const result = await removeFamilyMember({
+      actorUserId: "user-admin",
+      familyId: "family-1",
+      targetUserId: "user-member",
+    });
+
+    expect(dbMock.familyMembership.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "NOT_FOUND",
     });
   });
 });

--- a/app/lib/family.server.ts
+++ b/app/lib/family.server.ts
@@ -7,6 +7,36 @@ import { db } from "./db.server";
 const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const JOIN_CODE_LENGTH = 6;
 const MAX_JOIN_CODE_ATTEMPTS = 10;
+const familySummarySelect = {
+  id: true,
+  name: true,
+};
+
+const familyMembershipSelect = {
+  id: true,
+  familyId: true,
+  role: true,
+  userId: true,
+  family: {
+    select: {
+      id: true,
+      joinCode: true,
+      name: true,
+    },
+  },
+};
+
+const familyMemberSelect = {
+  id: true,
+  role: true,
+  user: {
+    select: {
+      displayName: true,
+      email: true,
+      id: true,
+    },
+  },
+};
 
 export async function getFamilyMembershipsForUser(userId: string) {
   return db.familyMembership.findMany({
@@ -16,13 +46,61 @@ export async function getFamilyMembershipsForUser(userId: string) {
       id: true,
       role: true,
       family: {
-        select: {
-          id: true,
-          name: true,
-          joinCode: true,
-        },
+        select: familySummarySelect,
       },
     },
+  });
+}
+
+export async function getFamilyMembershipForUser({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  return db.familyMembership.findUnique({
+    where: {
+      familyId_userId: {
+        familyId,
+        userId,
+      },
+    },
+    select: familyMembershipSelect,
+  });
+}
+
+export async function requireFamilyMembership(input: { familyId: string; userId: string }) {
+  const membership = await getFamilyMembershipForUser(input);
+
+  if (!membership) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return membership;
+}
+
+export async function requireFamilyAdmin(input: { familyId: string; userId: string }) {
+  const membership = await requireFamilyMembership(input);
+
+  if (membership.role !== "ADMIN") {
+    throw new Response("Du har ikke tilgang til a administrere denne familien.", {
+      status: 403,
+      statusText: "Forbidden",
+    });
+  }
+
+  return membership;
+}
+
+export async function listFamilyMembers(familyId: string) {
+  return db.familyMembership.findMany({
+    where: { familyId },
+    orderBy: [{ role: "asc" }, { createdAt: "asc" }],
+    select: familyMemberSelect,
   });
 }
 
@@ -112,6 +190,61 @@ export async function joinFamilyByCode({
   return {
     status: "JOINED" as const,
     family,
+  };
+}
+
+export async function removeFamilyMember({
+  familyId,
+  actorUserId,
+  targetUserId,
+}: {
+  familyId: string;
+  actorUserId: string;
+  targetUserId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId: actorUserId,
+  });
+
+  const targetMembership = await db.familyMembership.findUnique({
+    where: {
+      familyId_userId: {
+        familyId,
+        userId: targetUserId,
+      },
+    },
+    select: {
+      id: true,
+      role: true,
+      user: {
+        select: {
+          displayName: true,
+          id: true,
+        },
+      },
+    },
+  });
+
+  if (!targetMembership) {
+    return { status: "NOT_FOUND" as const };
+  }
+
+  if (targetMembership.user.id === actorUserId) {
+    return { status: "CANNOT_REMOVE_SELF" as const };
+  }
+
+  if (targetMembership.role !== "MEMBER") {
+    return { status: "CANNOT_REMOVE_ADMIN" as const };
+  }
+
+  await db.familyMembership.delete({
+    where: { id: targetMembership.id },
+  });
+
+  return {
+    status: "REMOVED" as const,
+    removedUser: targetMembership.user,
   };
 }
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,6 +3,7 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
 export default [
   index("routes/home.tsx"),
   route("app", "routes/app.tsx"),
+  route("families/:familyId", "routes/family.tsx"),
   route("login", "routes/login.tsx"),
   route("logout", "routes/logout.tsx"),
   route("prototype", "routes/prototype.tsx"),

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -220,13 +220,16 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
                     </span>
                   </div>
                   <p className="mt-3 text-sm leading-6 text-slate-600">
-                    Familiekode: <span className="font-semibold text-slate-900">{membership.family.joinCode}</span>
-                  </p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
                     {membership.role === "ADMIN"
-                      ? "Du er administrator for denne familien og kan dele koden for a invitere flere senere."
-                      : "Du har tilgang til denne familien og er klar for videre arbeid med ukeplaner og samarbeid."}
+                      ? "Du er administrator for denne familien og kan administrere medlemmer fra familieoversikten."
+                      : "Du har tilgang til denne familien og kan apne familieoversikten for videre arbeid."}
                   </p>
+                  <Link
+                    className="mt-5 inline-flex rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                    to={`/families/${membership.family.id}`}
+                  >
+                    Apne familie
+                  </Link>
                 </article>
               ))}
             </section>

--- a/app/routes/family.test.ts
+++ b/app/routes/family.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>("../lib/auth.server");
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/family.server", () => {
+  return {
+    listFamilyMembers: vi.fn(),
+    removeFamilyMember: vi.fn(),
+    requireFamilyMembership: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { listFamilyMembers, removeFamilyMember, requireFamilyMembership } from "../lib/family.server";
+import { action, loader } from "./family";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(url = "http://localhost/families/family-1", formData?: FormData) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns admin-only family data for admins", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      id: "membership-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+    vi.mocked(listFamilyMembers).mockResolvedValue([
+      {
+        id: "membership-1",
+        role: "ADMIN",
+        user: {
+          displayName: "Ola",
+          email: "ola@example.com",
+          id: "user-1",
+        },
+      },
+    ]);
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1?notice=member-removed"),
+      context: {} as never,
+    } as unknown as Parameters<typeof loader>[0]);
+
+    expect(requireFamilyMembership).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(listFamilyMembers).toHaveBeenCalledWith("family-1");
+    expect(result).toEqual({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      members: [
+        {
+          id: "membership-1",
+          role: "ADMIN",
+          user: {
+            displayName: "Ola",
+            email: "ola@example.com",
+            id: "user-1",
+          },
+        },
+      ],
+      notice: "member-removed",
+      user: mockUser,
+      userRole: "ADMIN",
+    });
+  });
+
+  it("hides the join code and member list from regular members", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      id: "membership-2",
+      role: "MEMBER",
+      userId: "user-1",
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(),
+      context: {} as never,
+    } as unknown as Parameters<typeof loader>[0]);
+
+    expect(listFamilyMembers).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      family: {
+        id: "family-1",
+        joinCode: null,
+        name: "Solberg",
+      },
+      members: [],
+      notice: null,
+      user: mockUser,
+      userRole: "MEMBER",
+    });
+  });
+
+  it("rethrows the login redirect for unauthenticated requests", async () => {
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: {
+        Location: "/login?redirectTo=%2Ffamilies%2Ffamily-1",
+      },
+    });
+
+    vi.mocked(requireUser).mockRejectedValue(redirectResponse);
+
+    await expect(
+      loader({
+        params: {
+          familyId: "family-1",
+        },
+        request: buildRequest(),
+        context: {} as never,
+      } as unknown as Parameters<typeof loader>[0]),
+    ).rejects.toBe(redirectResponse);
+  });
+
+  it("redirects after an admin removes a member", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(removeFamilyMember).mockResolvedValue({
+      status: "REMOVED",
+      removedUser: {
+        displayName: "Kari",
+        id: "user-2",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "remove-member");
+    formData.set("targetUserId", "user-2");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1", formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(removeFamilyMember).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      familyId: "family-1",
+      targetUserId: "user-2",
+    });
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1?notice=member-removed",
+    );
+  });
+
+  it("returns a form error when the member to remove is missing", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+
+    const formData = new FormData();
+    formData.set("intent", "remove-member");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1", formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(removeFamilyMember).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      formError: "Fant ikke medlemmet som skulle fjernes.",
+    });
+  });
+
+  it("returns a specific error when trying to remove another admin", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(removeFamilyMember).mockResolvedValue({
+      status: "CANNOT_REMOVE_ADMIN",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "remove-member");
+    formData.set("targetUserId", "user-2");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1", formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(result).toEqual({
+      formError: "Bare vanlige medlemmer kan fjernes i denne versjonen.",
+      targetUserId: "user-2",
+    });
+  });
+
+  it("rethrows forbidden admin-only action errors", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(removeFamilyMember).mockRejectedValue(
+      new Response("Du har ikke tilgang til a administrere denne familien.", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    const formData = new FormData();
+    formData.set("intent", "remove-member");
+    formData.set("targetUserId", "user-2");
+
+    await expect(
+      action({
+        params: {
+          familyId: "family-1",
+        },
+        request: buildRequest("http://localhost/families/family-1", formData),
+        context: {} as never,
+      } as unknown as Parameters<typeof action>[0]),
+    ).rejects.toMatchObject({
+      status: 403,
+      statusText: "Forbidden",
+    });
+  });
+});

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -1,0 +1,322 @@
+import { Form, Link, isRouteErrorResponse, useNavigation } from "react-router";
+
+import type { Route } from "./+types/family";
+import { requireUser } from "../lib/auth.server";
+import {
+  listFamilyMembers,
+  removeFamilyMember,
+  requireFamilyMembership,
+} from "../lib/family.server";
+
+type FamilyNotice = "member-removed";
+
+interface FamilyActionData {
+  formError?: string;
+  targetUserId?: string;
+}
+
+function getFamilyNotice(request: Request): FamilyNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (notice === "member-removed") {
+    return notice;
+  }
+
+  return null;
+}
+
+function buildFamilyRedirect({
+  request,
+  familyId,
+  notice,
+}: {
+  request: Request;
+  familyId: string;
+  notice: FamilyNotice;
+}) {
+  const url = new URL(`/families/${familyId}`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function getFamilyNoticeContent(notice: FamilyNotice) {
+  switch (notice) {
+    case "member-removed":
+      return {
+        description: "Medlemmet ble fjernet fra familien.",
+        title: "Endringen er lagret",
+      };
+  }
+}
+
+export const meta: Route.MetaFunction = () => {
+  return [
+    { title: "Familie | Mealplanner" },
+    { name: "description", content: "Familieoversikt og medlemsadministrasjon i Mealplanner." },
+  ];
+};
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const user = await requireUser(request);
+  const familyId = params.familyId;
+
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId: user.id,
+  });
+  const members = membership.role === "ADMIN" ? await listFamilyMembers(familyId) : [];
+
+  return {
+    family: {
+      id: membership.family.id,
+      joinCode: membership.role === "ADMIN" ? membership.family.joinCode : null,
+      name: membership.family.name,
+    },
+    members,
+    notice: getFamilyNotice(request),
+    user,
+    userRole: membership.role,
+  };
+}
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const user = await requireUser(request);
+  const familyId = params.familyId;
+
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent !== "remove-member") {
+    return {
+      formError: "Ukjent handling.",
+    } satisfies FamilyActionData;
+  }
+
+  const targetUserId = String(formData.get("targetUserId") ?? "");
+
+  if (!targetUserId) {
+    return {
+      formError: "Fant ikke medlemmet som skulle fjernes.",
+    } satisfies FamilyActionData;
+  }
+
+  const result = await removeFamilyMember({
+    actorUserId: user.id,
+    familyId,
+    targetUserId,
+  });
+
+  if (result.status === "REMOVED") {
+    return buildFamilyRedirect({
+      familyId,
+      notice: "member-removed",
+      request,
+    });
+  }
+
+  if (result.status === "NOT_FOUND") {
+    return {
+      formError: "Fant ikke medlemmet i denne familien.",
+      targetUserId,
+    } satisfies FamilyActionData;
+  }
+
+  if (result.status === "CANNOT_REMOVE_SELF") {
+    return {
+      formError: "Du kan ikke fjerne deg selv fra familien.",
+      targetUserId,
+    } satisfies FamilyActionData;
+  }
+
+  return {
+    formError: "Bare vanlige medlemmer kan fjernes i denne versjonen.",
+    targetUserId,
+  } satisfies FamilyActionData;
+}
+
+export default function FamilyRoute({ actionData, loaderData }: Route.ComponentProps) {
+  const navigation = useNavigation();
+  const noticeContent = loaderData.notice ? getFamilyNoticeContent(loaderData.notice) : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingTargetUserId = String(navigation.formData?.get("targetUserId") ?? "");
+  const isRemovingMember = navigation.state === "submitting" && pendingIntent === "remove-member";
+  const isAdmin = loaderData.userRole === "ADMIN";
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Familie
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.family.name}</h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                {isAdmin
+                  ? "Du kan administrere medlemmer og dele familiekoden med nye deltakere."
+                  : "Du har tilgang til familien og kan bruke den videre beskyttede appen."}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to="/app"
+              >
+                Tilbake til oversikten
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+          </section>
+        ) : null}
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold text-slate-950">Din tilgang</h2>
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
+                {isAdmin ? "Admin" : "Medlem"}
+              </span>
+            </div>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              {isAdmin
+                ? "Administratorer kan se familiekoden og fjerne vanlige medlemmer ved behov."
+                : "Bare administratorer kan se familiekoden og administrere medlemmer."}
+            </p>
+          </article>
+
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">Familiekode</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              {loaderData.family.joinCode
+                ? "Del denne koden med personer som skal bli med i familien."
+                : "Familiekoden er bare synlig for administratorer."}
+            </p>
+            <p className="mt-4 text-2xl font-semibold tracking-[0.28em] text-slate-950">
+              {loaderData.family.joinCode ?? "Skjult"}
+            </p>
+          </article>
+        </section>
+
+        {isAdmin ? (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Medlemmer</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Du kan fjerne vanlige medlemmer fra familien. Andre administratorer kan ikke fjernes her.
+              </p>
+            </div>
+
+            <div className="mt-6 grid gap-4">
+              {loaderData.members.map((member: (typeof loaderData.members)[number]) => {
+                const canRemove = member.role === "MEMBER";
+                const isPendingRemoval = isRemovingMember && pendingTargetUserId === member.user.id;
+                const memberError =
+                  actionData?.targetUserId === member.user.id ? actionData.formError : undefined;
+
+                return (
+                  <article
+                    key={member.id}
+                    className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                  >
+                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-3">
+                          <h3 className="text-base font-semibold text-slate-950">{member.user.displayName}</h3>
+                          <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
+                            {member.role === "ADMIN" ? "Admin" : "Medlem"}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm leading-6 text-slate-600">{member.user.email}</p>
+                      </div>
+
+                      {canRemove ? (
+                        <Form method="post">
+                          <input name="intent" type="hidden" value="remove-member" />
+                          <input name="targetUserId" type="hidden" value={member.user.id} />
+                          <button
+                            className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+                            disabled={isRemovingMember}
+                            type="submit"
+                          >
+                            {isPendingRemoval ? "Fjerner..." : "Fjern medlem"}
+                          </button>
+                        </Form>
+                      ) : null}
+                    </div>
+
+                    {memberError ? (
+                      <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                        {memberError}
+                      </p>
+                    ) : null}
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        ) : (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">Neste steg</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+              Familieadministrasjon ligger hos administratorene. Du kan fortsette videre til resten av den
+              beskyttede appen fra oversikten din.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  let title = "Noe gikk galt";
+  let description = "Vi klarte ikke a laste familieoversikten.";
+
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 403) {
+      title = "Ingen tilgang";
+      description = "Du har ikke tilgang til a administrere denne familien.";
+    } else if (error.status === 404) {
+      title = "Familien finnes ikke";
+      description = "Vi fant ikke familien du forsokte a apne.";
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto max-w-3xl rounded-[28px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+          to="/app"
+        >
+          Tilbake til oversikten
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add family-scoped authorization helpers and a dedicated family route for admin-only join-code visibility and member removal
- update the app dashboard to link into family management instead of exposing join codes directly
- fix stale auth sessions so login and registration do not redirect-loop on invalid cookies

## Test plan
- [x] npm run test -- --run
- [x] npm run typecheck

Closes #6