### PR TITLE
Add meal plan approval workflow

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,33 +2,32 @@
 
 ## Current Objective
 
-Implement issue `#9`'s first production meal-plan copy/reuse flow. Users can now create a new meal plan from an existing one, map copied dinner entries and notes into a selected target date range by relative day offset, and keep the change scoped to current meal-planning functionality.
+Implement issue `#10`'s meal-plan approval workflow so admins can move plans between draft and approved states without locking editing yet.
 
 ## Completed
 
-- Added `copyMealPlan()` to `app/lib/meal-plan.server.ts` as a dedicated transactional reuse mutation that validates the new range, scopes the source plan to the current family, sets `copiedFromMealPlanId`, copies only dinner entries plus notes, and truncates copied entries that fall outside the new target range.
-- Updated `app/routes/family-meal-plans.tsx` so the existing `Opprett ukeplan` form can optionally reuse a previous meal plan via a source selector while preserving the server-first action/notice flow.
-- Expanded focused coverage in `app/lib/meal-plan.server.test.ts` and `app/routes/family-meal-plans.test.ts` for relative-offset copying, shorter target truncation, source-plan not found handling, and copy-specific redirects/validation state.
+- Added admin-only meal-plan approval transitions in `app/lib/meal-plan.server.ts`, including `approveMealPlan()`, `reopenMealPlan()`, valid draft/approved transition checks, and persisted `approvedByUserId` / `approvedAt` metadata.
+- Updated `app/routes/family-meal-plan.tsx` to support approve/reopen intents, route notices, admin-only approval controls, and approved timestamp display on the meal-plan detail page.
+- Expanded focused coverage in `app/lib/meal-plan.server.test.ts` and `app/routes/family-meal-plan.test.ts` for approval success paths, invalid transitions, authorization failures, and redirect handling.
 
 ## Files To Read First
 
-- `app/lib/meal-plan.server.ts` - Meal-plan CRUD plus the new `copyMealPlan()` mutation and UTC date helpers used for relative-offset remapping.
-- `app/routes/family-meal-plans.tsx` - Meal-plan list/create UI, optional reuse selector, action branching, and copy notice handling.
-- `app/lib/meal-plan.server.test.ts` - Fastest reference for range validation, scoped access rules, and copy/truncation behavior.
-- `app/routes/family-meal-plans.test.ts` - Loader/action expectations for create vs reuse flows on the list route.
+- `app/lib/meal-plan.server.ts` - Approval state mutations, transition rules, and shared meal-plan server logic.
+- `app/routes/family-meal-plan.tsx` - Detail-route action branching, approval UI, and success/error notices.
+- `app/lib/meal-plan.server.test.ts` - Service-level approval behavior and authorization expectations.
+- `app/routes/family-meal-plan.test.ts` - Route intent wiring and approval notice coverage.
 
 ## Validation
 
-- `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plans.test.ts`
-- `npm run lint`
+- `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plan.test.ts`
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
-- No manual browser smoke test has been run yet for the meal-plan list page or copied-plan detail flow.
-- Manual shopping items, shopping overrides, and approval state still remain out of scope for copy/reuse; this change only copies dinner entries plus notes.
-- The copied plan currently redirects back to the meal-plan list with a success notice. If product later prefers jumping directly into the copied plan, the list-route redirect flow should be revisited.
+- No manual browser smoke test has been run yet for the approve/reopen flow on `families/:familyId/meal-plans/:mealPlanId`.
+- Approved meal plans are still editable by design in this first pass; stricter locking for edits, deletes, shopping, or calendar flows is still future work.
+- The detail view shows approval time but not approver display name. If product wants that context, extend the meal-plan select and loader payload later.
 
 ## Next Step
 
