### PR TITLE
Add meal plan copy and reuse flow

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,33 +2,33 @@
 
 ## Current Objective
 
-Implement issue `#8`'s first production dinner-planning flow. The selected meal-plan route now supports day-by-day dinner recipe selection plus per-day notes, backed by server persistence and the existing seeded recipe data.
+Implement issue `#9`'s first production meal-plan copy/reuse flow. Users can now create a new meal plan from an existing one, map copied dinner entries and notes into a selected target date range by relative day offset, and keep the change scoped to current meal-planning functionality.
 
 ## Completed
 
-- Extended `app/lib/meal-plan.server.ts` with a planning loader that returns visible meal-plan dates, existing dinner entries, and accessible recipes, plus a bulk save mutation for dinner entries with server-side date and recipe validation.
-- Reworked `app/routes/family-meal-plan.tsx` into the first production planning screen: users can save dinners and notes for each active date, browse a recipe bank, and still edit meal-plan metadata on the same route.
-- Expanded focused coverage in `app/lib/meal-plan.server.test.ts` and `app/routes/family-meal-plan.test.ts` for planning-data loading, entry save/clear behavior, validation errors, and route redirects.
+- Added `copyMealPlan()` to `app/lib/meal-plan.server.ts` as a dedicated transactional reuse mutation that validates the new range, scopes the source plan to the current family, sets `copiedFromMealPlanId`, copies only dinner entries plus notes, and truncates copied entries that fall outside the new target range.
+- Updated `app/routes/family-meal-plans.tsx` so the existing `Opprett ukeplan` form can optionally reuse a previous meal plan via a source selector while preserving the server-first action/notice flow.
+- Expanded focused coverage in `app/lib/meal-plan.server.test.ts` and `app/routes/family-meal-plans.test.ts` for relative-offset copying, shorter target truncation, source-plan not found handling, and copy-specific redirects/validation state.
 
 ## Files To Read First
 
-- `app/lib/meal-plan.server.ts` - Meal-plan CRUD, planning-data query, UTC date helpers, and bulk dinner entry persistence.
-- `app/routes/family-meal-plan.tsx` - Server-backed dinner planner UI, form parsing, notices, and metadata editing on the selected meal-plan route.
-- `app/lib/meal-plan.server.test.ts` - Fastest reference for entry validation, save semantics, and scoped access rules.
-- `app/routes/family-meal-plan.test.ts` - Loader/action expectations for the production planner route.
+- `app/lib/meal-plan.server.ts` - Meal-plan CRUD plus the new `copyMealPlan()` mutation and UTC date helpers used for relative-offset remapping.
+- `app/routes/family-meal-plans.tsx` - Meal-plan list/create UI, optional reuse selector, action branching, and copy notice handling.
+- `app/lib/meal-plan.server.test.ts` - Fastest reference for range validation, scoped access rules, and copy/truncation behavior.
+- `app/routes/family-meal-plans.test.ts` - Loader/action expectations for create vs reuse flows on the list route.
 
 ## Validation
 
-- `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plan.test.ts`
+- `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plans.test.ts`
 - `npm run lint`
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
-- No manual browser smoke test has been run yet for the dinner planner route.
-- Copy/reuse, shopping generation, and approval state are still follow-up slices; this change only covers daily dinner entry editing plus notes.
-- The planner currently saves the full visible date range in one submit; if product later prefers autosave or per-day saves, the route/action contract will need to change.
+- No manual browser smoke test has been run yet for the meal-plan list page or copied-plan detail flow.
+- Manual shopping items, shopping overrides, and approval state still remain out of scope for copy/reuse; this change only copies dinner entries plus notes.
+- The copied plan currently redirects back to the meal-plan list with a success notice. If product later prefers jumping directly into the copied plan, the list-route redirect flow should be revisited.
 
 ## Next Step
 
-Run a manual end-to-end check of `families/:familyId/meal-plans/:mealPlanId` to verify saving, clearing, and reloading dinners/notes in the browser, then continue with the next meal-planning slice such as copy/reuse or approval.
+Run a manual end-to-end check of `families/:familyId/meal-plans` to verify reusing a source plan, then open the copied plan and confirm dinners/notes landed on the expected target dates before moving on to approval or shopping-generation work.

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -12,6 +12,7 @@ const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
         update: vi.fn(),
       },
       mealPlanEntry: {
+        createMany: vi.fn(),
         deleteMany: vi.fn(),
         upsert: vi.fn(),
       },
