### PR TITLE
Add shopping list projection from meal plans

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,33 @@
 
 ## Current Objective
 
-Implement issue `#10`'s meal-plan approval workflow so admins can move plans between draft and approved states without locking editing yet.
+Implement issue `#11`'s deterministic shopping projection so generated shopping items come from persisted meal-plan recipes on the server with exact-match merging and focused coverage.
 
 ## Completed
 
-- Added admin-only meal-plan approval transitions in `app/lib/meal-plan.server.ts`, including `approveMealPlan()`, `reopenMealPlan()`, valid draft/approved transition checks, and persisted `approvedByUserId` / `approvedAt` metadata.
-- Updated `app/routes/family-meal-plan.tsx` to support approve/reopen intents, route notices, admin-only approval controls, and approved timestamp display on the meal-plan detail page.
-- Expanded focused coverage in `app/lib/meal-plan.server.test.ts` and `app/routes/family-meal-plan.test.ts` for approval success paths, invalid transitions, authorization failures, and redirect handling.
+- Added `app/lib/shopping.server.ts` with a dedicated meal-plan-scoped shopping projection query, deterministic generated-item source keys, exact-match merge behavior, override application, and store/section ordering.
+- Added the first production shopping route in `app/routes/family-meal-plan-shopping.tsx` and registered it in `app/routes.ts` so families can open a read-only server-generated shopping view from a meal plan.
+- Expanded focused coverage in `app/lib/shopping.server.test.ts` and `app/routes/family-meal-plan-shopping.test.ts` for projection, merge boundaries, override application, ordering, scoping, and loader serialization.
+- Updated `app/routes/family-meal-plan.tsx` with a direct link to the new shopping view.
 
 ## Files To Read First
 
-- `app/lib/meal-plan.server.ts` - Approval state mutations, transition rules, and shared meal-plan server logic.
-- `app/routes/family-meal-plan.tsx` - Detail-route action branching, approval UI, and success/error notices.
-- `app/lib/meal-plan.server.test.ts` - Service-level approval behavior and authorization expectations.
-- `app/routes/family-meal-plan.test.ts` - Route intent wiring and approval notice coverage.
+- `app/lib/shopping.server.ts` - Core server-side shopping projection, merge logic, override application, and store grouping.
+- `app/routes/family-meal-plan-shopping.tsx` - Read-only shopping projection loader and UI for one meal plan.
+- `app/lib/shopping.server.test.ts` - Service-level coverage for deterministic source keys, exact-match merging, overrides, and ordering.
+- `app/routes/family-meal-plan.tsx` - Meal-plan detail page entry point linking into the shopping route.
 
 ## Validation
 
-- `npm run test:run -- app/lib/meal-plan.server.test.ts app/routes/family-meal-plan.test.ts`
+- `npm run test:run -- app/lib/shopping.server.test.ts app/routes/family-meal-plan-shopping.test.ts`
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
-- No manual browser smoke test has been run yet for the approve/reopen flow on `families/:familyId/meal-plans/:mealPlanId`.
-- Approved meal plans are still editable by design in this first pass; stricter locking for edits, deletes, shopping, or calendar flows is still future work.
-- The detail view shows approval time but not approver display name. If product wants that context, extend the meal-plan select and loader payload later.
+- No manual browser smoke test has been run yet for `families/:familyId/meal-plans/:mealPlanId/shopping`.
+- The new production shopping flow is generated-item only; manual shopping items, override mutation actions, checked-state editing, postponement editing, and store-mode UX are still future work.
+- Generated source keys are stable for the same merged occurrence set, but a merge bucket changing because entries were added or removed will naturally produce a new key and reset any existing override for that generated row.
 
 ## Next Step
 