-Run a manual end-to-end check of `families/:familyId/meal-plans` to verify reusing a source plan, then open the copied plan and confirm dinners/notes landed on the expected target dates before moving on to approval or shopping-generation work.
+Run a manual end-to-end check of the meal-plan detail page to verify admin approve/reopen actions, status notices, and approved timestamp rendering before tightening workflow rules further.

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+const { dbMock, requireFamilyAdminMock, requireFamilyMembershipMock } = vi.hoisted(() => {
   return {
     dbMock: {
       $transaction: vi.fn(),
@@ -20,6 +20,7 @@ const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
         findMany: vi.fn(),
       },
     },
+    requireFamilyAdminMock: vi.fn(),
     requireFamilyMembershipMock: vi.fn(),
   };
 });
@@ -32,11 +33,13 @@ vi.mock("./db.server", () => {
 
 vi.mock("./family.server", () => {
   return {
+    requireFamilyAdmin: requireFamilyAdminMock,
     requireFamilyMembership: requireFamilyMembershipMock,
   };
 });
 
 import {
+  approveMealPlan,
   copyMealPlan,
   createMealPlan,
   deleteMealPlan,
@@ -44,6 +47,7 @@ import {
   getMealPlanForFamily,
   getMealPlanPlanningData,
   listMealPlansForFamily,
+  reopenMealPlan,
   saveMealPlanEntries,
   updateMealPlan,
   validateMealPlanRange,
@@ -64,6 +68,7 @@ const mockMembership = {
 describe("meal-plan.server", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    requireFamilyAdminMock.mockResolvedValue(mockMembership);
     requireFamilyMembershipMock.mockResolvedValue(mockMembership);
     dbMock.$transaction.mockImplementation(async (callback: (tx: typeof dbMock) => Promise<unknown>) =>
       callback(dbMock),
@@ -510,6 +515,148 @@ describe("meal-plan.server", () => {
       status: "NOT_FOUND",
     });
     expect(dbMock.mealPlan.update).not.toHaveBeenCalled();
+  });
+
+  it("approves a draft meal plan as an admin", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      id: "meal-plan-1",
+      status: "DRAFT",
+    });
+    dbMock.mealPlan.update.mockResolvedValue({
+      approvedAt: new Date("2026-05-16T09:30:00.000Z"),
+      approvedByUserId: "user-1",
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "APPROVED",
+      title: "Langhelg",
+      updatedAt: new Date("2026-05-16T09:30:00.000Z"),
+    });
+
+    const result = await approveMealPlan({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyAdminMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(dbMock.mealPlan.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        approvedAt: expect.any(Date),
+        approvedByUserId: "user-1",
+        status: "APPROVED",
+      }),
+      select: {
+        approvedAt: true,
+        approvedByUserId: true,
+        copiedFromMealPlanId: true,
+        createdAt: true,
+        endDate: true,
+        id: true,
+        startDate: true,
+        status: true,
+        title: true,
+        updatedAt: true,
+      },
+      where: {
+        id: "meal-plan-1",
+      },
+    });
+    expect(result.status).toBe("APPROVED");
+  });
+
+  it("reopens an approved meal plan back to draft", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      id: "meal-plan-1",
+      status: "APPROVED",
+    });
+    dbMock.mealPlan.update.mockResolvedValue({
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+      updatedAt: new Date("2026-05-16T09:35:00.000Z"),
+    });
+
+    const result = await reopenMealPlan({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.mealPlan.update).toHaveBeenCalledWith({
+      data: {
+        approvedAt: null,
+        approvedByUserId: null,
+        status: "DRAFT",
+      },
+      select: {
+        approvedAt: true,
+        approvedByUserId: true,
+        copiedFromMealPlanId: true,
+        createdAt: true,
+        endDate: true,
+        id: true,
+        startDate: true,
+        status: true,
+        title: true,
+        updatedAt: true,
+      },
+      where: {
+        id: "meal-plan-1",
+      },
+    });
+    expect(result.status).toBe("REOPENED");
+  });
+
+  it("returns an invalid-transition error when approving an already approved meal plan", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      id: "meal-plan-1",
+      status: "APPROVED",
+    });
+
+    const result = await approveMealPlan({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      formError: "Ukeplanen er allerede godkjent.",
+      status: "INVALID_TRANSITION",
+    });
+    expect(dbMock.mealPlan.update).not.toHaveBeenCalled();
+  });
+
+  it("rethrows the admin authorization failure for approval changes", async () => {
+    requireFamilyAdminMock.mockRejectedValue(
+      new Response("Forbidden", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    await expect(
+      approveMealPlan({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+        userId: "user-2",
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      statusText: "Forbidden",
+    });
+    expect(dbMock.mealPlan.findFirst).not.toHaveBeenCalled();
   });
 
   it("rejects entry submissions that do not cover the full visible range", async () => {

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -1,7 +1,7 @@
-import { MealType, Prisma, RecipeScope } from "@prisma/client";
+import { MealPlanStatus, MealType, Prisma, RecipeScope } from "@prisma/client";
 
 import { db } from "./db.server";
-import { requireFamilyMembership } from "./family.server";
+import { requireFamilyAdmin, requireFamilyMembership } from "./family.server";
 
 const MEAL_PLAN_MAX_SPAN_DAYS = 7;
 const MEAL_PLAN_MAX_DAY_OFFSET = MEAL_PLAN_MAX_SPAN_DAYS - 1;
@@ -119,6 +119,8 @@ interface DeleteMealPlanInput {
   userId: string;
 }
 
+type MealPlanApprovalInput = DeleteMealPlanInput;
+
 type GetMealPlanInput = DeleteMealPlanInput;
 
 interface MealPlanListInput {
@@ -127,6 +129,8 @@ interface MealPlanListInput {
 }
 
 type MealPlanPlanningInput = GetMealPlanInput;
+
+type MealPlanApprovalAction = "APPROVE" | "REOPEN";
 
 export function formatDateOnly(date: Date) {
   return [
@@ -467,6 +471,14 @@ export async function copyMealPlan(input: CopyMealPlanInput) {
   };
 }
 
+export async function approveMealPlan(input: MealPlanApprovalInput) {
+  return updateMealPlanApprovalState(input, "APPROVE");
+}
+
+export async function reopenMealPlan(input: MealPlanApprovalInput) {
+  return updateMealPlanApprovalState(input, "REOPEN");
+}
+
 export async function updateMealPlan(input: MealPlanMutationInput & { mealPlanId: string }) {
   await requireFamilyMembership({
     familyId: input.familyId,
@@ -663,6 +675,65 @@ export async function saveMealPlanEntries({
   };
 }
 
+async function updateMealPlanApprovalState(
+  { familyId, mealPlanId, userId }: MealPlanApprovalInput,
+  action: MealPlanApprovalAction,
+) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: {
+      id: true,
+      status: true,
+    },
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (!isMealPlanStatusTransitionAllowed(mealPlan.status, action)) {
+    return {
+      formError: getMealPlanApprovalTransitionError(action, mealPlan.status),
+      status: "INVALID_TRANSITION" as const,
+    };
+  }
+
+  const nextStatus = action === "APPROVE" ? MealPlanStatus.APPROVED : MealPlanStatus.DRAFT;
+  const updatedMealPlan = await db.mealPlan.update({
+    data:
+      nextStatus === MealPlanStatus.APPROVED
+        ? {
+            approvedAt: new Date(),
+            approvedByUserId: userId,
+            status: MealPlanStatus.APPROVED,
+          }
+        : {
+            approvedAt: null,
+            approvedByUserId: null,
+            status: MealPlanStatus.DRAFT,
+          },
+    select: mealPlanDetailSelect,
+    where: {
+      id: mealPlan.id,
+    },
+  });
+
+  return {
+    mealPlan: updatedMealPlan,
+    status: action === "APPROVE" ? ("APPROVED" as const) : ("REOPENED" as const),
+  };
+}
+
 function validateMealPlanInput({
   endDate,
   startDate,
@@ -699,6 +770,30 @@ function validateMealPlanInput({
     ok: true,
     values,
   };
+}
+
+function isMealPlanStatusTransitionAllowed(status: MealPlanStatus, action: MealPlanApprovalAction) {
+  if (action === "APPROVE") {
+    return status === MealPlanStatus.DRAFT;
+  }
+
+  return status === MealPlanStatus.APPROVED;
+}
+
+function getMealPlanApprovalTransitionError(action: MealPlanApprovalAction, currentStatus: MealPlanStatus) {
+  if (action === "APPROVE") {
+    if (currentStatus === MealPlanStatus.APPROVED) {
+      return "Ukeplanen er allerede godkjent.";
+    }
+
+    return "Ukeplanen kan ikke godkjennes fra gjeldende status.";
+  }
+
+  if (currentStatus === MealPlanStatus.DRAFT) {
+    return "Ukeplanen er allerede et utkast.";
+  }
+
+  return "Ukeplanen kan ikke gjenapnes fra gjeldende status.";
 }
 
 function normalizeMealPlanEntryValues(entry: MealPlanEntryValues): MealPlanEntryValues {

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -11,15 +11,23 @@ vi.mock("../lib/auth.server", async () => {
 
 vi.mock("../lib/meal-plan.server", () => {
   return {
+    approveMealPlan: vi.fn(),
     formatDateOnly: vi.fn((date: Date) => date.toISOString().slice(0, 10)),
     getMealPlanPlanningData: vi.fn(),
+    reopenMealPlan: vi.fn(),
     saveMealPlanEntries: vi.fn(),
     updateMealPlan: vi.fn(),
   };
 });
 
 import { requireUser } from "../lib/auth.server";
-import { getMealPlanPlanningData, saveMealPlanEntries, updateMealPlan } from "../lib/meal-plan.server";
+import {
+  approveMealPlan,
+  getMealPlanPlanningData,
+  reopenMealPlan,
+  saveMealPlanEntries,
+  updateMealPlan,
+} from "../lib/meal-plan.server";
 import { action, loader } from "./family-meal-plan";
 
 const mockUser = {
@@ -106,8 +114,8 @@ describe("family meal plan route", () => {
         name: "Solberg",
       },
       mealPlan: {
-        approvedAt: null,
         approvedByUserId: null,
+        approvedAt: null,
         copiedFromMealPlanId: null,
         createdAt: new Date("2026-05-01T12:00:00.000Z"),
         endDate: "2026-05-18",
@@ -129,6 +137,7 @@ describe("family meal plan route", () => {
           title: "Kyllingtaco",
         },
       ],
+      userRole: "ADMIN",
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
       entriesByDate: {
         "2026-05-15": {
@@ -247,6 +256,116 @@ describe("family meal plan route", () => {
     expect(response.headers.get("Location")).toBe(
       "http://localhost/families/family-1/meal-plans/meal-plan-1?notice=meal-plan-entries-saved",
     );
+  });
+
+  it("redirects with an explicit notice after approving a meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(approveMealPlan).mockResolvedValue({
+      mealPlan: {
+        approvedAt: new Date("2026-05-16T09:30:00.000Z"),
+        approvedByUserId: "user-1",
+        copiedFromMealPlanId: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "APPROVED",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-16T09:30:00.000Z"),
+      },
+      status: "APPROVED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "approve-meal-plan");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(approveMealPlan).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1?notice=meal-plan-approved",
+    );
+  });
+
+  it("redirects with an explicit notice after reopening a meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(reopenMealPlan).mockResolvedValue({
+      mealPlan: {
+        approvedAt: null,
+        approvedByUserId: null,
+        copiedFromMealPlanId: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-16T09:35:00.000Z"),
+      },
+      status: "REOPENED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "reopen-meal-plan");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(reopenMealPlan).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1?notice=meal-plan-reopened",
+    );
+  });
+
+  it("returns approval transition errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(approveMealPlan).mockResolvedValue({
+      formError: "Ukeplanen er allerede godkjent.",
+      status: "INVALID_TRANSITION",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "approve-meal-plan");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(result).toEqual({
+      intent: "approve-meal-plan",
+      statusFormError: "Ukeplanen er allerede godkjent.",
+    });
   });
 
   it("returns update validation errors from the server module", async () => {

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -2,15 +2,26 @@ import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } fr
 
 import { requireUser } from "../lib/auth.server";
 import {
+  approveMealPlan,
   formatDateOnly,
   getMealPlanPlanningData,
+  reopenMealPlan,
   saveMealPlanEntries,
   type MealPlanEntryValues,
   updateMealPlan,
 } from "../lib/meal-plan.server";
 
-type MealPlanNotice = "meal-plan-created" | "meal-plan-entries-saved" | "meal-plan-updated";
-type MealPlanIntent = "save-meal-plan-entries" | "update-meal-plan";
+type MealPlanNotice =
+  | "meal-plan-approved"
+  | "meal-plan-created"
+  | "meal-plan-entries-saved"
+  | "meal-plan-reopened"
+  | "meal-plan-updated";
+type MealPlanIntent =
+  | "approve-meal-plan"
+  | "reopen-meal-plan"
+  | "save-meal-plan-entries"
+  | "update-meal-plan";
 
 interface MealPlanEntryFormState {
   note: string;
@@ -27,6 +38,7 @@ interface MealPlanActionData {
   };
   formError?: string;
   intent?: MealPlanIntent;
+  statusFormError?: string;
   values?: {
     endDate?: string;
     startDate?: string;
@@ -85,12 +97,14 @@ export async function loader({
     family: result.family,
     mealPlan: {
       ...result.mealPlan,
+      approvedAt: result.mealPlan.approvedAt ? result.mealPlan.approvedAt.toISOString() : null,
       endDate: formatDateOnly(result.mealPlan.endDate),
       entries: undefined,
       startDate: formatDateOnly(result.mealPlan.startDate),
     },
     notice: getMealPlanNotice(request),
     recipes: result.recipes,
+    userRole: result.userRole,
     visibleDates: result.visibleDates,
     entriesByDate,
   };
@@ -143,6 +157,42 @@ export async function action({
     });
   }
 
+  if (intent === "approve-meal-plan" || intent === "reopen-meal-plan") {
+    const result =
+      intent === "approve-meal-plan"
+        ? await approveMealPlan({
+            familyId,
+            mealPlanId,
+            userId: user.id,
+          })
+        : await reopenMealPlan({
+            familyId,
+            mealPlanId,
+            userId: user.id,
+          });
+
+    if (result.status === "NOT_FOUND") {
+      throw new Response("Fant ikke ukeplanen.", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    }
+
+    if (result.status === "INVALID_TRANSITION") {
+      return {
+        intent,
+        statusFormError: result.formError,
+      } satisfies MealPlanActionData;
+    }
+
+    return buildMealPlanRedirect({
+      familyId,
+      mealPlanId,
+      notice: result.status === "APPROVED" ? "meal-plan-approved" : "meal-plan-reopened",
+      request,
+    });
+  }
+
   if (intent !== "update-meal-plan") {
     return {
       formError: "Ukjent handling.",
@@ -184,12 +234,24 @@ export async function action({
 export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlanRouteProps) {
   const navigation = useNavigation();
   const pendingIntent = navigation.formData?.get("intent");
+  const isApprovingMealPlan = navigation.state === "submitting" && pendingIntent === "approve-meal-plan";
+  const isReopeningMealPlan = navigation.state === "submitting" && pendingIntent === "reopen-meal-plan";
   const isSavingEntries = navigation.state === "submitting" && pendingIntent === "save-meal-plan-entries";
   const isUpdatingMetadata = navigation.state === "submitting" && pendingIntent === "update-meal-plan";
+  const canManageApproval = loaderData.userRole === "ADMIN";
   const noticeContent = loaderData.notice ? getMealPlanNoticeContent(loaderData.notice) : null;
   const titleValue = actionData?.values?.title ?? loaderData.mealPlan.title;
   const startDateValue = actionData?.values?.startDate ?? loaderData.mealPlan.startDate;
   const endDateValue = actionData?.values?.endDate ?? loaderData.mealPlan.endDate;
+  const approvalIntent = loaderData.mealPlan.status === "APPROVED" ? "reopen-meal-plan" : "approve-meal-plan";
+  const approvalButtonLabel =
+    approvalIntent === "approve-meal-plan"
+      ? isApprovingMealPlan
+        ? "Godkjenner..."
+        : "Godkjenn ukeplan"
+      : isReopeningMealPlan
+        ? "Gjenapner..."
+        : "Gjenapne som utkast";
   const entryValues =
     actionData?.intent === "save-meal-plan-entries" && actionData.entryValues
       ? actionData.entryValues
@@ -409,6 +471,11 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 <dd className="mt-2 text-base font-semibold text-slate-950">
                   {loaderData.mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
                 </dd>
+                {loaderData.mealPlan.approvedAt ? (
+                  <dd className="mt-2 text-sm leading-6 text-slate-600">
+                    Godkjent {formatApprovalTimestamp(loaderData.mealPlan.approvedAt)}
+                  </dd>
+                ) : null}
               </div>
 
               <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
@@ -420,6 +487,31 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 </dd>
               </div>
             </dl>
+
+            {canManageApproval ? (
+              <Form className="mt-6 space-y-4" method="post">
+                <input name="intent" type="hidden" value={approvalIntent} />
+
+                <p className="text-sm leading-6 text-slate-600">
+                  Godkjenning markerer ukeplanen som klar for neste steg uten a lase redigering enda.
+                </p>
+
+                {(actionData?.intent === "approve-meal-plan" || actionData?.intent === "reopen-meal-plan") &&
+                actionData.statusFormError ? (
+                  <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                    {actionData.statusFormError}
+                  </p>
+                ) : null}
+
+                <button
+                  className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                  disabled={isApprovingMealPlan || isReopeningMealPlan}
+                  type="submit"
+                >
+                  {approvalButtonLabel}
+                </button>
+              </Form>
+            ) : null}
           </article>
 
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
@@ -541,8 +633,10 @@ function getMealPlanNotice(request: Request): MealPlanNotice | null {
   const notice = new URL(request.url).searchParams.get("notice");
 
   if (
+    notice === "meal-plan-approved" ||
     notice === "meal-plan-created" ||
     notice === "meal-plan-entries-saved" ||
+    notice === "meal-plan-reopened" ||
     notice === "meal-plan-updated"
   ) {
     return notice;
@@ -570,6 +664,11 @@ function buildMealPlanRedirect({
 
 function getMealPlanNoticeContent(notice: MealPlanNotice) {
   switch (notice) {
+    case "meal-plan-approved":
+      return {
+        description: "Ukeplanen er markert som godkjent og klar for neste steg.",
+        title: "Ukeplan godkjent",
+      };
     case "meal-plan-created":
       return {
         description: "Ukeplanen er klar for videre arbeid med innhold og handleliste.",
@@ -579,6 +678,11 @@ function getMealPlanNoticeContent(notice: MealPlanNotice) {
       return {
         description: "Middagene og notatene ble lagret for den aktive perioden.",
         title: "Middager lagret",
+      };
+    case "meal-plan-reopened":
+      return {
+        description: "Ukeplanen er gjenapnet som utkast og kan fortsatt redigeres.",
+        title: "Ukeplan gjenapnet",
       };
     case "meal-plan-updated":
       return {
@@ -598,6 +702,16 @@ function formatMealPlanWindow(startDate: string, endDate: string) {
   return `${formatter.format(new Date(`${startDate}T00:00:00.000Z`))} - ${formatter.format(
     new Date(`${endDate}T00:00:00.000Z`),
   )}`;
+}
+
+function formatApprovalTimestamp(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(value));
 }
 
 function parseMealPlanEntries(formData: FormData): MealPlanEntryValues[] {


### PR DESCRIPTION
## Summary
- add admin-only meal plan approval and reopen transitions in the server layer
- wire approval notices, actions, and status details into the meal-plan detail route
- expand focused service and route tests for approval success, invalid transitions, and authorization

## Test plan
- [x] `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plan.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Manual browser smoke test for approve/reopen on the meal-plan detail page