@@ -36,6 +37,7 @@ vi.mock("./family.server", () => {
 });
 
 import {
+  copyMealPlan,
   createMealPlan,
   deleteMealPlan,
   formatDateOnly,
@@ -220,6 +222,191 @@ describe("meal-plan.server", () => {
       },
     });
     expect(dbMock.mealPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("copies dinner entries into a new target range using relative offsets", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          note: "Rester til lunsj",
+          recipeId: "kylling-taco",
+        },
+        {
+          date: new Date("2026-05-17T00:00:00.000Z"),
+          note: null,
+          recipeId: "tomatsuppe",
+        },
+      ],
+      id: "meal-plan-source",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+    });
+    dbMock.mealPlan.create.mockResolvedValue({
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: "meal-plan-source",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-22T00:00:00.000Z"),
+      id: "meal-plan-copy",
+      startDate: new Date("2026-05-20T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Neste uke",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const result = await copyMealPlan({
+      endDate: "2026-05-22",
+      familyId: "family-1",
+      sourceMealPlanId: "meal-plan-source",
+      startDate: "2026-05-20",
+      title: "Neste uke",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("CREATED");
+    expect(dbMock.mealPlan.findFirst).toHaveBeenCalledWith({
+      select: {
+        entries: {
+          orderBy: [{ date: "asc" }],
+          select: {
+            date: true,
+            note: true,
+            recipeId: true,
+          },
+          where: {
+            mealType: "DINNER",
+          },
+        },
+        id: true,
+        startDate: true,
+      },
+      where: {
+        familyId: "family-1",
+        id: "meal-plan-source",
+      },
+    });
+    expect(dbMock.mealPlan.create).toHaveBeenCalledWith({
+      data: {
+        copiedFromMealPlanId: "meal-plan-source",
+        endDate: new Date("2026-05-22T00:00:00.000Z"),
+        familyId: "family-1",
+        startDate: new Date("2026-05-20T00:00:00.000Z"),
+        title: "Neste uke",
+      },
+      select: {
+        approvedAt: true,
+        approvedByUserId: true,
+        copiedFromMealPlanId: true,
+        createdAt: true,
+        endDate: true,
+        id: true,
+        startDate: true,
+        status: true,
+        title: true,
+        updatedAt: true,
+      },
+    });
+    expect(dbMock.mealPlanEntry.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          date: new Date("2026-05-20T00:00:00.000Z"),
+          mealPlanId: "meal-plan-copy",
+          mealType: "DINNER",
+          note: "Rester til lunsj",
+          recipeId: "kylling-taco",
+        },
+        {
+          date: new Date("2026-05-22T00:00:00.000Z"),
+          mealPlanId: "meal-plan-copy",
+          mealType: "DINNER",
+          note: null,
+          recipeId: "tomatsuppe",
+        },
+      ],
+    });
+  });
+
+  it("truncates copied entries that fall outside a shorter target range", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          note: "",
+          recipeId: "kylling-taco",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          note: "Bare notat",
+          recipeId: null,
+        },
+        {
+          date: new Date("2026-05-17T00:00:00.000Z"),
+          note: "",
+          recipeId: "tomatsuppe",
+        },
+      ],
+      id: "meal-plan-source",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+    });
+    dbMock.mealPlan.create.mockResolvedValue({
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: "meal-plan-source",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-21T00:00:00.000Z"),
+      id: "meal-plan-copy",
+      startDate: new Date("2026-05-20T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Kort uke",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    await copyMealPlan({
+      endDate: "2026-05-21",
+      familyId: "family-1",
+      sourceMealPlanId: "meal-plan-source",
+      startDate: "2026-05-20",
+      title: "Kort uke",
+      userId: "user-1",
+    });
+
+    expect(dbMock.mealPlanEntry.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          date: new Date("2026-05-20T00:00:00.000Z"),
+          mealPlanId: "meal-plan-copy",
+          mealType: "DINNER",
+          note: "",
+          recipeId: "kylling-taco",
+        },
+        {
+          date: new Date("2026-05-21T00:00:00.000Z"),
+          mealPlanId: "meal-plan-copy",
+          mealType: "DINNER",
+          note: "Bare notat",
+          recipeId: null,
+        },
+      ],
+    });
+  });
+
+  it("returns NOT_FOUND when the source meal plan is outside the family scope", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue(null);
+
+    const result = await copyMealPlan({
+      endDate: "2026-05-22",
+      familyId: "family-1",
+      sourceMealPlanId: "meal-plan-404",
+      startDate: "2026-05-20",
+      title: "Neste uke",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "NOT_FOUND",
+    });
+    expect(dbMock.mealPlan.create).not.toHaveBeenCalled();
+    expect(dbMock.mealPlanEntry.createMany).not.toHaveBeenCalled();
   });
 
   it("throws a not-found response when a meal plan is outside the family scope", async () => {

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -96,6 +96,10 @@ interface MealPlanMutationInput {
   userId: string;
 }
 
+interface CopyMealPlanInput extends MealPlanMutationInput {
+  sourceMealPlanId: string;
+}
+
 export interface MealPlanEntryValues {
   date: string;
   note: string;
@@ -354,6 +358,111 @@ export async function createMealPlan(input: MealPlanMutationInput) {
       name: membership.family.name,
     },
     mealPlan,
+    status: "CREATED" as const,
+  };
+}
+
+export async function copyMealPlan(input: CopyMealPlanInput) {
+  const membership = await requireFamilyMembership({
+    familyId: input.familyId,
+    userId: input.userId,
+  });
+  const validation = validateMealPlanInput(input);
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  const result = await db.$transaction(async (tx) => {
+    const sourceMealPlan = await tx.mealPlan.findFirst({
+      select: {
+        entries: {
+          orderBy: [{ date: "asc" }],
+          select: {
+            date: true,
+            note: true,
+            recipeId: true,
+          },
+          where: {
+            mealType: PLANNING_MEAL_TYPE,
+          },
+        },
+        id: true,
+        startDate: true,
+      },
+      where: {
+        familyId: input.familyId,
+        id: input.sourceMealPlanId,
+      },
+    });
+
+    if (!sourceMealPlan) {
+      return {
+        status: "NOT_FOUND" as const,
+      };
+    }
+
+    const startDate = parseDateOnly(validation.values.startDate)!;
+    const endDate = parseDateOnly(validation.values.endDate)!;
+    const mealPlan = await tx.mealPlan.create({
+      data: {
+        copiedFromMealPlanId: sourceMealPlan.id,
+        endDate,
+        familyId: input.familyId,
+        startDate,
+        title: validation.values.title,
+      },
+      select: mealPlanDetailSelect,
+    });
+    const copiedEntries = sourceMealPlan.entries.flatMap((entry) => {
+      if (!entry.note && !entry.recipeId) {
+        return [];
+      }
+
+      const dayOffset = differenceInUtcDays(sourceMealPlan.startDate, entry.date);
+      const targetDate = addUtcDays(startDate, dayOffset);
+
+      if (targetDate.getTime() > endDate.getTime()) {
+        return [];
+      }
+
+      return [
+        {
+          date: targetDate,
+          mealPlanId: mealPlan.id,
+          mealType: PLANNING_MEAL_TYPE,
+          note: entry.note,
+          recipeId: entry.recipeId,
+        },
+      ];
+    });
+
+    if (copiedEntries.length > 0) {
+      await tx.mealPlanEntry.createMany({
+        data: copiedEntries,
+      });
+    }
+
+    return {
+      mealPlan,
+      status: "CREATED" as const,
+    };
+  });
+
+  if (result.status === "NOT_FOUND") {
+    return result;
+  }
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    mealPlan: result.mealPlan,
     status: "CREATED" as const,
   };
 }

