### PR TITLE
Implement meal plan CRUD with date-range validation

### DIFF
--- a/.cursor/skills/persist-agent-handoff/SKILL.md
+++ b/.cursor/skills/persist-agent-handoff/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: persist-agent-handoff
+description: Maintains a repo-root AGENT_HANDOFF.md with a concise snapshot of completed work, validation, risks, and next steps before a commit or pull request. Use when wrapping up coding work, preparing a commit, opening or updating a PR, handing work to the next agent, or continuing from a previous agent handoff.
+---
+
+# Persist Agent Handoff
+
+## Goal
+
+Leave the repository in a state where the next agent can understand the latest work quickly by reading `AGENT_HANDOFF.md`.
+
+## When To Use
+
+Use this skill when:
+
+- Wrapping up implementation work
+- Preparing to create a commit
+- Preparing to open or update a pull request
+- Handing work off to another agent
+- Picking up work that another agent already summarized
+
+## Core Rules
+
+- Treat `AGENT_HANDOFF.md` as the latest handoff snapshot, not a long-running diary.
+- Keep the file concise and current. Replace stale details instead of appending noisy history.
+- Never claim tests, linting, or manual checks were run unless they actually were.
+- Call out blockers, unfinished work, and risks plainly.
+- Prefer concrete file and feature names over generic wording.
+
+## Start-Of-Task Check
+
+Before making substantial changes, read `AGENT_HANDOFF.md` if it exists.
+
+Use it to understand:
+
+- The last task in progress
+- What was already completed
+- What still needs follow-up
+- Which files are the best starting points
+
+If the file is missing, continue normally and create it during wrap-up.
+
+## Wrap-Up Workflow
+
+Before your final commit or pull request wrap-up:
+
+1. Review the work completed in the current task.
+2. Confirm which checks actually ran.
+3. Update `AGENT_HANDOFF.md` with the latest state.
+4. Make sure the file reflects the current snapshot of the branch, including unfinished work.
+
+## Required Sections
+
+Write `AGENT_HANDOFF.md` with this structure:
+
+```markdown
+# Agent Handoff
+
+## Current Objective
+
+[One or two sentences describing the active goal or recently completed task.]
+
+## Completed
+
+- [Concrete change]
+- [Concrete change]
+
+## Files To Read First
+
+- `path/to/file` - [Why it matters]
+- `path/to/file` - [Why it matters]
+
+## Validation
+
+- [Command run or manual check performed]
+- [If nothing was run, say `Not run yet.`]
+
+## Open Items
+
+- [Remaining task, risk, or blocker]
+- [Anything the next agent should verify]
+
+## Next Step
+
+[Single best next action for the next agent.]
+```
+
+## Writing Guidance
+
+- `Current Objective`: Describe the current branch goal, not the whole project.
+- `Completed`: Focus on user-visible or structurally important changes.
+- `Files To Read First`: List only the few files that matter most for continuing the work.
+- `Validation`: Include exact checks that ran, or explicitly say none ran yet.
+- `Open Items`: Include bugs, missing polish, unanswered questions, or cleanup still needed.
+- `Next Step`: Make this actionable enough that the next agent can start immediately.
+
+## Quality Bar
+
+Good handoffs are:
+
+- Short enough to scan in under a minute
+- Specific enough that another agent can resume work without re-discovering context
+- Honest about incomplete work and test coverage
+
+Avoid:
+
+- Repeating every file touched
+- Copying large diff summaries
+- Writing vague notes like `fixed stuff` or `needs testing`
+
+## Example Triggers
+
+- `Create a commit and update the handoff`
+- `Open a PR and leave a summary for the next agent`
+- `Summarize what changed before wrapping up`
+- `Continue from the previous agent handoff`

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -1,0 +1,36 @@
+# Agent Handoff
+
+## Current Objective
+
+Implement issue `#7`'s first production meal-plan CRUD flow. The branch now has family-scoped, server-backed meal-plan create/list/select/update/delete with persisted date ranges and centralized 7-day validation.
+
+## Completed
+
+- Added `app/lib/meal-plan.server.ts` with family-scoped meal-plan CRUD, UTC date-only helpers, and shared `startDate` / `endDate` validation.
+- Added dedicated production routes in `app/routes/family-meal-plans.tsx` and `app/routes/family-meal-plan.tsx`, and registered them in `app/routes.ts`.
+- Linked the family overview in `app/routes/family.tsx` into the new meal-plan flow.
+- Added focused tests in `app/lib/meal-plan.server.test.ts`, `app/routes/family-meal-plans.test.ts`, and `app/routes/family-meal-plan.test.ts`.
+
+## Files To Read First
+
+- `app/lib/meal-plan.server.ts` - Core CRUD, family scoping, and date-range validation logic for meal plans.
+- `app/routes/family-meal-plans.tsx` - Family meal-plan list/create/delete route and UI.
+- `app/routes/family-meal-plan.tsx` - Selected meal-plan metadata edit route and redirect/error handling.
+- `app/lib/meal-plan.server.test.ts` - Fastest reference for expected validation and service behavior.
+
+## Validation
+
+- `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plans.test.ts app/routes/family-meal-plan.test.ts`
+- `npm run lint`
+- `./node_modules/.bin/tsc --noEmit`
+- `npm run typecheck` failed in this environment because `react-router typegen` requires Node `>20`, but the machine is on Node `18.20.8`.
+
+## Open Items
+
+- No manual browser smoke test has been run yet for the new meal-plan routes.
+- `npm run typecheck` will keep failing until the environment uses Node `20+` for `react-router typegen`.
+- The current scope only covers meal-plan metadata CRUD; entry editing, copy/reuse, shopping generation, and approval state are still follow-up work.
+
+## Next Step
+
+Run a manual end-to-end check of `families/:familyId/meal-plans` and `families/:familyId/meal-plans/:mealPlanId`, then continue with the next meal-planning slice on top of the new route structure.

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      mealPlan: {
+        create: vi.fn(),
+        delete: vi.fn(),
+        findFirst: vi.fn(),
+        findMany: vi.fn(),
+        update: vi.fn(),
+      },
+    },
+    requireFamilyMembershipMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+vi.mock("./family.server", () => {
+  return {
+    requireFamilyMembership: requireFamilyMembershipMock,
+  };
+});
+
+import {
+  createMealPlan,
+  deleteMealPlan,
+  formatDateOnly,
+  getMealPlanForFamily,
+  listMealPlansForFamily,
+  updateMealPlan,
+  validateMealPlanRange,
+} from "./meal-plan.server";
+
+const mockMembership = {
+  family: {
+    id: "family-1",
+    joinCode: "ABC123",
+    name: "Solberg",
+  },
+  familyId: "family-1",
+  id: "membership-1",
+  role: "ADMIN",
+  userId: "user-1",
+};
+
+describe("meal-plan.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue(mockMembership);
+  });
+
+  it("rejects missing date fields", () => {
+    expect(validateMealPlanRange("", "")).toEqual({
+      fieldErrors: {
+        endDate: "Velg en sluttdato.",
+        startDate: "Velg en startdato.",
+      },
+      ok: false,
+      values: {
+        endDate: "",
+        startDate: "",
+        title: "",
+      },
+    });
+  });
+
+  it("rejects reversed date ranges", () => {
+    expect(validateMealPlanRange("2026-05-18", "2026-05-15")).toEqual({
+      fieldErrors: {
+        endDate: "Sluttdatoen kan ikke være før startdatoen.",
+      },
+      ok: false,
+      values: {
+        endDate: "2026-05-15",
+        startDate: "2026-05-18",
+        title: "",
+      },
+    });
+  });
+
+  it("rejects ranges longer than seven days", () => {
+    expect(validateMealPlanRange("2026-05-12", "2026-05-20")).toEqual({
+      fieldErrors: {
+        endDate: "Datointervallet kan være maks 7 dager.",
+      },
+      ok: false,
+      values: {
+        endDate: "2026-05-20",
+        startDate: "2026-05-12",
+        title: "",
+      },
+    });
+  });
+
+  it("accepts valid partial-week ranges", () => {
+    expect(validateMealPlanRange("2026-05-14", "2026-05-17")).toEqual({
+      ok: true,
+      values: {
+        endDate: "2026-05-17",
+        startDate: "2026-05-14",
+        title: "",
+      },
+    });
+  });
+
+  it("lists meal plans only after verifying family membership", async () => {
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-12T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Uke 20",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+
+    const result = await listMealPlansForFamily({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyMembershipMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(dbMock.mealPlan.findMany).toHaveBeenCalledWith({
+      orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
+      select: {
+        createdAt: true,
+        endDate: true,
+        id: true,
+        startDate: true,
+        status: true,
+        title: true,
+        updatedAt: true,
+      },
+      where: {
+        familyId: "family-1",
+      },
+    });
+    expect(result.family).toEqual({
+      id: "family-1",
+      name: "Solberg",
+    });
+    expect(result.userRole).toBe("ADMIN");
+  });
+
+  it("creates a meal plan with trimmed title and UTC date-only values", async () => {
+    dbMock.mealPlan.create.mockResolvedValue({
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const result = await createMealPlan({
+      endDate: "2026-05-18",
+      familyId: "family-1",
+      startDate: "2026-05-15",
+      title: " Langhelg ",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("CREATED");
+    expect(dbMock.mealPlan.create).toHaveBeenCalledTimes(1);
+
+    const createCall = dbMock.mealPlan.create.mock.calls[0][0];
+    expect(createCall.data.familyId).toBe("family-1");
+    expect(createCall.data.title).toBe("Langhelg");
+    expect(formatDateOnly(createCall.data.startDate)).toBe("2026-05-15");
+    expect(formatDateOnly(createCall.data.endDate)).toBe("2026-05-18");
+  });
+
+  it("returns validation errors instead of creating invalid meal plans", async () => {
+    const result = await createMealPlan({
+      endDate: "2026-05-20",
+      familyId: "family-1",
+      startDate: "2026-05-12",
+      title: " ",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      fieldErrors: {
+        endDate: "Datointervallet kan være maks 7 dager.",
+        title: "Skriv inn et navn for ukeplanen.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        endDate: "2026-05-20",
+        startDate: "2026-05-12",
+        title: "",
+      },
+    });
+    expect(dbMock.mealPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("throws a not-found response when a meal plan is outside the family scope", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue(null);
+
+    await expect(
+      getMealPlanForFamily({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-404",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+
+  it("returns NOT_FOUND when updating a missing meal plan", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue(null);
+
+    const result = await updateMealPlan({
+      endDate: "2026-05-18",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-404",
+      startDate: "2026-05-15",
+      title: "Langhelg",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "NOT_FOUND",
+    });
+    expect(dbMock.mealPlan.update).not.toHaveBeenCalled();
+  });
+
+  it("deletes meal plans only within the scoped family", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      id: "meal-plan-1",
+      title: "Uke 20",
+    });
+    dbMock.mealPlan.delete.mockResolvedValue({
+      id: "meal-plan-1",
+    });
+
+    const result = await deleteMealPlan({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.mealPlan.findFirst).toHaveBeenCalledWith({
+      select: {
+        id: true,
+        title: true,
+      },
+      where: {
+        familyId: "family-1",
+        id: "meal-plan-1",
+      },
+    });
+    expect(dbMock.mealPlan.delete).toHaveBeenCalledWith({
+      where: {
+        id: "meal-plan-1",
+      },
+    });
+    expect(result).toEqual({
+      deletedMealPlan: {
+        id: "meal-plan-1",
+        title: "Uke 20",
+      },
+      status: "DELETED",
+    });
+  });
+});

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -1,0 +1,395 @@
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+
+const MEAL_PLAN_MAX_SPAN_DAYS = 7;
+const MEAL_PLAN_MAX_DAY_OFFSET = MEAL_PLAN_MAX_SPAN_DAYS - 1;
+
+const mealPlanSummarySelect = {
+  createdAt: true,
+  endDate: true,
+  id: true,
+  startDate: true,
+  status: true,
+  title: true,
+  updatedAt: true,
+};
+
+const mealPlanDetailSelect = {
+  ...mealPlanSummarySelect,
+  approvedAt: true,
+  approvedByUserId: true,
+  copiedFromMealPlanId: true,
+};
+
+export interface MealPlanFieldErrors {
+  endDate?: string;
+  startDate?: string;
+  title?: string;
+}
+
+interface MealPlanValues {
+  endDate: string;
+  startDate: string;
+  title: string;
+}
+
+type MealPlanValidationResult =
+  | {
+      ok: true;
+      values: MealPlanValues;
+    }
+  | {
+      fieldErrors: MealPlanFieldErrors;
+      ok: false;
+      values: MealPlanValues;
+    };
+
+interface MealPlanMutationInput {
+  endDate: string;
+  familyId: string;
+  startDate: string;
+  title: string;
+  userId: string;
+}
+
+interface DeleteMealPlanInput {
+  familyId: string;
+  mealPlanId: string;
+  userId: string;
+}
+
+type GetMealPlanInput = DeleteMealPlanInput;
+
+interface MealPlanListInput {
+  familyId: string;
+  userId: string;
+}
+
+export function formatDateOnly(date: Date) {
+  return [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+  ].join("-");
+}
+
+export function validateMealPlanRange(startDate: string, endDate: string): MealPlanValidationResult {
+  const values = {
+    endDate: endDate.trim(),
+    startDate: startDate.trim(),
+    title: "",
+  };
+  const fieldErrors: MealPlanFieldErrors = {};
+
+  if (!values.startDate) {
+    fieldErrors.startDate = "Velg en startdato.";
+  }
+
+  if (!values.endDate) {
+    fieldErrors.endDate = "Velg en sluttdato.";
+  }
+
+  if (fieldErrors.startDate || fieldErrors.endDate) {
+    return {
+      fieldErrors,
+      ok: false,
+      values,
+    };
+  }
+
+  const parsedStartDate = parseDateOnly(values.startDate);
+  const parsedEndDate = parseDateOnly(values.endDate);
+
+  if (!parsedStartDate) {
+    fieldErrors.startDate = "Startdatoen er ugyldig.";
+  }
+
+  if (!parsedEndDate) {
+    fieldErrors.endDate = "Sluttdatoen er ugyldig.";
+  }
+
+  if (fieldErrors.startDate || fieldErrors.endDate) {
+    return {
+      fieldErrors,
+      ok: false,
+      values,
+    };
+  }
+
+  if (!parsedStartDate || !parsedEndDate) {
+    return {
+      fieldErrors,
+      ok: false,
+      values,
+    };
+  }
+
+  if (parsedEndDate.getTime() < parsedStartDate.getTime()) {
+    return {
+      fieldErrors: {
+        endDate: "Sluttdatoen kan ikke være før startdatoen.",
+      },
+      ok: false,
+      values,
+    };
+  }
+
+  const spanInDays = differenceInUtcDays(parsedStartDate, parsedEndDate);
+
+  if (spanInDays > MEAL_PLAN_MAX_DAY_OFFSET) {
+    return {
+      fieldErrors: {
+        endDate: "Datointervallet kan være maks 7 dager.",
+      },
+      ok: false,
+      values,
+    };
+  }
+
+  return {
+    ok: true,
+    values,
+  };
+}
+
+export async function listMealPlansForFamily({ familyId, userId }: MealPlanListInput) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlans = await db.mealPlan.findMany({
+    orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
+    select: mealPlanSummarySelect,
+    where: {
+      familyId,
+    },
+  });
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    mealPlans,
+    userRole: membership.role,
+  };
+}
+
+export async function getMealPlanForFamily({ familyId, mealPlanId, userId }: GetMealPlanInput) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: mealPlanDetailSelect,
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    throw new Response("Fant ikke ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    mealPlan,
+    userRole: membership.role,
+  };
+}
+
+export async function createMealPlan(input: MealPlanMutationInput) {
+  const membership = await requireFamilyMembership({
+    familyId: input.familyId,
+    userId: input.userId,
+  });
+  const validation = validateMealPlanInput(input);
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  const mealPlan = await db.mealPlan.create({
+    data: {
+      endDate: parseDateOnly(validation.values.endDate)!,
+      familyId: input.familyId,
+      startDate: parseDateOnly(validation.values.startDate)!,
+      title: validation.values.title,
+    },
+    select: mealPlanDetailSelect,
+  });
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    mealPlan,
+    status: "CREATED" as const,
+  };
+}
+
+export async function updateMealPlan(input: MealPlanMutationInput & { mealPlanId: string }) {
+  await requireFamilyMembership({
+    familyId: input.familyId,
+    userId: input.userId,
+  });
+
+  const existingMealPlan = await db.mealPlan.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId: input.familyId,
+      id: input.mealPlanId,
+    },
+  });
+
+  if (!existingMealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const validation = validateMealPlanInput(input);
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  const mealPlan = await db.mealPlan.update({
+    data: {
+      endDate: parseDateOnly(validation.values.endDate)!,
+      startDate: parseDateOnly(validation.values.startDate)!,
+      title: validation.values.title,
+    },
+    select: mealPlanDetailSelect,
+    where: {
+      id: existingMealPlan.id,
+    },
+  });
+
+  return {
+    mealPlan,
+    status: "UPDATED" as const,
+  };
+}
+
+export async function deleteMealPlan({ familyId, mealPlanId, userId }: DeleteMealPlanInput) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: {
+      id: true,
+      title: true,
+    },
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  await db.mealPlan.delete({
+    where: {
+      id: mealPlan.id,
+    },
+  });
+
+  return {
+    deletedMealPlan: mealPlan,
+    status: "DELETED" as const,
+  };
+}
+
+function validateMealPlanInput({
+  endDate,
+  startDate,
+  title,
+}: Pick<MealPlanMutationInput, "endDate" | "startDate" | "title">): MealPlanValidationResult {
+  const trimmedTitle = title.trim();
+  const rangeValidation = validateMealPlanRange(startDate, endDate);
+  const values = {
+    endDate: rangeValidation.values.endDate,
+    startDate: rangeValidation.values.startDate,
+    title: trimmedTitle,
+  };
+
+  if (!trimmedTitle) {
+    return {
+      fieldErrors: {
+        ...(rangeValidation.ok ? {} : rangeValidation.fieldErrors),
+        title: "Skriv inn et navn for ukeplanen.",
+      },
+      ok: false,
+      values,
+    };
+  }
+
+  if (!rangeValidation.ok) {
+    return {
+      fieldErrors: rangeValidation.fieldErrors,
+      ok: false,
+      values,
+    };
+  }
+
+  return {
+    ok: true,
+    values,
+  };
+}
+
+function parseDateOnly(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearValue, monthValue, dayValue] = value.split("-");
+  const year = Number(yearValue);
+  const month = Number(monthValue);
+  const day = Number(dayValue);
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    Number.isNaN(parsedDate.getTime()) ||
+    parsedDate.getUTCFullYear() !== year ||
+    parsedDate.getUTCMonth() !== month - 1 ||
+    parsedDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsedDate;
+}
+
+function differenceInUtcDays(startDate: Date, endDate: Date) {
+  const millisecondsPerDay = 1000 * 60 * 60 * 24;
+
+  return Math.round((endDate.getTime() - startDate.getTime()) / millisecondsPerDay);
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -4,6 +4,8 @@ export default [
   index("routes/home.tsx"),
   route("app", "routes/app.tsx"),
   route("families/:familyId", "routes/family.tsx"),
+  route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
+  route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
   route("login", "routes/login.tsx"),
   route("logout", "routes/logout.tsx"),
   route("prototype", "routes/prototype.tsx"),

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>("../lib/auth.server");
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/meal-plan.server", () => {
+  return {
+    formatDateOnly: vi.fn((date: Date) => date.toISOString().slice(0, 10)),
+    getMealPlanForFamily: vi.fn(),
+    updateMealPlan: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanForFamily, updateMealPlan } from "../lib/meal-plan.server";
+import { action, loader } from "./family-meal-plan";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(url = "http://localhost/families/family-1/meal-plans/meal-plan-1", formData?: FormData) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family meal plan route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads a serialized meal plan for metadata editing", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanForFamily).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlan: {
+        approvedAt: null,
+        approvedByUserId: null,
+        copiedFromMealPlanId: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+      userRole: "ADMIN",
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1?notice=meal-plan-created"),
+    });
+
+    expect(getMealPlanForFamily).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlan: {
+        approvedAt: null,
+        approvedByUserId: null,
+        copiedFromMealPlanId: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: "2026-05-18",
+        id: "meal-plan-1",
+        startDate: "2026-05-15",
+        status: "DRAFT",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+      notice: "meal-plan-created",
+    });
+  });
+
+  it("returns update validation errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateMealPlan).mockResolvedValue({
+      fieldErrors: {
+        endDate: "Sluttdatoen kan ikke være før startdatoen.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        endDate: "2026-05-15",
+        startDate: "2026-05-18",
+        title: "Langhelg",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-meal-plan");
+    formData.set("title", "Langhelg");
+    formData.set("startDate", "2026-05-18");
+    formData.set("endDate", "2026-05-15");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(updateMealPlan).toHaveBeenCalledWith({
+      endDate: "2026-05-15",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      startDate: "2026-05-18",
+      title: "Langhelg",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      fieldErrors: {
+        endDate: "Sluttdatoen kan ikke være før startdatoen.",
+      },
+      values: {
+        endDate: "2026-05-15",
+        startDate: "2026-05-18",
+        title: "Langhelg",
+      },
+    });
+  });
+
+  it("redirects with an explicit notice after updating a meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateMealPlan).mockResolvedValue({
+      mealPlan: {
+        approvedAt: null,
+        approvedByUserId: null,
+        copiedFromMealPlanId: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+      },
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-meal-plan");
+    formData.set("title", "Langhelg");
+    formData.set("startDate", "2026-05-15");
+    formData.set("endDate", "2026-05-18");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1?notice=meal-plan-updated",
+    );
+  });
+
+  it("throws a not-found response when the meal plan disappears before update", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateMealPlan).mockResolvedValue({
+      status: "NOT_FOUND",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-meal-plan");
+    formData.set("title", "Langhelg");
+    formData.set("startDate", "2026-05-15");
+    formData.set("endDate", "2026-05-18");
+
+    await expect(
+      action({
+        params: {
+          familyId: "family-1",
+          mealPlanId: "meal-plan-1",
+        },
+        request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+});

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -1,0 +1,353 @@
+import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { formatDateOnly, getMealPlanForFamily, updateMealPlan } from "../lib/meal-plan.server";
+
+type MealPlanNotice = "meal-plan-created" | "meal-plan-updated";
+
+interface MealPlanActionData {
+  fieldErrors?: {
+    endDate?: string;
+    startDate?: string;
+    title?: string;
+  };
+  formError?: string;
+  values?: {
+    endDate?: string;
+    startDate?: string;
+    title?: string;
+  };
+}
+
+interface MealPlanRouteProps {
+  actionData?: MealPlanActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Rediger ukeplan | Mealplanner" },
+    { name: "description", content: "Oppdater navn og datointervall for en familieukeplan." },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const result = await getMealPlanForFamily({
+    familyId,
+    mealPlanId,
+    userId: user.id,
+  });
+
+  return {
+    family: result.family,
+    mealPlan: {
+      ...result.mealPlan,
+      endDate: formatDateOnly(result.mealPlan.endDate),
+      startDate: formatDateOnly(result.mealPlan.startDate),
+    },
+    notice: getMealPlanNotice(request),
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent !== "update-meal-plan") {
+    return {
+      formError: "Ukjent handling.",
+    } satisfies MealPlanActionData;
+  }
+
+  const result = await updateMealPlan({
+    endDate: String(formData.get("endDate") ?? ""),
+    familyId,
+    mealPlanId,
+    startDate: String(formData.get("startDate") ?? ""),
+    title: String(formData.get("title") ?? ""),
+    userId: user.id,
+  });
+
+  if (result.status === "NOT_FOUND") {
+    throw new Response("Fant ikke ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  if (result.status === "VALIDATION_ERROR") {
+    return {
+      fieldErrors: result.fieldErrors,
+      values: result.values,
+    } satisfies MealPlanActionData;
+  }
+
+  return buildMealPlanRedirect({
+    familyId,
+    mealPlanId,
+    notice: "meal-plan-updated",
+    request,
+  });
+}
+
+export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlanRouteProps) {
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+  const noticeContent = loaderData.notice ? getMealPlanNoticeContent(loaderData.notice) : null;
+  const titleValue = actionData?.values?.title ?? loaderData.mealPlan.title;
+  const startDateValue = actionData?.values?.startDate ?? loaderData.mealPlan.startDate;
+  const endDateValue = actionData?.values?.endDate ?? loaderData.mealPlan.endDate;
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Rediger ukeplan
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.mealPlan.title}</h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Oppdater navn og datointervall for denne familieukeplanen. Daglige malinger og handleliste
+                kan bygges videre pa denne ruten senere.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Tilbake til ukeplaner
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+          </section>
+        ) : null}
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Detaljer</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Planen tilhorer familien {loaderData.family.name} og bruker et lagret datointervall som
+                grunnlag for neste steg i planleggingsflyten.
+              </p>
+            </div>
+
+            <dl className="mt-6 grid gap-4 sm:grid-cols-2">
+              <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Status</dt>
+                <dd className="mt-2 text-base font-semibold text-slate-950">
+                  {loaderData.mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+                </dd>
+              </div>
+
+              <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                  Aktiv periode
+                </dt>
+                <dd className="mt-2 text-base font-semibold text-slate-950">
+                  {formatMealPlanWindow(loaderData.mealPlan.startDate, loaderData.mealPlan.endDate)}
+                </dd>
+              </div>
+            </dl>
+          </article>
+
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Oppdater ukeplan</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Datointervallet kan vare maks 7 dager og ma alltid ha en gyldig start- og sluttdato.
+              </p>
+            </div>
+
+            <Form className="mt-6 space-y-4" method="post">
+              <input name="intent" type="hidden" value="update-meal-plan" />
+
+              <label className="block text-sm font-medium text-slate-700">
+                Navn
+                <input
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={titleValue}
+                  name="title"
+                  type="text"
+                />
+              </label>
+
+              {actionData?.fieldErrors?.title ? <p className="text-sm text-rose-600">{actionData.fieldErrors.title}</p> : null}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="block text-sm font-medium text-slate-700">
+                  Startdato
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={startDateValue}
+                    name="startDate"
+                    type="date"
+                  />
+                </label>
+
+                <label className="block text-sm font-medium text-slate-700">
+                  Sluttdato
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={endDateValue}
+                    name="endDate"
+                    type="date"
+                  />
+                </label>
+              </div>
+
+              {actionData?.fieldErrors?.startDate ? (
+                <p className="text-sm text-rose-600">{actionData.fieldErrors.startDate}</p>
+              ) : null}
+              {actionData?.fieldErrors?.endDate ? (
+                <p className="text-sm text-rose-600">{actionData.fieldErrors.endDate}</p>
+              ) : null}
+              {actionData?.formError ? (
+                <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                  {actionData.formError}
+                </p>
+              ) : null}
+
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={isSubmitting}
+                type="submit"
+              >
+                {isSubmitting ? "Lagrer..." : "Lagre endringer"}
+              </button>
+            </Form>
+          </article>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let description = "Vi klarte ikke a laste ukeplanen.";
+
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 403) {
+      title = "Ingen tilgang";
+      description = "Du har ikke tilgang til denne familieukeplanen.";
+    } else if (error.status === 404) {
+      title = "Ukeplanen finnes ikke";
+      description = "Vi fant ikke ukeplanen du forsokte a apne.";
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto max-w-3xl rounded-[28px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+          to="/app"
+        >
+          Tilbake til oversikten
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}
+
+function getMealPlanNotice(request: Request): MealPlanNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (notice === "meal-plan-created" || notice === "meal-plan-updated") {
+    return notice;
+  }
+
+  return null;
+}
+
+function buildMealPlanRedirect({
+  familyId,
+  mealPlanId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  notice: MealPlanNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/meal-plans/${mealPlanId}`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function getMealPlanNoticeContent(notice: MealPlanNotice) {
+  switch (notice) {
+    case "meal-plan-created":
+      return {
+        description: "Ukeplanen er klar for videre arbeid med innhold og handleliste.",
+        title: "Ukeplan opprettet",
+      };
+    case "meal-plan-updated":
+      return {
+        description: "Endringene i navn og datointervall ble lagret.",
+        title: "Ukeplan oppdatert",
+      };
+  }
+}
+
+function formatMealPlanWindow(startDate: string, endDate: string) {
+  const formatter = new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
+
+  return `${formatter.format(new Date(`${startDate}T00:00:00.000Z`))} - ${formatter.format(
+    new Date(`${endDate}T00:00:00.000Z`),
+  )}`;
+}

--- a/app/routes/family-meal-plans.test.ts
+++ b/app/routes/family-meal-plans.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>("../lib/auth.server");
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/meal-plan.server", () => {
+  return {
+    createMealPlan: vi.fn(),
+    deleteMealPlan: vi.fn(),
+    formatDateOnly: vi.fn((date: Date) => date.toISOString().slice(0, 10)),
+    listMealPlansForFamily: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { createMealPlan, deleteMealPlan, listMealPlansForFamily } from "../lib/meal-plan.server";
+import { action, loader } from "./family-meal-plans";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(url = "http://localhost/families/family-1/meal-plans", formData?: FormData) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family meal plans route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads serialized family meal plans for the current family", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listMealPlansForFamily).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlans: [
+        {
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          endDate: new Date("2026-05-18T00:00:00.000Z"),
+          id: "meal-plan-1",
+          startDate: new Date("2026-05-15T00:00:00.000Z"),
+          status: "DRAFT",
+          title: "Langhelg",
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ],
+      userRole: "ADMIN",
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans?notice=meal-plan-created"),
+    });
+
+    expect(listMealPlansForFamily).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlans: [
+        {
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          endDate: "2026-05-18",
+          id: "meal-plan-1",
+          startDate: "2026-05-15",
+          status: "DRAFT",
+          title: "Langhelg",
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ],
+      notice: "meal-plan-created",
+    });
+  });
+
+  it("returns create validation errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createMealPlan).mockResolvedValue({
+      fieldErrors: {
+        endDate: "Datointervallet kan være maks 7 dager.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        endDate: "2026-05-20",
+        startDate: "2026-05-12",
+        title: "Uke 20",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-meal-plan");
+    formData.set("title", "Uke 20");
+    formData.set("startDate", "2026-05-12");
+    formData.set("endDate", "2026-05-20");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans", formData),
+    });
+
+    expect(createMealPlan).toHaveBeenCalledWith({
+      endDate: "2026-05-20",
+      familyId: "family-1",
+      startDate: "2026-05-12",
+      title: "Uke 20",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      fieldErrors: {
+        endDate: "Datointervallet kan være maks 7 dager.",
+      },
+      intent: "create-meal-plan",
+      values: {
+        endDate: "2026-05-20",
+        startDate: "2026-05-12",
+        title: "Uke 20",
+      },
+    });
+  });
+
+  it("redirects with a notice after creating a meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createMealPlan).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlan: {
+        approvedAt: null,
+        approvedByUserId: null,
+        copiedFromMealPlanId: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-meal-plan");
+    formData.set("title", "Langhelg");
+    formData.set("startDate", "2026-05-15");
+    formData.set("endDate", "2026-05-18");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans", formData),
+    });
+
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans?notice=meal-plan-created",
+    );
+  });
+
+  it("returns a delete error when the meal plan no longer exists", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(deleteMealPlan).mockResolvedValue({
+      status: "NOT_FOUND",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "delete-meal-plan");
+    formData.set("mealPlanId", "meal-plan-404");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans", formData),
+    });
+
+    expect(result).toEqual({
+      formError: "Fant ikke ukeplanen som skulle slettes.",
+      intent: "delete-meal-plan",
+      targetMealPlanId: "meal-plan-404",
+    });
+  });
+
+  it("rethrows the login redirect for unauthenticated requests", async () => {
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: {
+        Location: "/login?redirectTo=%2Ffamilies%2Ffamily-1%2Fmeal-plans",
+      },
+    });
+
+    vi.mocked(requireUser).mockRejectedValue(redirectResponse);
+
+    await expect(
+      loader({
+        params: {
+          familyId: "family-1",
+        },
+        request: buildRequest(),
+      }),
+    ).rejects.toBe(redirectResponse);
+  });
+});

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -1,0 +1,389 @@
+import { Form, Link, useNavigation, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { createMealPlan, deleteMealPlan, formatDateOnly, listMealPlansForFamily } from "../lib/meal-plan.server";
+
+type MealPlanNotice = "meal-plan-created" | "meal-plan-deleted";
+
+interface MealPlanActionData {
+  fieldErrors?: {
+    endDate?: string;
+    startDate?: string;
+    title?: string;
+  };
+  formError?: string;
+  intent?: "create-meal-plan" | "delete-meal-plan";
+  targetMealPlanId?: string;
+  values?: {
+    endDate?: string;
+    startDate?: string;
+    title?: string;
+  };
+}
+
+interface MealPlanListRouteProps {
+  actionData?: MealPlanActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Ukeplaner | Mealplanner" },
+    { name: "description", content: "Administrer familieukeplaner i Mealplanner." },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const result = await listMealPlansForFamily({
+    familyId,
+    userId: user.id,
+  });
+
+  return {
+    family: result.family,
+    mealPlans: result.mealPlans.map((mealPlan) => ({
+      ...mealPlan,
+      endDate: formatDateOnly(mealPlan.endDate),
+      startDate: formatDateOnly(mealPlan.startDate),
+    })),
+    notice: getMealPlanNotice(request),
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "create-meal-plan") {
+    const result = await createMealPlan({
+      endDate: String(formData.get("endDate") ?? ""),
+      familyId,
+      startDate: String(formData.get("startDate") ?? ""),
+      title: String(formData.get("title") ?? ""),
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        fieldErrors: result.fieldErrors,
+        intent,
+        values: result.values,
+      } satisfies MealPlanActionData;
+    }
+
+    return buildMealPlanRedirect({
+      familyId,
+      notice: "meal-plan-created",
+      request,
+    });
+  }
+
+  if (intent === "delete-meal-plan") {
+    const mealPlanId = String(formData.get("mealPlanId") ?? "");
+
+    if (!mealPlanId) {
+      return {
+        formError: "Fant ikke ukeplanen som skulle slettes.",
+      } satisfies MealPlanActionData;
+    }
+
+    const result = await deleteMealPlan({
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke ukeplanen som skulle slettes.",
+        intent,
+        targetMealPlanId: mealPlanId,
+      } satisfies MealPlanActionData;
+    }
+
+    return buildMealPlanRedirect({
+      familyId,
+      notice: "meal-plan-deleted",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies MealPlanActionData;
+}
+
+export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPlanListRouteProps) {
+  const navigation = useNavigation();
+  const noticeContent = loaderData.notice ? getMealPlanNoticeContent(loaderData.notice) : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingMealPlanId = String(navigation.formData?.get("mealPlanId") ?? "");
+  const isCreatingMealPlan = navigation.state === "submitting" && pendingIntent === "create-meal-plan";
+  const isDeletingMealPlan = navigation.state === "submitting" && pendingIntent === "delete-meal-plan";
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Ukeplaner
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.family.name}</h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Opprett og administrer familieukeplaner med lagrede start- og sluttdatoer.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}`}
+              >
+                Tilbake til familie
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+          </section>
+        ) : null}
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Opprett ukeplan</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Velg et navn og et datointervall pa maks 7 dager. Delvise uker som torsdag til sondag
+                er stottet.
+              </p>
+            </div>
+
+            <Form className="mt-6 space-y-4" method="post">
+              <input name="intent" type="hidden" value="create-meal-plan" />
+
+              <label className="block text-sm font-medium text-slate-700">
+                Navn
+                <input
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={actionData?.intent === "create-meal-plan" ? actionData.values?.title ?? "" : ""}
+                  name="title"
+                  placeholder="For eksempel Uke 20"
+                  type="text"
+                />
+              </label>
+
+              {actionData?.intent === "create-meal-plan" && actionData.fieldErrors?.title ? (
+                <p className="text-sm text-rose-600">{actionData.fieldErrors.title}</p>
+              ) : null}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="block text-sm font-medium text-slate-700">
+                  Startdato
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={
+                      actionData?.intent === "create-meal-plan" ? actionData.values?.startDate ?? "" : ""
+                    }
+                    name="startDate"
+                    type="date"
+                  />
+                </label>
+
+                <label className="block text-sm font-medium text-slate-700">
+                  Sluttdato
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={actionData?.intent === "create-meal-plan" ? actionData.values?.endDate ?? "" : ""}
+                    name="endDate"
+                    type="date"
+                  />
+                </label>
+              </div>
+
+              {actionData?.intent === "create-meal-plan" && actionData.fieldErrors?.startDate ? (
+                <p className="text-sm text-rose-600">{actionData.fieldErrors.startDate}</p>
+              ) : null}
+              {actionData?.intent === "create-meal-plan" && actionData.fieldErrors?.endDate ? (
+                <p className="text-sm text-rose-600">{actionData.fieldErrors.endDate}</p>
+              ) : null}
+              {actionData?.formError ? (
+                <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                  {actionData.formError}
+                </p>
+              ) : null}
+
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={isCreatingMealPlan}
+                type="submit"
+              >
+                {isCreatingMealPlan ? "Lagrer..." : "Opprett ukeplan"}
+              </button>
+            </Form>
+          </article>
+
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Lagrede ukeplaner</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Velg en ukeplan for a redigere navn og datoer, eller slett planer familien ikke trenger
+                lenger.
+              </p>
+            </div>
+
+            {loaderData.mealPlans.length > 0 ? (
+              <div className="mt-6 grid gap-4">
+                {loaderData.mealPlans.map((mealPlan) => {
+                  const isPendingDelete = isDeletingMealPlan && pendingMealPlanId === mealPlan.id;
+                  const deleteError =
+                    actionData?.targetMealPlanId === mealPlan.id ? actionData.formError : undefined;
+
+                  return (
+                    <article key={mealPlan.id} className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <div className="flex flex-wrap items-center gap-3">
+                            <h3 className="text-base font-semibold text-slate-950">{mealPlan.title}</h3>
+                            <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
+                              {mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+                            </span>
+                          </div>
+                          <p className="mt-2 text-sm leading-6 text-slate-600">
+                            {formatMealPlanWindow(mealPlan.startDate, mealPlan.endDate)}
+                          </p>
+                        </div>
+
+                        <div className="flex flex-wrap gap-3">
+                          <Link
+                            className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                            to={`/families/${loaderData.family.id}/meal-plans/${mealPlan.id}`}
+                          >
+                            Apne ukeplan
+                          </Link>
+
+                          <Form method="post">
+                            <input name="intent" type="hidden" value="delete-meal-plan" />
+                            <input name="mealPlanId" type="hidden" value={mealPlan.id} />
+                            <button
+                              className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+                              disabled={isDeletingMealPlan}
+                              type="submit"
+                            >
+                              {isPendingDelete ? "Sletter..." : "Slett"}
+                            </button>
+                          </Form>
+                        </div>
+                      </div>
+
+                      {deleteError ? (
+                        <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                          {deleteError}
+                        </p>
+                      ) : null}
+                    </article>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="mt-6 rounded-[24px] border border-dashed border-slate-300 bg-slate-50 px-5 py-6">
+                <h3 className="text-base font-semibold text-slate-950">Ingen ukeplaner ennå</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Opprett familiens forste ukeplan for a komme i gang med serverlagret planlegging.
+                </p>
+              </div>
+            )}
+          </section>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}
+
+function getMealPlanNotice(request: Request): MealPlanNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (notice === "meal-plan-created" || notice === "meal-plan-deleted") {
+    return notice;
+  }
+
+  return null;
+}
+
+function buildMealPlanRedirect({
+  familyId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  notice: MealPlanNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/meal-plans`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function getMealPlanNoticeContent(notice: MealPlanNotice) {
+  switch (notice) {
+    case "meal-plan-created":
+      return {
+        description: "Ukeplanen ble lagret med start- og sluttdato for familien.",
+        title: "Ukeplan opprettet",
+      };
+    case "meal-plan-deleted":
+      return {
+        description: "Ukeplanen ble slettet fra familien.",
+        title: "Ukeplan slettet",
+      };
+  }
+}
+
+function formatMealPlanWindow(startDate: string, endDate: string) {
+  const formatter = new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
+
+  return `${formatter.format(new Date(`${startDate}T00:00:00.000Z`))} - ${formatter.format(
+    new Date(`${endDate}T00:00:00.000Z`),
+  )}`;
+}

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -176,6 +176,12 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
 
             <div className="flex flex-wrap gap-3">
               <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Apne ukeplaner
+              </Link>
+              <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to="/app"
               >
@@ -218,6 +224,25 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
               {loaderData.family.joinCode ?? "Skjult"}
             </p>
           </article>
+        </section>
+
+        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-950">Ukeplaner</h2>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                Gå videre til familiens serverlagrede ukeplaner for å opprette, velge og oppdatere planer
+                med start- og sluttdato.
+              </p>
+            </div>
+
+            <Link
+              className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+              to={`/families/${loaderData.family.id}/meal-plans`}
+            >
+              Administrer ukeplaner
+            </Link>
+          </div>
         </section>
 
         {isAdmin ? (


### PR DESCRIPTION
## Summary
- add family-scoped, server-backed meal plan CRUD with centralized 7-day date-range validation
- add dedicated meal plan list and detail routes plus family dashboard links into the new flow
- add focused route and server tests, and add a reusable handoff skill plus updated `AGENT_HANDOFF.md`

## Test plan
- [x] `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plans.test.ts app/routes/family-meal-plan.test.ts`
- [x] `npm run lint`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] `npm run typecheck` (`react-router typegen` requires Node >20; current environment is Node 18.20.8)
- [ ] Manual browser smoke test for create/update/delete meal plan flow

Closes #7