-Run a manual end-to-end check of the meal-plan detail page to verify admin approve/reopen actions, status notices, and approved timestamp rendering before tightening workflow rules further.
+Run a manual end-to-end check of the new shopping route from an existing meal plan, then decide whether the next issue should add persisted manual items or override mutation actions first.

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      mealPlan: {
+        findFirst: vi.fn(),
+      },
+      store: {
+        findMany: vi.fn(),
+      },
+    },
+    requireFamilyMembershipMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+vi.mock("./family.server", () => {
+  return {
+    requireFamilyMembership: requireFamilyMembershipMock,
+  };
+});
+
+import { getMealPlanShoppingData } from "./shopping.server";
+
+const mockMembership = {
+  family: {
+    id: "family-1",
+    joinCode: "ABC123",
+    name: "Solberg",
+  },
+  familyId: "family-1",
+  id: "membership-1",
+  role: "ADMIN",
+  userId: "user-1",
+};
+
+describe("shopping.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue(mockMembership);
+  });
+
+  it("projects deterministic generated shopping items with exact-match merge, overrides, and store ordering", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  id: "category-bakery",
+                  name: "Brod",
+                },
+                categoryId: "category-bakery",
+                displayName: "Tortillalefser",
+                id: "ingredient-1",
+                ingredientId: "canonical-tortilla",
+                preferredStore: {
+                  id: "store-1",
+                  name: "Coop Mega",
+                },
+                preferredStoreId: "store-1",
+                sortOrder: 1,
+                unit: "pk",
+              },
+              {
+                amount: "1",
+                category: {
+                  id: "category-produce",
+                  name: "Frukt og gront",
+                },
+                categoryId: "category-produce",
+                displayName: "Paprika",
+                id: "ingredient-2",
+                ingredientId: "canonical-paprika",
+                preferredStore: {
+                  id: "store-1",
+                  name: "Coop Mega",
+                },
+                preferredStoreId: "store-1",
+                sortOrder: 2,
+                unit: "stk",
+              },
+            ],
+            title: "Taco",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  id: "category-bakery",
+                  name: "Brod",
+                },
+                categoryId: "category-bakery",
+                displayName: "Tortillalefser",
+                id: "ingredient-3",
+                ingredientId: "canonical-tortilla",
+                preferredStore: {
+                  id: "store-1",
+                  name: "Coop Mega",
+                },
+                preferredStoreId: "store-1",
+                sortOrder: 1,
+                unit: "pk",
+              },
+              {
+                amount: "1",
+                category: {
+                  id: "category-produce",
+                  name: "Frukt og gront",
+                },
+                categoryId: "category-produce",
+                displayName: "Lime",
+                id: "ingredient-4",
+                ingredientId: "canonical-lime",
+                preferredStore: {
+                  id: "store-2",
+                  name: "Meny",
+                },
+                preferredStoreId: "store-2",
+                sortOrder: 2,
+                unit: "stk",
+              },
+              {
+                amount: "2",
+                category: {
+                  id: "category-produce",
+                  name: "Frukt og gront",
+                },
+                categoryId: "category-produce",
+                displayName: "Tomater",
+                id: "ingredient-5",
+                ingredientId: "canonical-tomato",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 3,
+                unit: "stk",
+              },
+            ],
+            title: "Quesadilla",
+          },
+          recipeId: "recipe-2",
+        },
+      ],
+      id: "meal-plan-1",
+      shoppingOverrides: [
+        {
+          checked: true,
+          note: "Kjop pa tilbud",
+          postponedUntilDate: new Date("2026-05-16T00:00:00.000Z"),
+          preferredStore: {
+            id: "store-2",
+            name: "Meny",
+          },
+          preferredStoreId: "store-2",
+          sourceKey: "entry-1:ingredient-1|entry-2:ingredient-3",
+          sourceType: "GENERATED",
+        },
+      ],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-1",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-2",
+            sortOrder: 2,
+          },
+        ],
+      },
+      {
+        familyId: null,
+        id: "store-2",
+        name: "Meny",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-3",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-4",
+            sortOrder: 2,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyMembershipMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(dbMock.mealPlan.findFirst).toHaveBeenCalledWith({
+      select: expect.objectContaining({
+        endDate: true,
+        entries: expect.objectContaining({
+          orderBy: [{ date: "asc" }, { id: "asc" }],
+          where: {
+            mealType: "DINNER",
+          },
+        }),
+      }),
+      where: {
+        familyId: "family-1",
+        id: "meal-plan-1",
+      },
+    });
+    expect(dbMock.store.findMany).toHaveBeenCalledWith({
+      orderBy: [{ name: "asc" }],
+      select: expect.objectContaining({
+        id: true,
+        name: true,
+        sections: expect.objectContaining({
+          orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+        }),
+      }),
+      where: {
+        OR: [{ familyId: null }, { familyId: "family-1" }],
+      },
+    });
+    expect(result.visibleDates).toEqual(["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"]);
+    expect(result.projectedItems.map((item) => item.name)).toEqual([
+      "Paprika",
+      "Lime",
+      "Tortillalefser",
+      "Tomater",
+    ]);
+
+    const mergedItem = result.projectedItems[2];
+
+    expect(mergedItem).toEqual(
+      expect.objectContaining({
+        checked: true,
+        name: "Tortillalefser",
+        note: "Kjop pa tilbud",
+        occurrenceCount: 2,
+        postponedUntilDate: new Date("2026-05-16T00:00:00.000Z"),
+        preferredStore: {
+          id: "store-2",
+          name: "Meny",
+        },
+        quantityLabel: "1 pk",
+        section: {
+          displayName: "Brod",
+          sortOrder: 2,
+        },
+        sourceKey: "entry-1:ingredient-1|entry-2:ingredient-3",
+        sourceType: "GENERATED",
+      }),
+    );
+    expect(mergedItem.occurrences).toEqual([
+      {
+        date: new Date("2026-05-15T00:00:00.000Z"),
+        mealPlanEntryId: "entry-1",
+        recipeId: "recipe-1",
+        recipeIngredientId: "ingredient-1",
+        recipeTitle: "Taco",
+      },
+      {
+        date: new Date("2026-05-16T00:00:00.000Z"),
+        mealPlanEntryId: "entry-2",
+        recipeId: "recipe-2",
+        recipeIngredientId: "ingredient-3",
+        recipeTitle: "Quesadilla",
+      },
+    ]);
+    expect(result.storeGroups).toHaveLength(3);
+    expect(result.storeGroups.map((group) => group.store?.name ?? "Ingen valgt butikk")).toEqual([
+      "Coop Mega",
+      "Meny",
+      "Ingen valgt butikk",
+    ]);
+    expect(result.storeGroups[1]?.sections.map((section) => section.displayName)).toEqual([
+      "Frukt og gront",
+      "Brod",
+    ]);
+  });
+
+  it("keeps generated items separate when exact-match fields differ", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  id: "category-dairy",
+                  name: "Meieri",
+                },
+                categoryId: "category-dairy",
+                displayName: "Yoghurt",
+                id: "ingredient-1",
+                ingredientId: "canonical-yoghurt",
+                preferredStore: {
+                  id: "store-1",
+                  name: "Coop Mega",
+                },
+                preferredStoreId: "store-1",
+                sortOrder: 1,
+                unit: "beger",
+              },
+            ],
+            title: "Frokostbolle",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "2",
+                category: {
+                  id: "category-dairy",
+                  name: "Meieri",
+                },
+                categoryId: "category-dairy",
+                displayName: "Yoghurt",
+                id: "ingredient-2",
+                ingredientId: "canonical-yoghurt",
+                preferredStore: {
+                  id: "store-1",
+                  name: "Coop Mega",
+                },
+                preferredStoreId: "store-1",
+                sortOrder: 1,
+                unit: "beger",
+              },
+            ],
+            title: "Parfait",
+          },
+          recipeId: "recipe-2",
+        },
+      ],
+      id: "meal-plan-1",
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-dairy",
+            displayName: "Meieri",
+            id: "section-1",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.projectedItems).toHaveLength(2);
+    expect(result.projectedItems.map((item) => item.sourceKey)).toEqual([
+      "entry-1:ingredient-1",
+      "entry-2:ingredient-2",
+    ]);
+    expect(result.projectedItems.map((item) => item.quantityLabel)).toEqual(["1 beger", "2 beger"]);
+  });
+
+  it("throws a not-found response when the meal plan is outside the family scope", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue(null);
+
+    await expect(
+      getMealPlanShoppingData({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-404",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    expect(dbMock.store.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -1,0 +1,576 @@
+import { MealType, Prisma, ShoppingItemSource } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { getMealPlanDateRange } from "./meal-plan.server";
+
+const generatedShoppingRecipeIngredientSelect = Prisma.validator<Prisma.RecipeIngredientSelect>()({
+  amount: true,
+  category: {
+    select: {
+      displayName: true,
+      id: true,
+    },
+  },
+  categoryId: true,
+  displayName: true,
+  id: true,
+  ingredientId: true,
+  preferredStore: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+  preferredStoreId: true,
+  sortOrder: true,
+  unit: true,
+});
+
+const generatedShoppingRecipeSelect = Prisma.validator<Prisma.RecipeSelect>()({
+  id: true,
+  ingredients: {
+    orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+    select: generatedShoppingRecipeIngredientSelect,
+  },
+  title: true,
+});
+
+const generatedShoppingMealPlanEntrySelect = Prisma.validator<Prisma.MealPlanEntrySelect>()({
+  date: true,
+  id: true,
+  mealType: true,
+  recipe: {
+    select: generatedShoppingRecipeSelect,
+  },
+  recipeId: true,
+});
+
+const generatedShoppingOverrideSelect = Prisma.validator<Prisma.ShoppingItemOverrideSelect>()({
+  checked: true,
+  note: true,
+  postponedUntilDate: true,
+  preferredStore: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+  preferredStoreId: true,
+  sourceKey: true,
+  sourceType: true,
+});
+
+const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
+  endDate: true,
+  entries: {
+    orderBy: [{ date: "asc" }, { id: "asc" }],
+    select: generatedShoppingMealPlanEntrySelect,
+    where: {
+      mealType: MealType.DINNER,
+    },
+  },
+  id: true,
+  shoppingOverrides: {
+    orderBy: [{ sourceKey: "asc" }],
+    select: generatedShoppingOverrideSelect,
+    where: {
+      sourceType: ShoppingItemSource.GENERATED,
+    },
+  },
+  startDate: true,
+  status: true,
+  title: true,
+});
+
+const shoppingStoreSelect = Prisma.validator<Prisma.StoreSelect>()({
+  familyId: true,
+  id: true,
+  name: true,
+  sections: {
+    orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+    select: {
+      categoryId: true,
+      displayName: true,
+      id: true,
+      sortOrder: true,
+    },
+  },
+});
+
+type ShoppingMealPlan = Prisma.MealPlanGetPayload<{
+  select: typeof shoppingMealPlanSelect;
+}>;
+type ShoppingStore = Prisma.StoreGetPayload<{
+  select: typeof shoppingStoreSelect;
+}>;
+
+type StoreSummary = {
+  id: string;
+  name: string;
+} | null;
+
+type StoreSectionSummary = {
+  displayName: string;
+  sortOrder: number;
+};
+
+interface GeneratedProjectionBucket {
+  amount: string | null;
+  category: {
+    id: string;
+    name: string;
+  };
+  name: string;
+  occurrences: ProjectedShoppingOccurrence[];
+  occurrenceKeys: string[];
+  preferredStore: StoreSummary;
+  sortAnchor: {
+    date: Date;
+    ingredientSortOrder: number;
+    recipeTitle: string;
+  };
+  unit: string | null;
+}
+
+export interface ProjectedShoppingOccurrence {
+  date: Date;
+  mealPlanEntryId: string;
+  recipeId: string;
+  recipeIngredientId: string;
+  recipeTitle: string;
+}
+
+export interface ProjectedShoppingItem {
+  amount: string | null;
+  category: {
+    id: string;
+    name: string;
+  };
+  checked: boolean;
+  firstDate: Date;
+  lastDate: Date;
+  name: string;
+  note: string | null;
+  occurrenceCount: number;
+  occurrences: ProjectedShoppingOccurrence[];
+  postponedUntilDate: Date | null;
+  preferredStore: StoreSummary;
+  quantityLabel: string | null;
+  section: StoreSectionSummary;
+  sourceKey: string;
+  sourceType: "GENERATED";
+  unit: string | null;
+}
+
+export interface ProjectedShoppingSectionGroup {
+  category: {
+    id: string;
+    name: string;
+  };
+  displayName: string;
+  items: ProjectedShoppingItem[];
+}
+
+export interface ProjectedShoppingStoreGroup {
+  sections: ProjectedShoppingSectionGroup[];
+  store: StoreSummary;
+}
+
+export async function getMealPlanShoppingData({
+  familyId,
+  mealPlanId,
+  userId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: shoppingMealPlanSelect,
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    throw new Response("Fant ikke ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  const stores = await db.store.findMany({
+    orderBy: [{ name: "asc" }],
+    select: shoppingStoreSelect,
+    where: {
+      OR: [{ familyId: null }, { familyId }],
+    },
+  });
+
+  const projectedItems = projectGeneratedShoppingItems({
+    mealPlan,
+    stores,
+  });
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    mealPlan,
+    projectedItems,
+    storeGroups: buildProjectedStoreGroups(projectedItems),
+    userRole: membership.role,
+    visibleDates: getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate),
+  };
+}
+
+function projectGeneratedShoppingItems({
+  mealPlan,
+  stores,
+}: {
+  mealPlan: ShoppingMealPlan;
+  stores: ShoppingStore[];
+}) {
+  const storeSectionsByStoreId = new Map(
+    stores.map((store) => [
+      store.id,
+      new Map(
+        store.sections.map((section) => [
+          section.categoryId,
+          {
+            displayName: section.displayName,
+            sortOrder: section.sortOrder,
+          },
+        ]),
+      ),
+    ]),
+  );
+  const overrideBySourceKey = new Map(
+    mealPlan.shoppingOverrides.map((override) => [override.sourceKey, override]),
+  );
+  const buckets = new Map<string, GeneratedProjectionBucket>();
+
+  for (const entry of mealPlan.entries) {
+    const recipe = entry.recipe;
+
+    if (!recipe) {
+      continue;
+    }
+
+    for (const ingredient of recipe.ingredients) {
+      const occurrence: ProjectedShoppingOccurrence = {
+        date: entry.date,
+        mealPlanEntryId: entry.id,
+        recipeId: recipe.id,
+        recipeIngredientId: ingredient.id,
+        recipeTitle: recipe.title,
+      };
+      const occurrenceKey = buildGeneratedOccurrenceKey({
+        mealPlanEntryId: entry.id,
+        recipeIngredientId: ingredient.id,
+      });
+      const mergeKey = buildGeneratedMergeKey({
+        amount: ingredient.amount,
+        categoryId: ingredient.categoryId,
+        displayName: ingredient.displayName,
+        ingredientId: ingredient.ingredientId,
+        preferredStoreId: ingredient.preferredStoreId,
+        unit: ingredient.unit,
+      });
+      const existingBucket = buckets.get(mergeKey);
+
+      if (existingBucket) {
+        existingBucket.occurrenceKeys.push(occurrenceKey);
+        existingBucket.occurrences.push(occurrence);
+
+        if (compareProjectionAnchors(existingBucket.sortAnchor, {
+          date: entry.date,
+          ingredientSortOrder: ingredient.sortOrder,
+          recipeTitle: recipe.title,
+        }) > 0) {
+          existingBucket.sortAnchor = {
+            date: entry.date,
+            ingredientSortOrder: ingredient.sortOrder,
+            recipeTitle: recipe.title,
+          };
+        }
+
+        continue;
+      }
+
+      buckets.set(mergeKey, {
+        amount: ingredient.amount,
+        category: {
+          name: ingredient.category.displayName,
+          id: ingredient.category.id,
+        },
+        name: ingredient.displayName,
+        occurrences: [occurrence],
+        occurrenceKeys: [occurrenceKey],
+        preferredStore: ingredient.preferredStore,
+        sortAnchor: {
+          date: entry.date,
+          ingredientSortOrder: ingredient.sortOrder,
+          recipeTitle: recipe.title,
+        },
+        unit: ingredient.unit,
+      });
+    }
+  }
+
+  return [...buckets.values()]
+    .map((bucket) => {
+      const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
+      const override = overrideBySourceKey.get(sourceKey);
+      const preferredStore = override?.preferredStore ?? bucket.preferredStore;
+      const section = resolveStoreSection({
+        category: bucket.category,
+        preferredStore,
+        storeSectionsByStoreId,
+      });
+      const occurrences = [...bucket.occurrences].sort(compareProjectedOccurrences);
+
+      return {
+        amount: bucket.amount,
+        category: bucket.category,
+        checked: override?.checked ?? false,
+        firstDate: occurrences[0]!.date,
+        lastDate: occurrences[occurrences.length - 1]!.date,
+        name: bucket.name,
+        note: override?.note ?? null,
+        occurrenceCount: occurrences.length,
+        occurrences,
+        postponedUntilDate: override?.postponedUntilDate ?? null,
+        preferredStore,
+        quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
+        section,
+        sourceKey,
+        sourceType: ShoppingItemSource.GENERATED,
+        unit: bucket.unit,
+      } satisfies ProjectedShoppingItem;
+    })
+    .sort(compareProjectedItems);
+}
+
+function buildProjectedStoreGroups(items: ProjectedShoppingItem[]): ProjectedShoppingStoreGroup[] {
+  const groupMap = new Map<
+    string,
+    {
+      sections: Map<string, ProjectedShoppingSectionGroup>;
+      store: StoreSummary;
+    }
+  >();
+
+  for (const item of items) {
+    const storeKey = item.preferredStore?.id ?? "__no-store__";
+    const existingStoreGroup = groupMap.get(storeKey);
+
+    if (!existingStoreGroup) {
+      groupMap.set(storeKey, {
+        sections: new Map(),
+        store: item.preferredStore,
+      });
+    }
+
+    const storeGroup = groupMap.get(storeKey)!;
+    const sectionKey = `${item.category.id}:${item.section.displayName}`;
+    const existingSection = storeGroup.sections.get(sectionKey);
+
+    if (!existingSection) {
+      storeGroup.sections.set(sectionKey, {
+        category: item.category,
+        displayName: item.section.displayName,
+        items: [item],
+      });
+
+      continue;
+    }
+
+    existingSection.items.push(item);
+  }
+
+  return [...groupMap.values()]
+    .map((group) => {
+      const sections = [...group.sections.values()]
+        .map((section) => ({
+          ...section,
+          items: [...section.items].sort(compareProjectedItems),
+        }))
+        .sort((left, right) => {
+          const leftItem = left.items[0]!;
+          const rightItem = right.items[0]!;
+
+          if (leftItem.section.sortOrder !== rightItem.section.sortOrder) {
+            return leftItem.section.sortOrder - rightItem.section.sortOrder;
+          }
+
+          return left.displayName.localeCompare(right.displayName, "nb");
+        });
+
+      return {
+        sections,
+        store: group.store,
+      };
+    })
+    .sort((left, right) => compareStoreSummaries(left.store, right.store));
+}
+
+function buildGeneratedOccurrenceKey({
+  mealPlanEntryId,
+  recipeIngredientId,
+}: {
+  mealPlanEntryId: string;
+  recipeIngredientId: string;
+}) {
+  return `${mealPlanEntryId}:${recipeIngredientId}`;
+}
+
+function buildMergedGeneratedSourceKey(occurrenceKeys: string[]) {
+  return occurrenceKeys.slice().sort().join("|");
+}
+
+function buildGeneratedMergeKey({
+  amount,
+  categoryId,
+  displayName,
+  ingredientId,
+  preferredStoreId,
+  unit,
+}: {
+  amount: string | null;
+  categoryId: string;
+  displayName: string;
+  ingredientId: string | null;
+  preferredStoreId: string | null;
+  unit: string | null;
+}) {
+  return JSON.stringify({
+    amount: amount ?? null,
+    categoryId,
+    displayName: ingredientId ? null : displayName,
+    ingredientId,
+    preferredStoreId: preferredStoreId ?? null,
+    unit: unit ?? null,
+  });
+}
+
+function resolveStoreSection({
+  category,
+  preferredStore,
+  storeSectionsByStoreId,
+}: {
+  category: {
+    id: string;
+    name: string;
+  };
+  preferredStore: StoreSummary;
+  storeSectionsByStoreId: Map<string, Map<string, StoreSectionSummary>>;
+}) {
+  if (!preferredStore) {
+    return {
+      displayName: category.name,
+      sortOrder: Number.MAX_SAFE_INTEGER,
+    };
+  }
+
+  const storeSections = storeSectionsByStoreId.get(preferredStore.id);
+  const section = storeSections?.get(category.id);
+
+  if (!section) {
+    return {
+      displayName: category.name,
+      sortOrder: Number.MAX_SAFE_INTEGER,
+    };
+  }
+
+  return section;
+}
+
+function buildQuantityLabel(amount: string | null, unit: string | null) {
+  const parts = [amount, unit].filter((value) => value && value.trim().length > 0);
+
+  return parts.length ? parts.join(" ") : null;
+}
+
+function compareProjectedOccurrences(left: ProjectedShoppingOccurrence, right: ProjectedShoppingOccurrence) {
+  if (left.date.getTime() !== right.date.getTime()) {
+    return left.date.getTime() - right.date.getTime();
+  }
+
+  const recipeTitleComparison = left.recipeTitle.localeCompare(right.recipeTitle, "nb");
+
+  if (recipeTitleComparison !== 0) {
+    return recipeTitleComparison;
+  }
+
+  return left.recipeIngredientId.localeCompare(right.recipeIngredientId, "nb");
+}
+
+function compareProjectionAnchors(
+  left: { date: Date; ingredientSortOrder: number; recipeTitle: string },
+  right: { date: Date; ingredientSortOrder: number; recipeTitle: string },
+) {
+  if (left.date.getTime() !== right.date.getTime()) {
+    return left.date.getTime() - right.date.getTime();
+  }
+
+  if (left.ingredientSortOrder !== right.ingredientSortOrder) {
+    return left.ingredientSortOrder - right.ingredientSortOrder;
+  }
+
+  return left.recipeTitle.localeCompare(right.recipeTitle, "nb");
+}
+
+function compareStoreSummaries(left: StoreSummary, right: StoreSummary) {
+  if (!left && !right) {
+    return 0;
+  }
+
+  if (!left) {
+    return 1;
+  }
+
+  if (!right) {
+    return -1;
+  }
+
+  return left.name.localeCompare(right.name, "nb");
+}
+
+function compareProjectedItems(left: ProjectedShoppingItem, right: ProjectedShoppingItem) {
+  const storeComparison = compareStoreSummaries(left.preferredStore, right.preferredStore);
+
+  if (storeComparison !== 0) {
+    return storeComparison;
+  }
+
+  if (left.section.sortOrder !== right.section.sortOrder) {
+    return left.section.sortOrder - right.section.sortOrder;
+  }
+
+  const sectionComparison = left.section.displayName.localeCompare(right.section.displayName, "nb");
+
+  if (sectionComparison !== 0) {
+    return sectionComparison;
+  }
+
+  if (left.firstDate.getTime() !== right.firstDate.getTime()) {
+    return left.firstDate.getTime() - right.firstDate.getTime();
+  }
+
+  const nameComparison = left.name.localeCompare(right.name, "nb");
+
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  return left.sourceKey.localeCompare(right.sourceKey, "nb");
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -6,6 +6,7 @@ export default [
   route("families/:familyId", "routes/family.tsx"),
   route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
   route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
+  route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
   route("login", "routes/login.tsx"),
   route("logout", "routes/logout.tsx"),
   route("prototype", "routes/prototype.tsx"),

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>("../lib/auth.server");
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping.server", () => {
+  return {
+    getMealPlanShoppingData: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanShoppingData } from "../lib/shopping.server";
+import { loader } from "./family-meal-plan-shopping";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(url = "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping") {
+  return new Request(url);
+}
+
+describe("family meal plan shopping route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads and serializes the server-projected shopping list", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanShoppingData).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlan: {
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        entries: [],
+        id: "meal-plan-1",
+        shoppingOverrides: [],
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Langhelg",
+      },
+      projectedItems: [
+        {
+          amount: "1",
+          category: {
+            id: "category-produce",
+            name: "Frukt og gront",
+          },
+          checked: false,
+          firstDate: new Date("2026-05-15T00:00:00.000Z"),
+          lastDate: new Date("2026-05-16T00:00:00.000Z"),
+          name: "Lime",
+          note: null,
+          occurrenceCount: 1,
+          occurrences: [
+            {
+              date: new Date("2026-05-15T00:00:00.000Z"),
+              mealPlanEntryId: "entry-1",
+              recipeId: "recipe-1",
+              recipeIngredientId: "ingredient-1",
+              recipeTitle: "Taco",
+            },
+          ],
+          postponedUntilDate: null,
+          preferredStore: {
+            id: "store-1",
+            name: "Meny",
+          },
+          quantityLabel: "1 stk",
+          section: {
+            displayName: "Frukt og gront",
+            sortOrder: 1,
+          },
+          sourceKey: "entry-1:ingredient-1",
+          sourceType: "GENERATED",
+          unit: "stk",
+        },
+      ],
+      storeGroups: [
+        {
+          sections: [
+            {
+              category: {
+                id: "category-produce",
+                name: "Frukt og gront",
+              },
+              displayName: "Frukt og gront",
+              items: [
+                {
+                  amount: "1",
+                  category: {
+                    id: "category-produce",
+                    name: "Frukt og gront",
+                  },
+                  checked: false,
+                  firstDate: new Date("2026-05-15T00:00:00.000Z"),
+                  lastDate: new Date("2026-05-16T00:00:00.000Z"),
+                  name: "Lime",
+                  note: null,
+                  occurrenceCount: 1,
+                  occurrences: [
+                    {
+                      date: new Date("2026-05-15T00:00:00.000Z"),
+                      mealPlanEntryId: "entry-1",
+                      recipeId: "recipe-1",
+                      recipeIngredientId: "ingredient-1",
+                      recipeTitle: "Taco",
+                    },
+                  ],
+                  postponedUntilDate: null,
+                  preferredStore: {
+                    id: "store-1",
+                    name: "Meny",
+                  },
+                  quantityLabel: "1 stk",
+                  section: {
+                    displayName: "Frukt og gront",
+                    sortOrder: 1,
+                  },
+                  sourceKey: "entry-1:ingredient-1",
+                  sourceType: "GENERATED",
+                  unit: "stk",
+                },
+              ],
+            },
+          ],
+          store: {
+            id: "store-1",
+            name: "Meny",
+          },
+        },
+      ],
+      userRole: "ADMIN",
+      visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(getMealPlanShoppingData).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      mealPlan: {
+        endDate: "2026-05-18",
+        entries: undefined,
+        id: "meal-plan-1",
+        shoppingOverrides: undefined,
+        startDate: "2026-05-15",
+        status: "DRAFT",
+        title: "Langhelg",
+      },
+      projectedItemCount: 1,
+      storeGroups: [
+        {
+          sections: [
+            {
+              category: {
+                id: "category-produce",
+                name: "Frukt og gront",
+              },
+              displayName: "Frukt og gront",
+              items: [
+                {
+                  amount: "1",
+                  category: {
+                    id: "category-produce",
+                    name: "Frukt og gront",
+                  },
+                  checked: false,
+                  firstDate: "2026-05-15",
+                  lastDate: "2026-05-16",
+                  name: "Lime",
+                  note: null,
+                  occurrenceCount: 1,
+                  occurrences: [
+                    {
+                      date: "2026-05-15",
+                      mealPlanEntryId: "entry-1",
+                      recipeId: "recipe-1",
+                      recipeIngredientId: "ingredient-1",
+                      recipeTitle: "Taco",
+                    },
+                  ],
+                  postponedUntilDate: null,
+                  preferredStore: {
+                    id: "store-1",
+                    name: "Meny",
+                  },
+                  quantityLabel: "1 stk",
+                  section: {
+                    displayName: "Frukt og gront",
+                    sortOrder: 1,
+                  },
+                  sourceKey: "entry-1:ingredient-1",
+                  sourceType: "GENERATED",
+                  unit: "stk",
+                },
+              ],
+            },
+          ],
+          store: {
+            id: "store-1",
+            name: "Meny",
+          },
+        },
+      ],
+      userRole: "ADMIN",
+      visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
+    });
+  });
+});

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1,0 +1,293 @@
+import { Link, isRouteErrorResponse, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanShoppingData } from "../lib/shopping.server";
+
+interface FamilyMealPlanShoppingRouteProps {
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Handleliste | Mealplanner" },
+    { name: "description", content: "Servergenerert handleliste for valgt familieukeplan." },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const result = await getMealPlanShoppingData({
+    familyId,
+    mealPlanId,
+    userId: user.id,
+  });
+
+  return {
+    family: result.family,
+    mealPlan: {
+      ...result.mealPlan,
+      endDate: formatDateOnly(result.mealPlan.endDate),
+      entries: undefined,
+      shoppingOverrides: undefined,
+      startDate: formatDateOnly(result.mealPlan.startDate),
+    },
+    projectedItemCount: result.projectedItems.length,
+    storeGroups: result.storeGroups.map((group) => ({
+      sections: group.sections.map((section) => ({
+        ...section,
+        items: section.items.map((item) => ({
+          ...item,
+          firstDate: formatDateOnly(item.firstDate),
+          lastDate: formatDateOnly(item.lastDate),
+          occurrences: item.occurrences.map((occurrence) => ({
+            ...occurrence,
+            date: formatDateOnly(occurrence.date),
+          })),
+          postponedUntilDate: item.postponedUntilDate ? formatDateOnly(item.postponedUntilDate) : null,
+        })),
+      })),
+      store: group.store,
+    })),
+    userRole: result.userRole,
+    visibleDates: result.visibleDates,
+  };
+}
+
+export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPlanShoppingRouteProps) {
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Handleliste
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.mealPlan.title}</h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Dette er en servergenerert projeksjon av ingrediensene fra planlagte middager i den aktive
+                perioden. Listen er deterministisk og viser hvilke oppskrifter hvert punkt kommer fra.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}`}
+              >
+                Tilbake til ukeplan
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Alle ukeplaner
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Projeksjon</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Listen dekker perioden {formatMealPlanWindow(loaderData.mealPlan.startDate, loaderData.mealPlan.endDate)}
+                {" "}og inneholder {loaderData.projectedItemCount} genererte varelinjer.
+              </p>
+            </div>
+
+            <dl className="mt-6 grid gap-4">
+              <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Status</dt>
+                <dd className="mt-2 text-base font-semibold text-slate-950">
+                  {loaderData.mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+                </dd>
+              </div>
+
+              <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Synlige datoer</dt>
+                <dd className="mt-2 text-sm leading-6 text-slate-700">
+                  {loaderData.visibleDates.map(formatDateLabel).join(", ")}
+                </dd>
+              </div>
+            </dl>
+          </article>
+
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Hvordan dette bygges</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Hvert punkt er laget fra lagrede oppskriftsingredienser pa serveren. Like ingredienser blir
+                bare slaatt sammen nar navn, mengde, enhet, kategori og foretrukket butikk matcher eksakt.
+              </p>
+            </div>
+          </article>
+        </section>
+
+        {loaderData.storeGroups.length ? (
+          <section className="grid gap-6">
+            {loaderData.storeGroups.map((group) => (
+              <article
+                key={group.store?.id ?? "no-store"}
+                className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200"
+              >
+                <div className="flex flex-col gap-2">
+                  <h2 className="text-lg font-semibold text-slate-950">
+                    {group.store?.name ?? "Ingen valgt butikk"}
+                  </h2>
+                  <p className="text-sm leading-6 text-slate-600">
+                    {group.store
+                      ? "Varene er sortert etter butikkens seksjoner der de finnes."
+                      : "Disse varene har ingen foretrukket butikk ennå."}
+                  </p>
+                </div>
+
+                <div className="mt-6 grid gap-5">
+                  {group.sections.map((section) => (
+                    <section key={`${group.store?.id ?? "no-store"}:${section.category.id}`}>
+                      <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        {section.displayName}
+                      </h3>
+
+                      <div className="mt-3 grid gap-3">
+                        {section.items.map((item) => (
+                          <article
+                            key={item.sourceKey}
+                            className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                          >
+                            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                              <div>
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <h4 className="text-base font-semibold text-slate-950">{item.name}</h4>
+                                  {item.quantityLabel ? (
+                                    <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                                      {item.quantityLabel}
+                                    </span>
+                                  ) : null}
+                                  {item.checked ? (
+                                    <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
+                                      Avkrysset
+                                    </span>
+                                  ) : null}
+                                  {item.postponedUntilDate ? (
+                                    <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+                                      Utsatt til {formatDateLabel(item.postponedUntilDate)}
+                                    </span>
+                                  ) : null}
+                                </div>
+
+                                <p className="mt-3 text-sm leading-6 text-slate-600">
+                                  Fra {item.occurrenceCount} planlagte {item.occurrenceCount === 1 ? "middag" : "middager"}
+                                  {" "}mellom {formatDateLabel(item.firstDate)} og {formatDateLabel(item.lastDate)}.
+                                </p>
+                                {item.note ? (
+                                  <p className="mt-2 text-sm leading-6 text-slate-700">Notat: {item.note}</p>
+                                ) : null}
+                              </div>
+
+                              <div className="rounded-[20px] bg-white p-4 ring-1 ring-slate-200 md:max-w-sm">
+                                <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                                  Kilder
+                                </p>
+                                <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
+                                  {item.occurrences.map((occurrence) => (
+                                    <li key={`${occurrence.mealPlanEntryId}:${occurrence.recipeIngredientId}`}>
+                                      {formatDateLabel(occurrence.date)}: {occurrence.recipeTitle}
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                            </div>
+                          </article>
+                        ))}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </section>
+        ) : (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">Ingen varer ennå</h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+              Legg til middager i ukeplanen for a generere handlelisten pa serveren.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let description = "Vi klarte ikke a laste handlelisten.";
+
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 403) {
+      title = "Ingen tilgang";
+      description = "Du har ikke tilgang til denne familiehandlelisten.";
+    } else if (error.status === 404) {
+      title = "Handlelisten finnes ikke";
+      description = "Vi fant ikke ukeplanen du forsokte a hente handlelisten for.";
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto max-w-3xl rounded-[28px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+          to="/app"
+        >
+          Tilbake til oversikten
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}
+
+function formatDateOnly(date: Date) {
+  return [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+  ].join("-");
+}
+
+function formatDateLabel(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+  }).format(new Date(`${value}T00:00:00.000Z`));
+}
+
+function formatMealPlanWindow(startDate: string, endDate: string) {
+  return `${formatDateLabel(startDate)} til ${formatDateLabel(endDate)}`;
+}

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -280,6 +280,12 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
 
             <div className="flex flex-wrap gap-3">
               <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
+              >
+                Apne handleliste
+              </Link>
+              <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to={`/families/${loaderData.family.id}/meal-plans`}
               >


### PR DESCRIPTION
## Summary
- add a dedicated server-side shopping projection service that derives generated items from meal-plan recipes
- expose the first read-only shopping route for a meal plan and link to it from the meal-plan detail page
- cover deterministic merge, override, ordering, and loader serialization behavior with focused tests

## Test plan
- [x] `npm run test:run -- app/lib/shopping.server.test.ts app/routes/family-meal-plan-shopping.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`

Closes #11