--- a/app/routes/family-meal-plans.test.ts
+++ b/app/routes/family-meal-plans.test.ts
@@ -11,6 +11,7 @@ vi.mock("../lib/auth.server", async () => {
 
 vi.mock("../lib/meal-plan.server", () => {
   return {
+    copyMealPlan: vi.fn(),
     createMealPlan: vi.fn(),
     deleteMealPlan: vi.fn(),
     formatDateOnly: vi.fn((date: Date) => date.toISOString().slice(0, 10)),
@@ -19,7 +20,7 @@ vi.mock("../lib/meal-plan.server", () => {
 });
 
 import { requireUser } from "../lib/auth.server";
-import { createMealPlan, deleteMealPlan, listMealPlansForFamily } from "../lib/meal-plan.server";
+import { copyMealPlan, createMealPlan, deleteMealPlan, listMealPlansForFamily } from "../lib/meal-plan.server";
 import { action, loader } from "./family-meal-plans";
 
 const mockUser = {
@@ -134,8 +135,60 @@ describe("family meal plans route", () => {
       intent: "create-meal-plan",
       values: {
         endDate: "2026-05-20",
+        sourceMealPlanId: "",
         startDate: "2026-05-12",
         title: "Uke 20",
+      },
+    });
+  });
+
+  it("returns copy validation errors while preserving the selected source meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(copyMealPlan).mockResolvedValue({
+      fieldErrors: {
+        title: "Skriv inn et navn for ukeplanen.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        endDate: "2026-05-22",
+        startDate: "2026-05-20",
+        title: "",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-meal-plan");
+    formData.set("title", " ");
+    formData.set("startDate", "2026-05-20");
+    formData.set("endDate", "2026-05-22");
+    formData.set("sourceMealPlanId", "meal-plan-source");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans", formData),
+    });
+
+    expect(copyMealPlan).toHaveBeenCalledWith({
+      endDate: "2026-05-22",
+      familyId: "family-1",
+      sourceMealPlanId: "meal-plan-source",
+      startDate: "2026-05-20",
+      title: " ",
+      userId: "user-1",
+    });
+    expect(createMealPlan).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      fieldErrors: {
+        title: "Skriv inn et navn for ukeplanen.",
+      },
+      intent: "create-meal-plan",
+      values: {
+        endDate: "2026-05-22",
+        sourceMealPlanId: "meal-plan-source",
+        startDate: "2026-05-20",
+        title: "",
       },
     });
   });
@@ -182,6 +235,83 @@ describe("family meal plans route", () => {
     expect(response.headers.get("Location")).toBe(
       "http://localhost/families/family-1/meal-plans?notice=meal-plan-created",
     );
+  });
+
+  it("redirects with a copy notice after reusing an existing meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(copyMealPlan).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlan: {
+        approvedAt: null,
+        approvedByUserId: null,
+        copiedFromMealPlanId: "meal-plan-source",
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-22T00:00:00.000Z"),
+        id: "meal-plan-copy",
+        startDate: new Date("2026-05-20T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Neste uke",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-meal-plan");
+    formData.set("title", "Neste uke");
+    formData.set("startDate", "2026-05-20");
+    formData.set("endDate", "2026-05-22");
+    formData.set("sourceMealPlanId", "meal-plan-source");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans", formData),
+    });
+
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans?notice=meal-plan-copied",
+    );
+  });
+
+  it("returns a create-form error when the selected source meal plan no longer exists", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(copyMealPlan).mockResolvedValue({
+      status: "NOT_FOUND",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-meal-plan");
+    formData.set("title", "Neste uke");
+    formData.set("startDate", "2026-05-20");
+    formData.set("endDate", "2026-05-22");
+    formData.set("sourceMealPlanId", "meal-plan-source");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans", formData),
+    });
+
+    expect(result).toEqual({
+      formError: "Fant ikke ukeplanen du ville gjenbruke. Velg en annen ukeplan og prov igjen.",
+      intent: "create-meal-plan",
+      values: {
+        endDate: "2026-05-22",
+        sourceMealPlanId: "meal-plan-source",
+        startDate: "2026-05-20",
+        title: "Neste uke",
+      },
+    });
   });
 
   it("returns a delete error when the meal plan no longer exists", async () => {

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -1,9 +1,15 @@
 import { Form, Link, useNavigation, type MetaFunction } from "react-router";
 
 import { requireUser } from "../lib/auth.server";
-import { createMealPlan, deleteMealPlan, formatDateOnly, listMealPlansForFamily } from "../lib/meal-plan.server";
+import {
+  copyMealPlan,
+  createMealPlan,
+  deleteMealPlan,
+  formatDateOnly,
+  listMealPlansForFamily,
+} from "../lib/meal-plan.server";
 
-type MealPlanNotice = "meal-plan-created" | "meal-plan-deleted";
+type MealPlanNotice = "meal-plan-copied" | "meal-plan-created" | "meal-plan-deleted";
 
 interface MealPlanActionData {
   fieldErrors?: {
@@ -16,6 +22,7 @@ interface MealPlanActionData {
   targetMealPlanId?: string;
   values?: {
     endDate?: string;
+    sourceMealPlanId?: string;
     startDate?: string;
     title?: string;
   };
@@ -75,25 +82,51 @@ export async function action({
   const intent = String(formData.get("intent") ?? "");
 
   if (intent === "create-meal-plan") {
-    const result = await createMealPlan({
+    const values = {
       endDate: String(formData.get("endDate") ?? ""),
-      familyId,
+      sourceMealPlanId: String(formData.get("sourceMealPlanId") ?? "").trim(),
       startDate: String(formData.get("startDate") ?? ""),
       title: String(formData.get("title") ?? ""),
-      userId: user.id,
-    });
+    };
+    const result = values.sourceMealPlanId
+      ? await copyMealPlan({
+          endDate: values.endDate,
+          familyId,
+          sourceMealPlanId: values.sourceMealPlanId,
+          startDate: values.startDate,
+          title: values.title,
+          userId: user.id,
+        })
+      : await createMealPlan({
+          endDate: values.endDate,
+          familyId,
+          startDate: values.startDate,
+          title: values.title,
+          userId: user.id,
+        });
 
     if (result.status === "VALIDATION_ERROR") {
       return {
         fieldErrors: result.fieldErrors,
         intent,
-        values: result.values,
+        values: {
+          ...result.values,
+          sourceMealPlanId: values.sourceMealPlanId,
+        },
+      } satisfies MealPlanActionData;
+    }
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke ukeplanen du ville gjenbruke. Velg en annen ukeplan og prov igjen.",
+        intent,
+        values,
       } satisfies MealPlanActionData;
     }
 
     return buildMealPlanRedirect({
       familyId,
-      notice: "meal-plan-created",
+      notice: values.sourceMealPlanId ? "meal-plan-copied" : "meal-plan-created",
       request,
     });
   }
@@ -140,6 +173,7 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
   const pendingMealPlanId = String(navigation.formData?.get("mealPlanId") ?? "");
   const isCreatingMealPlan = navigation.state === "submitting" && pendingIntent === "create-meal-plan";
   const isDeletingMealPlan = navigation.state === "submitting" && pendingIntent === "delete-meal-plan";
+  const sourceMealPlanValue = actionData?.intent === "create-meal-plan" ? actionData.values?.sourceMealPlanId ?? "" : "";
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -179,8 +213,8 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
             <div className="flex flex-col gap-2">
               <h2 className="text-lg font-semibold text-slate-950">Opprett ukeplan</h2>
               <p className="text-sm leading-6 text-slate-600">
-                Velg et navn og et datointervall pa maks 7 dager. Delvise uker som torsdag til sondag
-                er stottet.
+                Velg et navn og et datointervall pa maks 7 dager. Du kan starte fra en tom ukeplan eller
+                gjenbruke middager og notater fra en tidligere plan.
               </p>
             </div>
 
@@ -201,6 +235,27 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
               {actionData?.intent === "create-meal-plan" && actionData.fieldErrors?.title ? (
                 <p className="text-sm text-rose-600">{actionData.fieldErrors.title}</p>
               ) : null}
+
+              <label className="block text-sm font-medium text-slate-700">
+                Start med eksisterende ukeplan
+                <select
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={sourceMealPlanValue}
+                  name="sourceMealPlanId"
+                >
+                  <option value="">Tom ukeplan</option>
+                  {loaderData.mealPlans.map((mealPlan) => (
+                    <option key={mealPlan.id} value={mealPlan.id}>
+                      {mealPlan.title} ({formatMealPlanWindow(mealPlan.startDate, mealPlan.endDate)})
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <p className="text-sm leading-6 text-slate-500">
+                Velg en tidligere ukeplan for a kopiere middager og notater til samme relative dager i den
+                nye perioden.
+              </p>
 
               <div className="grid gap-4 sm:grid-cols-2">
                 <label className="block text-sm font-medium text-slate-700">
@@ -339,7 +394,7 @@ function requireFamilyId(familyId: string | undefined) {
 function getMealPlanNotice(request: Request): MealPlanNotice | null {
   const notice = new URL(request.url).searchParams.get("notice");
 
-  if (notice === "meal-plan-created" || notice === "meal-plan-deleted") {
+  if (notice === "meal-plan-copied" || notice === "meal-plan-created" || notice === "meal-plan-deleted") {
     return notice;
   }
 
@@ -363,6 +418,11 @@ function buildMealPlanRedirect({
 
 function getMealPlanNoticeContent(notice: MealPlanNotice) {
   switch (notice) {
+    case "meal-plan-copied":
+      return {
+        description: "Den nye ukeplanen ble opprettet med kopierte middager og notater i den valgte perioden.",
+        title: "Ukeplan gjenbrukt",
+      };
     case "meal-plan-created":
       return {
         description: "Ukeplanen ble lagret med start- og sluttdato for familien.",


### PR DESCRIPTION
## Summary
- add a dedicated `copyMealPlan()` mutation that reuses an existing plan into a new date range using relative day offsets
- update the meal-plan list/create route to optionally start from an existing plan and show copy-specific success and error states
- expand focused tests for copy remapping, truncation, and route action behavior

## Test plan
- [x] `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plans.test.ts`
- [x] `npm run lint`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Manual browser smoke test not run