### PR TITLE
Add manual shopping items and persisted override state

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,33 +2,34 @@
 
 ## Current Objective
 
-Implement issue `#11`'s deterministic shopping projection so generated shopping items come from persisted meal-plan recipes on the server with exact-match merging and focused coverage.
+Implement issue `#12`'s persisted shopping interactions so meal-plan shopping lists can mix deterministic generated items with manual rows and saved user state.
 
 ## Completed
 
-- Added `app/lib/shopping.server.ts` with a dedicated meal-plan-scoped shopping projection query, deterministic generated-item source keys, exact-match merge behavior, override application, and store/section ordering.
-- Added the first production shopping route in `app/routes/family-meal-plan-shopping.tsx` and registered it in `app/routes.ts` so families can open a read-only server-generated shopping view from a meal plan.
-- Expanded focused coverage in `app/lib/shopping.server.test.ts` and `app/routes/family-meal-plan-shopping.test.ts` for projection, merge boundaries, override application, ordering, scoping, and loader serialization.
-- Updated `app/routes/family-meal-plan.tsx` with a direct link to the new shopping view.
+- Expanded `app/lib/shopping.server.ts` so the shopping read model now loads manual shopping items, all shopping overrides, available categories/stores, merged item counts, and a discriminated generated/manual projection grouped by store and section.
+- Added `app/lib/shopping-write.server.ts` with validated manual item create/update/delete flows, generated override updates, checked-state persistence, and transactional cleanup of manual override rows.
+- Reworked `app/routes/family-meal-plan-shopping.tsx` from a loader-only page into a multi-intent shopping route with add/edit/delete forms for manual rows, generated-item override controls, checked toggles, notices, and serialized loader data for both item types.
+- Expanded focused coverage in `app/lib/shopping.server.test.ts`, `app/lib/shopping-write.server.test.ts`, and `app/routes/family-meal-plan-shopping.test.ts` for merged projection, write-path validation, override behavior, cleanup, redirects, and route action payloads.
 
 ## Files To Read First
 
-- `app/lib/shopping.server.ts` - Core server-side shopping projection, merge logic, override application, and store grouping.
-- `app/routes/family-meal-plan-shopping.tsx` - Read-only shopping projection loader and UI for one meal plan.
-- `app/lib/shopping.server.test.ts` - Service-level coverage for deterministic source keys, exact-match merging, overrides, and ordering.
-- `app/routes/family-meal-plan.tsx` - Meal-plan detail page entry point linking into the shopping route.
+- `app/lib/shopping.server.ts` - Combined generated/manual shopping read model, grouping, counts, and projected item types.
+- `app/lib/shopping-write.server.ts` - Validated shopping mutations for manual rows and generated/manual persisted state.
+- `app/routes/family-meal-plan-shopping.tsx` - Loader/action route, notice flow, and all shopping forms and controls.
+- `app/lib/shopping-write.server.test.ts` - Focused write-path coverage for validation, cleanup, and override persistence rules.
 
 ## Validation
 
-- `npm run test:run -- app/lib/shopping.server.test.ts app/routes/family-meal-plan-shopping.test.ts`
+- `npm run test:run -- app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-meal-plan-shopping.test.ts`
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
 - No manual browser smoke test has been run yet for `families/:familyId/meal-plans/:mealPlanId/shopping`.
-- The new production shopping flow is generated-item only; manual shopping items, override mutation actions, checked-state editing, postponement editing, and store-mode UX are still future work.
-- Generated source keys are stable for the same merged occurrence set, but a merge bucket changing because entries were added or removed will naturally produce a new key and reset any existing override for that generated row.
+- Generated source keys are still only stable for the same merged occurrence set, so recipe or meal-plan changes that alter a merge bucket will naturally stop matching any existing generated override row for that bucket.
+- Generated override writes currently trust the posted `sourceKey`; the UI only submits live keys, but there is no extra server-side verification that a generated key still exists in the current projection before persisting an override.
+- The route now supports full-page form submissions only; there is still no fetcher-based or mobile store-mode shopping UX.
 
 ## Next Step
 
-Run a manual end-to-end check of the new shopping route from an existing meal plan, then decide whether the next issue should add persisted manual items or override mutation actions first.
+Run a manual end-to-end smoke test of the shopping route with both generated and manual rows, especially add/edit/delete, checked toggles, and generated override persistence across a refresh.

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -1,0 +1,280 @@
+import { ShoppingItemSource } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock, transactionMock } = vi.hoisted(() => {
+  const transactionMock = {
+    manualShoppingItem: {
+      delete: vi.fn(),
+    },
+    shoppingItemOverride: {
+      deleteMany: vi.fn(),
+    },
+  };
+
+  return {
+    dbMock: {
+      $transaction: vi.fn(),
+      ingredientCategory: {
+        findUnique: vi.fn(),
+      },
+      manualShoppingItem: {
+        create: vi.fn(),
+        findFirst: vi.fn(),
+        update: vi.fn(),
+      },
+      mealPlan: {
+        findFirst: vi.fn(),
+      },
+      shoppingItemOverride: {
+        delete: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+        upsert: vi.fn(),
+      },
+      store: {
+        findFirst: vi.fn(),
+      },
+    },
+    requireFamilyMembershipMock: vi.fn(),
+    transactionMock,
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+vi.mock("./family.server", () => {
+  return {
+    requireFamilyMembership: requireFamilyMembershipMock,
+  };
+});
+
+import {
+  createManualShoppingItem,
+  deleteManualShoppingItem,
+  toggleShoppingItemChecked,
+  updateGeneratedShoppingItemOverride,
+} from "./shopping-write.server";
+
+const mockMealPlan = {
+  endDate: new Date("2026-05-18T00:00:00.000Z"),
+  id: "meal-plan-1",
+  startDate: new Date("2026-05-15T00:00:00.000Z"),
+};
+
+describe("shopping-write.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue({
+      familyId: "family-1",
+      id: "membership-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+    dbMock.mealPlan.findFirst.mockResolvedValue(mockMealPlan);
+    dbMock.$transaction.mockImplementation(async (callback: (tx: typeof transactionMock) => unknown) =>
+      callback(transactionMock),
+    );
+  });
+
+  it("returns manual item validation errors before writing", async () => {
+    const result = await createManualShoppingItem({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+      values: {
+        buyOnDate: "2026-05-25",
+        categoryId: "",
+        name: "   ",
+        note: "",
+        preferredStoreId: "",
+        quantity: "",
+      },
+    });
+
+    expect(result).toEqual({
+      fieldErrors: {
+        buyOnDate: "Datoen ma ligge innenfor ukeplanens aktive periode.",
+        categoryId: "Velg en kategori.",
+        name: "Skriv inn et varenavn.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        buyOnDate: "2026-05-25",
+        categoryId: "",
+        name: "",
+        note: "",
+        preferredStoreId: "",
+        quantity: "",
+      },
+    });
+    expect(dbMock.ingredientCategory.findUnique).not.toHaveBeenCalled();
+    expect(dbMock.manualShoppingItem.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a scoped manual shopping item with trimmed values", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-produce",
+    });
+    dbMock.store.findFirst.mockResolvedValue({
+      id: "store-1",
+    });
+
+    const result = await createManualShoppingItem({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+      values: {
+        buyOnDate: "2026-05-16",
+        categoryId: "category-produce",
+        name: "  Bananer  ",
+        note: "  Til smoothien  ",
+        preferredStoreId: "store-1",
+        quantity: "  6 stk  ",
+      },
+    });
+
+    expect(result).toEqual({
+      status: "CREATED",
+    });
+    expect(dbMock.manualShoppingItem.create).toHaveBeenCalledWith({
+      data: {
+        buyOnDate: new Date("2026-05-16T00:00:00.000Z"),
+        categoryId: "category-produce",
+        mealPlanId: "meal-plan-1",
+        name: "Bananer",
+        note: "Til smoothien",
+        preferredStoreId: "store-1",
+        quantity: "6 stk",
+      },
+    });
+  });
+
+  it("deletes a manual shopping item together with any manual override rows", async () => {
+    dbMock.manualShoppingItem.findFirst.mockResolvedValue({
+      id: "manual-item-1",
+    });
+
+    const result = await deleteManualShoppingItem({
+      familyId: "family-1",
+      manualItemId: "manual-item-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "DELETED",
+    });
+    expect(dbMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(transactionMock.shoppingItemOverride.deleteMany).toHaveBeenCalledWith({
+      where: {
+        mealPlanId: "meal-plan-1",
+        sourceKey: "manual-item-1",
+        sourceType: ShoppingItemSource.MANUAL,
+      },
+    });
+    expect(transactionMock.manualShoppingItem.delete).toHaveBeenCalledWith({
+      where: {
+        id: "manual-item-1",
+      },
+    });
+  });
+
+  it("removes manual checked overrides when unchecking a manual row", async () => {
+    dbMock.manualShoppingItem.findFirst.mockResolvedValue({
+      id: "manual-item-1",
+    });
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue({
+      checked: true,
+      createdAt: new Date("2026-05-15T00:00:00.000Z"),
+      id: "override-1",
+      mealPlanId: "meal-plan-1",
+      note: null,
+      postponedUntilDate: null,
+      preferredStoreId: null,
+      sourceKey: "manual-item-1",
+      sourceType: ShoppingItemSource.MANUAL,
+      updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+    });
+
+    const result = await toggleShoppingItemChecked({
+      checked: false,
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "manual-item-1",
+      sourceType: ShoppingItemSource.MANUAL,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.shoppingItemOverride.delete).toHaveBeenCalledWith({
+      where: {
+        id: "override-1",
+      },
+    });
+    expect(dbMock.shoppingItemOverride.update).not.toHaveBeenCalled();
+  });
+
+  it("upserts generated override fields while preserving checked state", async () => {
+    dbMock.store.findFirst.mockResolvedValue({
+      id: "store-2",
+    });
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue({
+      checked: true,
+      createdAt: new Date("2026-05-15T00:00:00.000Z"),
+      id: "override-1",
+      mealPlanId: "meal-plan-1",
+      note: null,
+      postponedUntilDate: null,
+      preferredStoreId: null,
+      sourceKey: "entry-1:ingredient-1",
+      sourceType: ShoppingItemSource.GENERATED,
+      updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+    });
+
+    const result = await updateGeneratedShoppingItemOverride({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+      values: {
+        note: "  Husk tilbud  ",
+        postponedUntilDate: "2026-05-17",
+        preferredStoreId: "store-2",
+      },
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.shoppingItemOverride.upsert).toHaveBeenCalledWith({
+      create: {
+        checked: true,
+        mealPlanId: "meal-plan-1",
+        note: "Husk tilbud",
+        postponedUntilDate: new Date("2026-05-17T00:00:00.000Z"),
+        preferredStoreId: "store-2",
+        sourceKey: "entry-1:ingredient-1",
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+      update: {
+        checked: true,
+        note: "Husk tilbud",
+        postponedUntilDate: new Date("2026-05-17T00:00:00.000Z"),
+        preferredStoreId: "store-2",
+      },
+      where: {
+        mealPlanId_sourceType_sourceKey: {
+          mealPlanId: "meal-plan-1",
+          sourceKey: "entry-1:ingredient-1",
+          sourceType: ShoppingItemSource.GENERATED,
+        },
+      },
+    });
+  });
+});

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -1,0 +1,701 @@
+import { ShoppingItemSource } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+
+export interface ManualShoppingItemValues {
+  buyOnDate: string;
+  categoryId: string;
+  name: string;
+  note: string;
+  preferredStoreId: string;
+  quantity: string;
+}
+
+export interface ManualShoppingItemFieldErrors {
+  buyOnDate?: string;
+  categoryId?: string;
+  name?: string;
+  preferredStoreId?: string;
+}
+
+export interface GeneratedShoppingItemOverrideValues {
+  note: string;
+  postponedUntilDate: string;
+  preferredStoreId: string;
+}
+
+export interface GeneratedShoppingItemOverrideFieldErrors {
+  postponedUntilDate?: string;
+  preferredStoreId?: string;
+}
+
+export async function createManualShoppingItem({
+  familyId,
+  mealPlanId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  userId: string;
+  values: ManualShoppingItemValues;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const validation = await validateManualShoppingItemValues({
+    familyId,
+    mealPlan,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  await db.manualShoppingItem.create({
+    data: {
+      buyOnDate: validation.buyOnDate,
+      categoryId: validation.values.categoryId,
+      mealPlanId: mealPlan.id,
+      name: validation.values.name,
+      note: validation.values.note || null,
+      preferredStoreId: validation.preferredStoreId,
+      quantity: validation.values.quantity || null,
+    },
+  });
+
+  return {
+    status: "CREATED" as const,
+  };
+}
+
+export async function updateManualShoppingItem({
+  familyId,
+  manualItemId,
+  mealPlanId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  manualItemId: string;
+  mealPlanId: string;
+  userId: string;
+  values: ManualShoppingItemValues;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const existingItem = await db.manualShoppingItem.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      id: manualItemId,
+      mealPlanId: mealPlan.id,
+    },
+  });
+
+  if (!existingItem) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const validation = await validateManualShoppingItemValues({
+    familyId,
+    mealPlan,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  await db.manualShoppingItem.update({
+    data: {
+      buyOnDate: validation.buyOnDate,
+      categoryId: validation.values.categoryId,
+      name: validation.values.name,
+      note: validation.values.note || null,
+      preferredStoreId: validation.preferredStoreId,
+      quantity: validation.values.quantity || null,
+    },
+    where: {
+      id: existingItem.id,
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+export async function deleteManualShoppingItem({
+  familyId,
+  manualItemId,
+  mealPlanId,
+  userId,
+}: {
+  familyId: string;
+  manualItemId: string;
+  mealPlanId: string;
+  userId: string;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const existingItem = await db.manualShoppingItem.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      id: manualItemId,
+      mealPlanId: mealPlan.id,
+    },
+  });
+
+  if (!existingItem) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  await db.$transaction(async (tx) => {
+    await tx.shoppingItemOverride.deleteMany({
+      where: {
+        mealPlanId: mealPlan.id,
+        sourceKey: existingItem.id,
+        sourceType: ShoppingItemSource.MANUAL,
+      },
+    });
+    await tx.manualShoppingItem.delete({
+      where: {
+        id: existingItem.id,
+      },
+    });
+  });
+
+  return {
+    status: "DELETED" as const,
+  };
+}
+
+export async function toggleShoppingItemChecked({
+  checked,
+  familyId,
+  mealPlanId,
+  sourceKey,
+  sourceType,
+  userId,
+}: {
+  checked: boolean;
+  familyId: string;
+  mealPlanId: string;
+  sourceKey: string;
+  sourceType: ShoppingItemSource;
+  userId: string;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (sourceType === ShoppingItemSource.MANUAL) {
+    const existingItem = await db.manualShoppingItem.findFirst({
+      select: {
+        id: true,
+      },
+      where: {
+        id: sourceKey,
+        mealPlanId: mealPlan.id,
+      },
+    });
+
+    if (!existingItem) {
+      return {
+        status: "NOT_FOUND" as const,
+      };
+    }
+  }
+
+  const existingOverride = await db.shoppingItemOverride.findUnique({
+    where: {
+      mealPlanId_sourceType_sourceKey: {
+        mealPlanId: mealPlan.id,
+        sourceKey,
+        sourceType,
+      },
+    },
+  });
+
+  if (!checked) {
+    if (!existingOverride) {
+      return {
+        status: "UPDATED" as const,
+      };
+    }
+
+    if (shouldDeleteOverrideAfterUnchecked(existingOverride)) {
+      await db.shoppingItemOverride.delete({
+        where: {
+          id: existingOverride.id,
+        },
+      });
+    } else {
+      await db.shoppingItemOverride.update({
+        data: {
+          checked: false,
+        },
+        where: {
+          id: existingOverride.id,
+        },
+      });
+    }
+
+    return {
+      status: "UPDATED" as const,
+    };
+  }
+
+  await db.shoppingItemOverride.upsert({
+    create: {
+      checked: true,
+      mealPlanId: mealPlan.id,
+      sourceKey,
+      sourceType,
+    },
+    update: {
+      checked: true,
+    },
+    where: {
+      mealPlanId_sourceType_sourceKey: {
+        mealPlanId: mealPlan.id,
+        sourceKey,
+        sourceType,
+      },
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+export async function updateGeneratedShoppingItemOverride({
+  familyId,
+  mealPlanId,
+  sourceKey,
+  userId,
+  values,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  sourceKey: string;
+  userId: string;
+  values: GeneratedShoppingItemOverrideValues;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const validation = await validateGeneratedShoppingItemOverrideValues({
+    familyId,
+    mealPlan,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  const existingOverride = await db.shoppingItemOverride.findUnique({
+    where: {
+      mealPlanId_sourceType_sourceKey: {
+        mealPlanId: mealPlan.id,
+        sourceKey,
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+    },
+  });
+  const nextData: {
+    checked: boolean;
+    note: string | null;
+    postponedUntilDate: Date | null;
+    preferredStoreId: string | null;
+  } = {
+    checked: existingOverride?.checked ?? false,
+    note: validation.values.note || null,
+    postponedUntilDate: validation.postponedUntilDate ?? null,
+    preferredStoreId: validation.preferredStoreId,
+  };
+
+  if (isOverrideEmpty(nextData)) {
+    if (existingOverride) {
+      await db.shoppingItemOverride.delete({
+        where: {
+          id: existingOverride.id,
+        },
+      });
+    }
+
+    return {
+      status: "UPDATED" as const,
+    };
+  }
+
+  await db.shoppingItemOverride.upsert({
+    create: {
+      ...nextData,
+      mealPlanId: mealPlan.id,
+      sourceKey,
+      sourceType: ShoppingItemSource.GENERATED,
+    },
+    update: nextData,
+    where: {
+      mealPlanId_sourceType_sourceKey: {
+        mealPlanId: mealPlan.id,
+        sourceKey,
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+async function getScopedMealPlan({
+  familyId,
+  mealPlanId,
+  userId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  return db.mealPlan.findFirst({
+    select: {
+      endDate: true,
+      id: true,
+      startDate: true,
+    },
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+}
+
+async function validateManualShoppingItemValues({
+  familyId,
+  mealPlan,
+  values,
+}: {
+  familyId: string;
+  mealPlan: {
+    endDate: Date;
+    id: string;
+    startDate: Date;
+  };
+  values: ManualShoppingItemValues;
+}) {
+  const normalizedValues = normalizeManualShoppingItemValues(values);
+  const fieldErrors: ManualShoppingItemFieldErrors = {};
+
+  if (!normalizedValues.name) {
+    fieldErrors.name = "Skriv inn et varenavn.";
+  }
+
+  if (!normalizedValues.categoryId) {
+    fieldErrors.categoryId = "Velg en kategori.";
+  }
+
+  const buyOnDateValidation = validateOptionalDateInRange(
+    normalizedValues.buyOnDate,
+    mealPlan.startDate,
+    mealPlan.endDate,
+    "Velg en gyldig handledato.",
+  );
+
+  if (!buyOnDateValidation.ok) {
+    fieldErrors.buyOnDate = buyOnDateValidation.fieldError;
+  }
+
+  if (fieldErrors.name || fieldErrors.categoryId || fieldErrors.buyOnDate) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  const [matchingCategory, matchingStore] = await Promise.all([
+    db.ingredientCategory.findUnique({
+      select: {
+        id: true,
+      },
+      where: {
+        id: normalizedValues.categoryId,
+      },
+    }),
+    resolveScopedStoreId(normalizedValues.preferredStoreId, familyId),
+  ]);
+
+  if (!matchingCategory) {
+    fieldErrors.categoryId = "Velg en gyldig kategori.";
+  }
+
+  if (normalizedValues.preferredStoreId && !matchingStore) {
+    fieldErrors.preferredStoreId = "Velg en gyldig butikk for familien.";
+  }
+
+  if (fieldErrors.categoryId || fieldErrors.preferredStoreId) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  return {
+    buyOnDate: buyOnDateValidation.date,
+    ok: true as const,
+    preferredStoreId: matchingStore,
+    values: normalizedValues,
+  };
+}
+
+async function validateGeneratedShoppingItemOverrideValues({
+  familyId,
+  mealPlan,
+  values,
+}: {
+  familyId: string;
+  mealPlan: {
+    endDate: Date;
+    id: string;
+    startDate: Date;
+  };
+  values: GeneratedShoppingItemOverrideValues;
+}) {
+  const normalizedValues = normalizeGeneratedShoppingItemOverrideValues(values);
+  const fieldErrors: GeneratedShoppingItemOverrideFieldErrors = {};
+  const postponedDateValidation = validateOptionalDateInRange(
+    normalizedValues.postponedUntilDate,
+    mealPlan.startDate,
+    mealPlan.endDate,
+    "Velg en gyldig dato innenfor ukeplanen.",
+  );
+
+  if (!postponedDateValidation.ok) {
+    fieldErrors.postponedUntilDate = postponedDateValidation.fieldError;
+  }
+
+  if (fieldErrors.postponedUntilDate) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  const preferredStoreId = await resolveScopedStoreId(normalizedValues.preferredStoreId, familyId);
+
+  if (normalizedValues.preferredStoreId && !preferredStoreId) {
+    return {
+      fieldErrors: {
+        preferredStoreId: "Velg en gyldig butikk for familien.",
+      },
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  return {
+    ok: true as const,
+    postponedUntilDate: postponedDateValidation.date,
+    preferredStoreId,
+    values: normalizedValues,
+  };
+}
+
+function normalizeManualShoppingItemValues(values: ManualShoppingItemValues): ManualShoppingItemValues {
+  return {
+    buyOnDate: values.buyOnDate.trim(),
+    categoryId: values.categoryId.trim(),
+    name: values.name.trim(),
+    note: values.note.trim(),
+    preferredStoreId: values.preferredStoreId.trim(),
+    quantity: values.quantity.trim(),
+  };
+}
+
+function normalizeGeneratedShoppingItemOverrideValues(
+  values: GeneratedShoppingItemOverrideValues,
+): GeneratedShoppingItemOverrideValues {
+  return {
+    note: values.note.trim(),
+    postponedUntilDate: values.postponedUntilDate.trim(),
+    preferredStoreId: values.preferredStoreId.trim(),
+  };
+}
+
+async function resolveScopedStoreId(preferredStoreId: string, familyId: string) {
+  if (!preferredStoreId) {
+    return null;
+  }
+
+  const store = await db.store.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      id: preferredStoreId,
+      OR: [{ familyId: null }, { familyId }],
+    },
+  });
+
+  return store?.id ?? null;
+}
+
+function validateOptionalDateInRange(
+  value: string,
+  startDate: Date,
+  endDate: Date,
+  invalidMessage: string,
+) {
+  if (!value) {
+    return {
+      date: null,
+      ok: true as const,
+    };
+  }
+
+  const parsedDate = parseDateOnly(value);
+
+  if (!parsedDate) {
+    return {
+      fieldError: invalidMessage,
+      ok: false as const,
+    };
+  }
+
+  if (parsedDate.getTime() < startDate.getTime() || parsedDate.getTime() > endDate.getTime()) {
+    return {
+      fieldError: "Datoen ma ligge innenfor ukeplanens aktive periode.",
+      ok: false as const,
+    };
+  }
+
+  return {
+    date: parsedDate,
+    ok: true as const,
+  };
+}
+
+function parseDateOnly(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearValue, monthValue, dayValue] = value.split("-");
+  const year = Number(yearValue);
+  const month = Number(monthValue);
+  const day = Number(dayValue);
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    Number.isNaN(parsedDate.getTime()) ||
+    parsedDate.getUTCFullYear() !== year ||
+    parsedDate.getUTCMonth() !== month - 1 ||
+    parsedDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsedDate;
+}
+
+function shouldDeleteOverrideAfterUnchecked(existingOverride: {
+  note: string | null;
+  postponedUntilDate: Date | null;
+  preferredStoreId: string | null;
+  sourceType: ShoppingItemSource;
+}) {
+  if (existingOverride.sourceType === ShoppingItemSource.MANUAL) {
+    return true;
+  }
+
+  return !existingOverride.note && !existingOverride.postponedUntilDate && !existingOverride.preferredStoreId;
+}
+
+function isOverrideEmpty(values: {
+  checked: boolean;
+  note: string | null;
+  postponedUntilDate: Date | null;
+  preferredStoreId: string | null;
+}) {
+  return !values.checked && !values.note && !values.postponedUntilDate && !values.preferredStoreId;
+}

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
   return {
     dbMock: {
+      ingredientCategory: {
+        findMany: vi.fn(),
+      },
       mealPlan: {
         findFirst: vi.fn(),
       },
@@ -44,9 +47,23 @@ describe("shopping.server", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     requireFamilyMembershipMock.mockResolvedValue(mockMembership);
+    dbMock.ingredientCategory.findMany.mockResolvedValue([
+      {
+        displayName: "Brod",
+        id: "category-bakery",
+      },
+      {
+        displayName: "Frukt og gront",
+        id: "category-produce",
+      },
+      {
+        displayName: "Meieri",
+        id: "category-dairy",
+      },
+    ]);
   });
 
-  it("projects deterministic generated shopping items with exact-match merge, overrides, and store ordering", async () => {
+  it("projects deterministic generated and manual shopping items with exact-match merge, overrides, and store ordering", async () => {
     dbMock.mealPlan.findFirst.mockResolvedValue({
       endDate: new Date("2026-05-18T00:00:00.000Z"),
       entries: [
@@ -163,6 +180,25 @@ describe("shopping.server", () => {
         },
       ],
       id: "meal-plan-1",
+      manualShoppingItems: [
+        {
+          buyOnDate: new Date("2026-05-18T00:00:00.000Z"),
+          category: {
+            displayName: "Meieri",
+            id: "category-dairy",
+          },
+          categoryId: "category-dairy",
+          id: "manual-item-1",
+          name: "Yoghurt",
+          note: "Til frokost",
+          preferredStore: {
+            id: "store-1",
+            name: "Coop Mega",
+          },
+          preferredStoreId: "store-1",
+          quantity: "2 beger",
+        },
+      ],
       shoppingOverrides: [
         {
           checked: true,
@@ -175,6 +211,15 @@ describe("shopping.server", () => {
           preferredStoreId: "store-2",
           sourceKey: "entry-1:ingredient-1|entry-2:ingredient-3",
           sourceType: "GENERATED",
+        },
+        {
+          checked: true,
+          note: null,
+          postponedUntilDate: null,
+          preferredStore: null,
+          preferredStoreId: null,
+          sourceKey: "manual-item-1",
+          sourceType: "MANUAL",
         },
       ],
       startDate: new Date("2026-05-15T00:00:00.000Z"),
@@ -260,15 +305,61 @@ describe("shopping.server", () => {
         OR: [{ familyId: null }, { familyId: "family-1" }],
       },
     });
+    expect(dbMock.ingredientCategory.findMany).toHaveBeenCalledWith({
+      orderBy: [{ displayName: "asc" }],
+      select: {
+        displayName: true,
+        id: true,
+      },
+    });
+    expect(result.categories.map((category) => category.displayName)).toEqual(["Brod", "Frukt og gront", "Meieri"]);
+    expect(result.itemCounts).toEqual({
+      generated: 4,
+      manual: 1,
+      total: 5,
+    });
+    expect(result.stores).toEqual([
+      {
+        id: "store-1",
+        name: "Coop Mega",
+      },
+      {
+        id: "store-2",
+        name: "Meny",
+      },
+    ]);
     expect(result.visibleDates).toEqual(["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"]);
     expect(result.projectedItems.map((item) => item.name)).toEqual([
       "Paprika",
+      "Yoghurt",
       "Lime",
       "Tortillalefser",
       "Tomater",
     ]);
 
-    const mergedItem = result.projectedItems[2];
+    const manualItem = result.projectedItems[1];
+    const mergedItem = result.projectedItems[3];
+
+    expect(manualItem).toEqual(
+      expect.objectContaining({
+        buyOnDate: new Date("2026-05-18T00:00:00.000Z"),
+        category: {
+          id: "category-dairy",
+          name: "Meieri",
+        },
+        checked: true,
+        name: "Yoghurt",
+        note: "Til frokost",
+        preferredStore: {
+          id: "store-1",
+          name: "Coop Mega",
+        },
+        quantity: "2 beger",
+        quantityLabel: "2 beger",
+        sourceKey: "manual-item-1",
+        sourceType: "MANUAL",
+      }),
+    );
 
     expect(mergedItem).toEqual(
       expect.objectContaining({
@@ -290,6 +381,9 @@ describe("shopping.server", () => {
         sourceType: "GENERATED",
       }),
     );
+    if (mergedItem.sourceType !== "GENERATED") {
+      throw new Error("Expected a generated shopping item.");
+    }
     expect(mergedItem.occurrences).toEqual([
       {
         date: new Date("2026-05-15T00:00:00.000Z"),
@@ -312,6 +406,14 @@ describe("shopping.server", () => {
       "Meny",
       "Ingen valgt butikk",
     ]);
+    expect(
+      result.storeGroups[0]?.sections.flatMap((section) => section.items).find((item) => item.sourceKey === "manual-item-1"),
+    ).toEqual(
+      expect.objectContaining({
+        name: "Yoghurt",
+        sourceType: "MANUAL",
+      }),
+    );
     expect(result.storeGroups[1]?.sections.map((section) => section.displayName)).toEqual([
       "Frukt og gront",
       "Brod",
@@ -384,6 +486,7 @@ describe("shopping.server", () => {
         },
       ],
       id: "meal-plan-1",
+      manualShoppingItems: [],
       shoppingOverrides: [],
       startDate: new Date("2026-05-15T00:00:00.000Z"),
       status: "DRAFT",
@@ -411,6 +514,11 @@ describe("shopping.server", () => {
       userId: "user-1",
     });
 
+    expect(result.itemCounts).toEqual({
+      generated: 2,
+      manual: 0,
+      total: 2,
+    });
     expect(result.projectedItems).toHaveLength(2);
     expect(result.projectedItems.map((item) => item.sourceKey)).toEqual([
       "entry-1:ingredient-1",
@@ -434,5 +542,6 @@ describe("shopping.server", () => {
     });
 
     expect(dbMock.store.findMany).not.toHaveBeenCalled();
+    expect(dbMock.ingredientCategory.findMany).not.toHaveBeenCalled();
   });
 });

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -4,23 +4,27 @@ import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { getMealPlanDateRange } from "./meal-plan.server";
 
+const storeSummarySelect = Prisma.validator<Prisma.StoreSelect>()({
+  id: true,
+  name: true,
+});
+
+const categorySummarySelect = Prisma.validator<Prisma.IngredientCategorySelect>()({
+  displayName: true,
+  id: true,
+});
+
 const generatedShoppingRecipeIngredientSelect = Prisma.validator<Prisma.RecipeIngredientSelect>()({
   amount: true,
   category: {
-    select: {
-      displayName: true,
-      id: true,
-    },
+    select: categorySummarySelect,
   },
   categoryId: true,
   displayName: true,
   id: true,
   ingredientId: true,
   preferredStore: {
-    select: {
-      id: true,
-      name: true,
-    },
+    select: storeSummarySelect,
   },
   preferredStoreId: true,
   sortOrder: true,
@@ -46,19 +50,32 @@ const generatedShoppingMealPlanEntrySelect = Prisma.validator<Prisma.MealPlanEnt
   recipeId: true,
 });
 
-const generatedShoppingOverrideSelect = Prisma.validator<Prisma.ShoppingItemOverrideSelect>()({
+const shoppingOverrideSelect = Prisma.validator<Prisma.ShoppingItemOverrideSelect>()({
   checked: true,
   note: true,
   postponedUntilDate: true,
   preferredStore: {
-    select: {
-      id: true,
-      name: true,
-    },
+    select: storeSummarySelect,
   },
   preferredStoreId: true,
   sourceKey: true,
   sourceType: true,
+});
+
+const manualShoppingItemSelect = Prisma.validator<Prisma.ManualShoppingItemSelect>()({
+  buyOnDate: true,
+  category: {
+    select: categorySummarySelect,
+  },
+  categoryId: true,
+  id: true,
+  name: true,
+  note: true,
+  preferredStore: {
+    select: storeSummarySelect,
+  },
+  preferredStoreId: true,
+  quantity: true,
 });
 
 const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
@@ -71,12 +88,13 @@ const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
     },
   },
   id: true,
+  manualShoppingItems: {
+    orderBy: [{ buyOnDate: "asc" }, { id: "asc" }],
+    select: manualShoppingItemSelect,
+  },
   shoppingOverrides: {
-    orderBy: [{ sourceKey: "asc" }],
-    select: generatedShoppingOverrideSelect,
-    where: {
-      sourceType: ShoppingItemSource.GENERATED,
-    },
+    orderBy: [{ sourceType: "asc" }, { sourceKey: "asc" }],
+    select: shoppingOverrideSelect,
   },
   startDate: true,
   status: true,
@@ -98,11 +116,22 @@ const shoppingStoreSelect = Prisma.validator<Prisma.StoreSelect>()({
   },
 });
 
+const shoppingCategorySelect = Prisma.validator<Prisma.IngredientCategorySelect>()({
+  displayName: true,
+  id: true,
+});
+
 type ShoppingMealPlan = Prisma.MealPlanGetPayload<{
   select: typeof shoppingMealPlanSelect;
 }>;
 type ShoppingStore = Prisma.StoreGetPayload<{
   select: typeof shoppingStoreSelect;
+}>;
+type ShoppingCategory = Prisma.IngredientCategoryGetPayload<{
+  select: typeof shoppingCategorySelect;
+}>;
+type ShoppingOverride = Prisma.ShoppingItemOverrideGetPayload<{
+  select: typeof shoppingOverrideSelect;
 }>;
 
 type StoreSummary = {
@@ -133,6 +162,21 @@ interface GeneratedProjectionBucket {
   unit: string | null;
 }
 
+interface ProjectedShoppingItemBase {
+  category: {
+    id: string;
+    name: string;
+  };
+  checked: boolean;
+  name: string;
+  note: string | null;
+  preferredStore: StoreSummary;
+  quantityLabel: string | null;
+  section: StoreSectionSummary;
+  sourceKey: string;
+  sourceType: ShoppingItemSource;
+}
+
 export interface ProjectedShoppingOccurrence {
   date: Date;
   mealPlanEntryId: string;
@@ -141,27 +185,24 @@ export interface ProjectedShoppingOccurrence {
   recipeTitle: string;
 }
 
-export interface ProjectedShoppingItem {
+export interface ProjectedGeneratedShoppingItem extends ProjectedShoppingItemBase {
   amount: string | null;
-  category: {
-    id: string;
-    name: string;
-  };
-  checked: boolean;
   firstDate: Date;
   lastDate: Date;
-  name: string;
-  note: string | null;
   occurrenceCount: number;
   occurrences: ProjectedShoppingOccurrence[];
   postponedUntilDate: Date | null;
-  preferredStore: StoreSummary;
-  quantityLabel: string | null;
-  section: StoreSectionSummary;
-  sourceKey: string;
   sourceType: "GENERATED";
   unit: string | null;
 }
+
+export interface ProjectedManualShoppingItem extends ProjectedShoppingItemBase {
+  buyOnDate: Date | null;
+  quantity: string | null;
+  sourceType: "MANUAL";
+}
+
+export type ProjectedShoppingItem = ProjectedGeneratedShoppingItem | ProjectedManualShoppingItem;
 
 export interface ProjectedShoppingSectionGroup {
   category: {
@@ -206,27 +247,48 @@ export async function getMealPlanShoppingData({
     });
   }
 
-  const stores = await db.store.findMany({
-    orderBy: [{ name: "asc" }],
-    select: shoppingStoreSelect,
-    where: {
-      OR: [{ familyId: null }, { familyId }],
-    },
-  });
+  const [stores, categories] = await Promise.all([
+    db.store.findMany({
+      orderBy: [{ name: "asc" }],
+      select: shoppingStoreSelect,
+      where: {
+        OR: [{ familyId: null }, { familyId }],
+      },
+    }),
+    db.ingredientCategory.findMany({
+      orderBy: [{ displayName: "asc" }],
+      select: shoppingCategorySelect,
+    }),
+  ]);
 
-  const projectedItems = projectGeneratedShoppingItems({
+  const generatedItems = projectGeneratedShoppingItems({
     mealPlan,
     stores,
   });
+  const manualItems = projectManualShoppingItems({
+    mealPlan,
+    stores,
+  });
+  const projectedItems = [...generatedItems, ...manualItems].sort(compareProjectedItems);
 
   return {
+    categories,
     family: {
       id: membership.family.id,
       name: membership.family.name,
     },
+    itemCounts: {
+      generated: generatedItems.length,
+      manual: manualItems.length,
+      total: projectedItems.length,
+    },
     mealPlan,
     projectedItems,
     storeGroups: buildProjectedStoreGroups(projectedItems),
+    stores: stores.map((store) => ({
+      id: store.id,
+      name: store.name,
+    })),
     userRole: membership.role,
     visibleDates: getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate),
   };
@@ -239,23 +301,8 @@ function projectGeneratedShoppingItems({
   mealPlan: ShoppingMealPlan;
   stores: ShoppingStore[];
 }) {
-  const storeSectionsByStoreId = new Map(
-    stores.map((store) => [
-      store.id,
-      new Map(
-        store.sections.map((section) => [
-          section.categoryId,
-          {
-            displayName: section.displayName,
-            sortOrder: section.sortOrder,
-          },
-        ]),
-      ),
-    ]),
-  );
-  const overrideBySourceKey = new Map(
-    mealPlan.shoppingOverrides.map((override) => [override.sourceKey, override]),
-  );
+  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
+  const overrideBySourceKey = buildOverrideMap(mealPlan.shoppingOverrides, ShoppingItemSource.GENERATED);
   const buckets = new Map<string, GeneratedProjectionBucket>();
 
   for (const entry of mealPlan.entries) {
@@ -291,11 +338,13 @@ function projectGeneratedShoppingItems({
         existingBucket.occurrenceKeys.push(occurrenceKey);
         existingBucket.occurrences.push(occurrence);
 
-        if (compareProjectionAnchors(existingBucket.sortAnchor, {
-          date: entry.date,
-          ingredientSortOrder: ingredient.sortOrder,
-          recipeTitle: recipe.title,
-        }) > 0) {
+        if (
+          compareProjectionAnchors(existingBucket.sortAnchor, {
+            date: entry.date,
+            ingredientSortOrder: ingredient.sortOrder,
+            recipeTitle: recipe.title,
+          }) > 0
+        ) {
           existingBucket.sortAnchor = {
             date: entry.date,
             ingredientSortOrder: ingredient.sortOrder,
@@ -309,8 +358,8 @@ function projectGeneratedShoppingItems({
       buckets.set(mergeKey, {
         amount: ingredient.amount,
         category: {
-          name: ingredient.category.displayName,
           id: ingredient.category.id,
+          name: ingredient.category.displayName,
         },
         name: ingredient.displayName,
         occurrences: [occurrence],
@@ -326,38 +375,77 @@ function projectGeneratedShoppingItems({
     }
   }
 
-  return [...buckets.values()]
-    .map((bucket) => {
-      const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
-      const override = overrideBySourceKey.get(sourceKey);
-      const preferredStore = override?.preferredStore ?? bucket.preferredStore;
-      const section = resolveStoreSection({
-        category: bucket.category,
-        preferredStore,
-        storeSectionsByStoreId,
-      });
-      const occurrences = [...bucket.occurrences].sort(compareProjectedOccurrences);
+  return [...buckets.values()].map((bucket) => {
+    const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
+    const override = overrideBySourceKey.get(sourceKey);
+    const preferredStore = override?.preferredStore ?? bucket.preferredStore;
+    const section = resolveStoreSection({
+      category: bucket.category,
+      preferredStore,
+      storeSectionsByStoreId,
+    });
+    const occurrences = [...bucket.occurrences].sort(compareProjectedOccurrences);
 
-      return {
-        amount: bucket.amount,
-        category: bucket.category,
-        checked: override?.checked ?? false,
-        firstDate: occurrences[0]!.date,
-        lastDate: occurrences[occurrences.length - 1]!.date,
-        name: bucket.name,
-        note: override?.note ?? null,
-        occurrenceCount: occurrences.length,
-        occurrences,
-        postponedUntilDate: override?.postponedUntilDate ?? null,
-        preferredStore,
-        quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
-        section,
-        sourceKey,
-        sourceType: ShoppingItemSource.GENERATED,
-        unit: bucket.unit,
-      } satisfies ProjectedShoppingItem;
-    })
-    .sort(compareProjectedItems);
+    return {
+      amount: bucket.amount,
+      category: bucket.category,
+      checked: override?.checked ?? false,
+      firstDate: occurrences[0]!.date,
+      lastDate: occurrences[occurrences.length - 1]!.date,
+      name: bucket.name,
+      note: override?.note ?? null,
+      occurrenceCount: occurrences.length,
+      occurrences,
+      postponedUntilDate: override?.postponedUntilDate ?? null,
+      preferredStore,
+      quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
+      section,
+      sourceKey,
+      sourceType: ShoppingItemSource.GENERATED,
+      unit: bucket.unit,
+    } satisfies ProjectedGeneratedShoppingItem;
+  });
+}
+
+function projectManualShoppingItems({
+  mealPlan,
+  stores,
+}: {
+  mealPlan: ShoppingMealPlan;
+  stores: ShoppingStore[];
+}) {
+  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
+  const overrideBySourceKey = buildOverrideMap(mealPlan.shoppingOverrides, ShoppingItemSource.MANUAL);
+
+  return mealPlan.manualShoppingItems.map((item) => {
+    const override = overrideBySourceKey.get(item.id);
+    const preferredStore = item.preferredStore;
+    const section = resolveStoreSection({
+      category: {
+        id: item.category.id,
+        name: item.category.displayName,
+      },
+      preferredStore,
+      storeSectionsByStoreId,
+    });
+
+    return {
+      buyOnDate: item.buyOnDate,
+      category: {
+        id: item.category.id,
+        name: item.category.displayName,
+      },
+      checked: override?.checked ?? false,
+      name: item.name,
+      note: item.note,
+      preferredStore,
+      quantity: item.quantity,
+      quantityLabel: buildManualQuantityLabel(item.quantity),
+      section,
+      sourceKey: item.id,
+      sourceType: ShoppingItemSource.MANUAL,
+    } satisfies ProjectedManualShoppingItem;
+  });
 }
 
 function buildProjectedStoreGroups(items: ProjectedShoppingItem[]): ProjectedShoppingStoreGroup[] {
@@ -421,6 +509,31 @@ function buildProjectedStoreGroups(items: ProjectedShoppingItem[]): ProjectedSho
       };
     })
     .sort((left, right) => compareStoreSummaries(left.store, right.store));
+}
+
+function buildStoreSectionsByStoreId(stores: ShoppingStore[]) {
+  return new Map(
+    stores.map((store) => [
+      store.id,
+      new Map(
+        store.sections.map((section) => [
+          section.categoryId,
+          {
+            displayName: section.displayName,
+            sortOrder: section.sortOrder,
+          },
+        ]),
+      ),
+    ]),
+  );
+}
+
+function buildOverrideMap(overrides: ShoppingOverride[], sourceType: ShoppingItemSource) {
+  return new Map(
+    overrides
+      .filter((override) => override.sourceType === sourceType)
+      .map((override) => [override.sourceKey, override]),
+  );
 }
 
 function buildGeneratedOccurrenceKey({
@@ -500,6 +613,12 @@ function buildQuantityLabel(amount: string | null, unit: string | null) {
   return parts.length ? parts.join(" ") : null;
 }
 
+function buildManualQuantityLabel(quantity: string | null) {
+  const trimmedQuantity = quantity?.trim() ?? "";
+
+  return trimmedQuantity.length > 0 ? trimmedQuantity : null;
+}
+
 function compareProjectedOccurrences(left: ProjectedShoppingOccurrence, right: ProjectedShoppingOccurrence) {
   if (left.date.getTime() !== right.date.getTime()) {
     return left.date.getTime() - right.date.getTime();
@@ -562,8 +681,11 @@ function compareProjectedItems(left: ProjectedShoppingItem, right: ProjectedShop
     return sectionComparison;
   }
 
-  if (left.firstDate.getTime() !== right.firstDate.getTime()) {
-    return left.firstDate.getTime() - right.firstDate.getTime();
+  const leftSortTimestamp = getProjectedItemSortTimestamp(left);
+  const rightSortTimestamp = getProjectedItemSortTimestamp(right);
+
+  if (leftSortTimestamp !== rightSortTimestamp) {
+    return leftSortTimestamp - rightSortTimestamp;
   }
 
   const nameComparison = left.name.localeCompare(right.name, "nb");
@@ -573,4 +695,12 @@ function compareProjectedItems(left: ProjectedShoppingItem, right: ProjectedShop
   }
 
   return left.sourceKey.localeCompare(right.sourceKey, "nb");
+}
+
+function getProjectedItemSortTimestamp(item: ProjectedShoppingItem) {
+  if (item.sourceType === "GENERATED") {
+    return item.firstDate.getTime();
+  }
+
+  return item.buyOnDate ? item.buyOnDate.getTime() : Number.MIN_SAFE_INTEGER;
 }

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -9,27 +9,29 @@ const storeSummarySelect = Prisma.validator<Prisma.StoreSelect>()({
   name: true,
 });
 
-const categorySummarySelect = Prisma.validator<Prisma.IngredientCategorySelect>()({
-  displayName: true,
-  id: true,
-});
+const categorySummarySelect =
+  Prisma.validator<Prisma.IngredientCategorySelect>()({
+    displayName: true,
+    id: true,
+  });
 
-const generatedShoppingRecipeIngredientSelect = Prisma.validator<Prisma.RecipeIngredientSelect>()({
-  amount: true,
-  category: {
-    select: categorySummarySelect,
-  },
-  categoryId: true,
-  displayName: true,
-  id: true,
-  ingredientId: true,
-  preferredStore: {
-    select: storeSummarySelect,
-  },
-  preferredStoreId: true,
-  sortOrder: true,
-  unit: true,
-});
+const generatedShoppingRecipeIngredientSelect =
+  Prisma.validator<Prisma.RecipeIngredientSelect>()({
+    amount: true,
+    category: {
+      select: categorySummarySelect,
+    },
+    categoryId: true,
+    displayName: true,
+    id: true,
+    ingredientId: true,
+    preferredStore: {
+      select: storeSummarySelect,
+    },
+    preferredStoreId: true,
+    sortOrder: true,
+    unit: true,
+  });
 
 const generatedShoppingRecipeSelect = Prisma.validator<Prisma.RecipeSelect>()({
   id: true,
@@ -40,43 +42,46 @@ const generatedShoppingRecipeSelect = Prisma.validator<Prisma.RecipeSelect>()({
   title: true,
 });
 
-const generatedShoppingMealPlanEntrySelect = Prisma.validator<Prisma.MealPlanEntrySelect>()({
-  date: true,
-  id: true,
-  mealType: true,
-  recipe: {
-    select: generatedShoppingRecipeSelect,
-  },
-  recipeId: true,
-});
+const generatedShoppingMealPlanEntrySelect =
+  Prisma.validator<Prisma.MealPlanEntrySelect>()({
+    date: true,
+    id: true,
+    mealType: true,
+    recipe: {
+      select: generatedShoppingRecipeSelect,
+    },
+    recipeId: true,
+  });
 
-const shoppingOverrideSelect = Prisma.validator<Prisma.ShoppingItemOverrideSelect>()({
-  checked: true,
-  note: true,
-  postponedUntilDate: true,
-  preferredStore: {
-    select: storeSummarySelect,
-  },
-  preferredStoreId: true,
-  sourceKey: true,
-  sourceType: true,
-});
+const shoppingOverrideSelect =
+  Prisma.validator<Prisma.ShoppingItemOverrideSelect>()({
+    checked: true,
+    note: true,
+    postponedUntilDate: true,
+    preferredStore: {
+      select: storeSummarySelect,
+    },
+    preferredStoreId: true,
+    sourceKey: true,
+    sourceType: true,
+  });
 
-const manualShoppingItemSelect = Prisma.validator<Prisma.ManualShoppingItemSelect>()({
-  buyOnDate: true,
-  category: {
-    select: categorySummarySelect,
-  },
-  categoryId: true,
-  id: true,
-  name: true,
-  note: true,
-  preferredStore: {
-    select: storeSummarySelect,
-  },
-  preferredStoreId: true,
-  quantity: true,
-});
+const manualShoppingItemSelect =
+  Prisma.validator<Prisma.ManualShoppingItemSelect>()({
+    buyOnDate: true,
+    category: {
+      select: categorySummarySelect,
+    },
+    categoryId: true,
+    id: true,
+    name: true,
+    note: true,
+    preferredStore: {
+      select: storeSummarySelect,
+    },
+    preferredStoreId: true,
+    quantity: true,
+  });
 
 const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
   endDate: true,
@@ -116,19 +121,17 @@ const shoppingStoreSelect = Prisma.validator<Prisma.StoreSelect>()({
   },
 });
 
-const shoppingCategorySelect = Prisma.validator<Prisma.IngredientCategorySelect>()({
-  displayName: true,
-  id: true,
-});
+const shoppingCategorySelect =
+  Prisma.validator<Prisma.IngredientCategorySelect>()({
+    displayName: true,
+    id: true,
+  });
 
 type ShoppingMealPlan = Prisma.MealPlanGetPayload<{
   select: typeof shoppingMealPlanSelect;
 }>;
 type ShoppingStore = Prisma.StoreGetPayload<{
   select: typeof shoppingStoreSelect;
-}>;
-type ShoppingCategory = Prisma.IngredientCategoryGetPayload<{
-  select: typeof shoppingCategorySelect;
 }>;
 type ShoppingOverride = Prisma.ShoppingItemOverrideGetPayload<{
   select: typeof shoppingOverrideSelect;
@@ -202,7 +205,9 @@ export interface ProjectedManualShoppingItem extends ProjectedShoppingItemBase {
   sourceType: "MANUAL";
 }
 
-export type ProjectedShoppingItem = ProjectedGeneratedShoppingItem | ProjectedManualShoppingItem;
+export type ProjectedShoppingItem =
+  | ProjectedGeneratedShoppingItem
+  | ProjectedManualShoppingItem;
 
 export interface ProjectedShoppingSectionGroup {
   category: {
@@ -269,7 +274,9 @@ export async function getMealPlanShoppingData({
     mealPlan,
     stores,
   });
-  const projectedItems = [...generatedItems, ...manualItems].sort(compareProjectedItems);
+  const projectedItems = [...generatedItems, ...manualItems].sort(
+    compareProjectedItems,
+  );
 
   return {
     categories,
@@ -302,7 +309,10 @@ function projectGeneratedShoppingItems({
   stores: ShoppingStore[];
 }) {
   const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
-  const overrideBySourceKey = buildOverrideMap(mealPlan.shoppingOverrides, ShoppingItemSource.GENERATED);
+  const overrideBySourceKey = buildOverrideMap(
+    mealPlan.shoppingOverrides,
+    ShoppingItemSource.GENERATED,
+  );
   const buckets = new Map<string, GeneratedProjectionBucket>();
 
   for (const entry of mealPlan.entries) {
@@ -384,7 +394,9 @@ function projectGeneratedShoppingItems({
       preferredStore,
       storeSectionsByStoreId,
     });
-    const occurrences = [...bucket.occurrences].sort(compareProjectedOccurrences);
+    const occurrences = [...bucket.occurrences].sort(
+      compareProjectedOccurrences,
+    );
 
     return {
       amount: bucket.amount,
@@ -415,7 +427,10 @@ function projectManualShoppingItems({
   stores: ShoppingStore[];
 }) {
   const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
-  const overrideBySourceKey = buildOverrideMap(mealPlan.shoppingOverrides, ShoppingItemSource.MANUAL);
+  const overrideBySourceKey = buildOverrideMap(
+    mealPlan.shoppingOverrides,
+    ShoppingItemSource.MANUAL,
+  );
 
   return mealPlan.manualShoppingItems.map((item) => {
     const override = overrideBySourceKey.get(item.id);
@@ -448,7 +463,9 @@ function projectManualShoppingItems({
   });
 }
 
-function buildProjectedStoreGroups(items: ProjectedShoppingItem[]): ProjectedShoppingStoreGroup[] {
+function buildProjectedStoreGroups(
+  items: ProjectedShoppingItem[],
+): ProjectedShoppingStoreGroup[] {
   const groupMap = new Map<
     string,
     {
@@ -528,7 +545,10 @@ function buildStoreSectionsByStoreId(stores: ShoppingStore[]) {
   );
 }
 
-function buildOverrideMap(overrides: ShoppingOverride[], sourceType: ShoppingItemSource) {
+function buildOverrideMap(
+  overrides: ShoppingOverride[],
+  sourceType: ShoppingItemSource,
+) {
   return new Map(
     overrides
       .filter((override) => override.sourceType === sourceType)
@@ -608,7 +628,9 @@ function resolveStoreSection({
 }
 
 function buildQuantityLabel(amount: string | null, unit: string | null) {
-  const parts = [amount, unit].filter((value) => value && value.trim().length > 0);
+  const parts = [amount, unit].filter(
+    (value) => value && value.trim().length > 0,
+  );
 
   return parts.length ? parts.join(" ") : null;
 }
@@ -619,12 +641,18 @@ function buildManualQuantityLabel(quantity: string | null) {
   return trimmedQuantity.length > 0 ? trimmedQuantity : null;
 }
 
-function compareProjectedOccurrences(left: ProjectedShoppingOccurrence, right: ProjectedShoppingOccurrence) {
+function compareProjectedOccurrences(
+  left: ProjectedShoppingOccurrence,
+  right: ProjectedShoppingOccurrence,
+) {
   if (left.date.getTime() !== right.date.getTime()) {
     return left.date.getTime() - right.date.getTime();
   }
 
-  const recipeTitleComparison = left.recipeTitle.localeCompare(right.recipeTitle, "nb");
+  const recipeTitleComparison = left.recipeTitle.localeCompare(
+    right.recipeTitle,
+    "nb",
+  );
 
   if (recipeTitleComparison !== 0) {
     return recipeTitleComparison;
@@ -664,8 +692,14 @@ function compareStoreSummaries(left: StoreSummary, right: StoreSummary) {
   return left.name.localeCompare(right.name, "nb");
 }
 
-function compareProjectedItems(left: ProjectedShoppingItem, right: ProjectedShoppingItem) {
-  const storeComparison = compareStoreSummaries(left.preferredStore, right.preferredStore);
+function compareProjectedItems(
+  left: ProjectedShoppingItem,
+  right: ProjectedShoppingItem,
+) {
+  const storeComparison = compareStoreSummaries(
+    left.preferredStore,
+    right.preferredStore,
+  );
 
   if (storeComparison !== 0) {
     return storeComparison;
@@ -675,7 +709,10 @@ function compareProjectedItems(left: ProjectedShoppingItem, right: ProjectedShop
     return left.section.sortOrder - right.section.sortOrder;
   }
 
-  const sectionComparison = left.section.displayName.localeCompare(right.section.displayName, "nb");
+  const sectionComparison = left.section.displayName.localeCompare(
+    right.section.displayName,
+    "nb",
+  );
 
   if (sectionComparison !== 0) {
     return sectionComparison;

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -15,9 +15,24 @@ vi.mock("../lib/shopping.server", () => {
   };
 });
 
+vi.mock("../lib/shopping-write.server", () => {
+  return {
+    createManualShoppingItem: vi.fn(),
+    deleteManualShoppingItem: vi.fn(),
+    toggleShoppingItemChecked: vi.fn(),
+    updateGeneratedShoppingItemOverride: vi.fn(),
+    updateManualShoppingItem: vi.fn(),
+  };
+});
+
 import { requireUser } from "../lib/auth.server";
 import { getMealPlanShoppingData } from "../lib/shopping.server";
-import { loader } from "./family-meal-plan-shopping";
+import {
+  createManualShoppingItem,
+  toggleShoppingItemChecked,
+  updateGeneratedShoppingItemOverride,
+} from "../lib/shopping-write.server";
+import { action, loader } from "./family-meal-plan-shopping";
 
 const mockUser = {
   displayName: "Ola",
@@ -26,8 +41,11 @@ const mockUser = {
   isGlobalAdmin: false,
 };
 
-function buildRequest(url = "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping") {
-  return new Request(url);
+function buildRequest(url = "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping", formData?: FormData) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
 }
 
 describe("family meal plan shopping route", () => {
@@ -35,17 +53,29 @@ describe("family meal plan shopping route", () => {
     vi.clearAllMocks();
   });
 
-  it("loads and serializes the server-projected shopping list", async () => {
+  it("loads and serializes generated and manual shopping data", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(getMealPlanShoppingData).mockResolvedValue({
+      categories: [
+        {
+          displayName: "Frukt og gront",
+          id: "category-produce",
+        },
+      ],
       family: {
         id: "family-1",
         name: "Solberg",
+      },
+      itemCounts: {
+        generated: 1,
+        manual: 1,
+        total: 2,
       },
       mealPlan: {
         endDate: new Date("2026-05-18T00:00:00.000Z"),
         entries: [],
         id: "meal-plan-1",
+        manualShoppingItems: [],
         shoppingOverrides: [],
         startDate: new Date("2026-05-15T00:00:00.000Z"),
         status: "DRAFT",
@@ -86,6 +116,28 @@ describe("family meal plan shopping route", () => {
           sourceKey: "entry-1:ingredient-1",
           sourceType: "GENERATED",
           unit: "stk",
+        },
+        {
+          buyOnDate: new Date("2026-05-18T00:00:00.000Z"),
+          category: {
+            id: "category-produce",
+            name: "Frukt og gront",
+          },
+          checked: true,
+          name: "Bananer",
+          note: "Til smoothien",
+          preferredStore: {
+            id: "store-1",
+            name: "Meny",
+          },
+          quantity: "6 stk",
+          quantityLabel: "6 stk",
+          section: {
+            displayName: "Frukt og gront",
+            sortOrder: 1,
+          },
+          sourceKey: "manual-item-1",
+          sourceType: "MANUAL",
         },
       ],
       storeGroups: [
@@ -133,6 +185,28 @@ describe("family meal plan shopping route", () => {
                   sourceType: "GENERATED",
                   unit: "stk",
                 },
+                {
+                  buyOnDate: new Date("2026-05-18T00:00:00.000Z"),
+                  category: {
+                    id: "category-produce",
+                    name: "Frukt og gront",
+                  },
+                  checked: true,
+                  name: "Bananer",
+                  note: "Til smoothien",
+                  preferredStore: {
+                    id: "store-1",
+                    name: "Meny",
+                  },
+                  quantity: "6 stk",
+                  quantityLabel: "6 stk",
+                  section: {
+                    displayName: "Frukt og gront",
+                    sortOrder: 1,
+                  },
+                  sourceKey: "manual-item-1",
+                  sourceType: "MANUAL",
+                },
               ],
             },
           ],
@@ -140,6 +214,12 @@ describe("family meal plan shopping route", () => {
             id: "store-1",
             name: "Meny",
           },
+        },
+      ],
+      stores: [
+        {
+          id: "store-1",
+          name: "Meny",
         },
       ],
       userRole: "ADMIN",
@@ -164,16 +244,28 @@ describe("family meal plan shopping route", () => {
         id: "family-1",
         name: "Solberg",
       },
+      itemCounts: {
+        generated: 1,
+        manual: 1,
+        total: 2,
+      },
       mealPlan: {
         endDate: "2026-05-18",
         entries: undefined,
         id: "meal-plan-1",
+        manualShoppingItems: undefined,
         shoppingOverrides: undefined,
         startDate: "2026-05-15",
         status: "DRAFT",
         title: "Langhelg",
       },
-      projectedItemCount: 1,
+      notice: null,
+      categories: [
+        {
+          displayName: "Frukt og gront",
+          id: "category-produce",
+        },
+      ],
       storeGroups: [
         {
           sections: [
@@ -219,6 +311,28 @@ describe("family meal plan shopping route", () => {
                   sourceType: "GENERATED",
                   unit: "stk",
                 },
+                {
+                  buyOnDate: "2026-05-18",
+                  category: {
+                    id: "category-produce",
+                    name: "Frukt og gront",
+                  },
+                  checked: true,
+                  name: "Bananer",
+                  note: "Til smoothien",
+                  preferredStore: {
+                    id: "store-1",
+                    name: "Meny",
+                  },
+                  quantity: "6 stk",
+                  quantityLabel: "6 stk",
+                  section: {
+                    displayName: "Frukt og gront",
+                    sortOrder: 1,
+                  },
+                  sourceKey: "manual-item-1",
+                  sourceType: "MANUAL",
+                },
               ],
             },
           ],
@@ -228,8 +342,171 @@ describe("family meal plan shopping route", () => {
           },
         },
       ],
+      stores: [
+        {
+          id: "store-1",
+          name: "Meny",
+        },
+      ],
       userRole: "ADMIN",
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
+    });
+  });
+
+  it("returns manual item validation errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createManualShoppingItem).mockResolvedValue({
+      fieldErrors: {
+        name: "Skriv inn et varenavn.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        buyOnDate: "",
+        categoryId: "category-produce",
+        name: "",
+        note: "Til dessert",
+        preferredStoreId: "",
+        quantity: "2 stk",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "add-manual-shopping-item");
+    formData.set("name", "  ");
+    formData.set("quantity", "2 stk");
+    formData.set("categoryId", "category-produce");
+    formData.set("preferredStoreId", "");
+    formData.set("buyOnDate", "");
+    formData.set("note", "Til dessert");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1/shopping", formData),
+    });
+
+    expect(createManualShoppingItem).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+      values: {
+        buyOnDate: "",
+        categoryId: "category-produce",
+        name: "  ",
+        note: "Til dessert",
+        preferredStoreId: "",
+        quantity: "2 stk",
+      },
+    });
+    expect(result).toEqual({
+      intent: "add-manual-shopping-item",
+      manualFieldErrors: {
+        name: "Skriv inn et varenavn.",
+      },
+      manualValues: {
+        buyOnDate: "",
+        categoryId: "category-produce",
+        name: "",
+        note: "Til dessert",
+        preferredStoreId: "",
+        quantity: "2 stk",
+      },
+    });
+  });
+
+  it("redirects with a notice after toggling checked state", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(toggleShoppingItemChecked).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "toggle-shopping-item-checked");
+    formData.set("sourceKey", "manual-item-1");
+    formData.set("sourceType", "MANUAL");
+    formData.set("checked", "true");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1/shopping", formData),
+    });
+
+    expect(toggleShoppingItemChecked).toHaveBeenCalledWith({
+      checked: true,
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "manual-item-1",
+      sourceType: "MANUAL",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping?notice=shopping-item-check-state-updated",
+    );
+  });
+
+  it("returns generated override validation errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateGeneratedShoppingItemOverride).mockResolvedValue({
+      fieldErrors: {
+        postponedUntilDate: "Datoen ma ligge innenfor ukeplanens aktive periode.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        note: "Kjop senere",
+        postponedUntilDate: "2026-05-21",
+        preferredStoreId: "store-1",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-generated-shopping-item");
+    formData.set("sourceKey", "entry-1:ingredient-1");
+    formData.set("note", "Kjop senere");
+    formData.set("postponedUntilDate", "2026-05-21");
+    formData.set("preferredStoreId", "store-1");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1/shopping", formData),
+    });
+
+    expect(updateGeneratedShoppingItemOverride).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+      values: {
+        note: "Kjop senere",
+        postponedUntilDate: "2026-05-21",
+        preferredStoreId: "store-1",
+      },
+    });
+    expect(result).toEqual({
+      generatedOverrideFieldErrors: {
+        postponedUntilDate: "Datoen ma ligge innenfor ukeplanens aktive periode.",
+      },
+      intent: "update-generated-shopping-item",
+      itemTarget: {
+        sourceKey: "entry-1:ingredient-1",
+        sourceType: "GENERATED",
+      },
+      overrideValues: {
+        note: "Kjop senere",
+        postponedUntilDate: "2026-05-21",
+        preferredStoreId: "store-1",
+      },
     });
   });
 });

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1,16 +1,65 @@
-import { Link, isRouteErrorResponse, type MetaFunction } from "react-router";
+import { ShoppingItemSource } from "@prisma/client";
+import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
 
 import { requireUser } from "../lib/auth.server";
 import { getMealPlanShoppingData } from "../lib/shopping.server";
+import {
+  createManualShoppingItem,
+  deleteManualShoppingItem,
+  toggleShoppingItemChecked,
+  updateGeneratedShoppingItemOverride,
+  updateManualShoppingItem,
+  type GeneratedShoppingItemOverrideFieldErrors,
+  type GeneratedShoppingItemOverrideValues,
+  type ManualShoppingItemFieldErrors,
+  type ManualShoppingItemValues,
+} from "../lib/shopping-write.server";
+
+type ShoppingNotice =
+  | "generated-shopping-item-updated"
+  | "manual-shopping-item-added"
+  | "manual-shopping-item-deleted"
+  | "manual-shopping-item-updated"
+  | "shopping-item-check-state-updated";
+
+type ShoppingIntent =
+  | "add-manual-shopping-item"
+  | "delete-manual-shopping-item"
+  | "toggle-shopping-item-checked"
+  | "update-generated-shopping-item"
+  | "update-manual-shopping-item";
+
+interface ShoppingActionData {
+  formError?: string;
+  generatedOverrideFieldErrors?: GeneratedShoppingItemOverrideFieldErrors;
+  intent?: ShoppingIntent;
+  itemTarget?: {
+    sourceKey: string;
+    sourceType: ShoppingItemSource;
+  };
+  manualFieldErrors?: ManualShoppingItemFieldErrors;
+  manualValues?: ManualShoppingItemValues;
+  overrideValues?: GeneratedShoppingItemOverrideValues;
+}
 
 interface FamilyMealPlanShoppingRouteProps {
+  actionData?: ShoppingActionData;
   loaderData: Awaited<ReturnType<typeof loader>>;
 }
+
+const defaultManualShoppingItemValues: ManualShoppingItemValues = {
+  buyOnDate: "",
+  categoryId: "",
+  name: "",
+  note: "",
+  preferredStoreId: "",
+  quantity: "",
+};
 
 export const meta: MetaFunction = () => {
   return [
     { title: "Handleliste | Mealplanner" },
-    { name: "description", content: "Servergenerert handleliste for valgt familieukeplan." },
+    { name: "description", content: "Handleliste med genererte og manuelle varelinjer for valgt ukeplan." },
   ];
 };
 
@@ -34,40 +83,226 @@ export async function loader({
   });
 
   return {
+    categories: result.categories,
     family: result.family,
+    itemCounts: result.itemCounts,
     mealPlan: {
       ...result.mealPlan,
       endDate: formatDateOnly(result.mealPlan.endDate),
       entries: undefined,
+      manualShoppingItems: undefined,
       shoppingOverrides: undefined,
       startDate: formatDateOnly(result.mealPlan.startDate),
     },
-    projectedItemCount: result.projectedItems.length,
+    notice: getShoppingNotice(request),
     storeGroups: result.storeGroups.map((group) => ({
       sections: group.sections.map((section) => ({
         ...section,
-        items: section.items.map((item) => ({
-          ...item,
-          firstDate: formatDateOnly(item.firstDate),
-          lastDate: formatDateOnly(item.lastDate),
-          occurrences: item.occurrences.map((occurrence) => ({
-            ...occurrence,
-            date: formatDateOnly(occurrence.date),
-          })),
-          postponedUntilDate: item.postponedUntilDate ? formatDateOnly(item.postponedUntilDate) : null,
-        })),
+        items: section.items.map(serializeProjectedShoppingItem),
       })),
       store: group.store,
     })),
+    stores: result.stores,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
   };
 }
 
-export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPlanShoppingRouteProps) {
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "add-manual-shopping-item") {
+    const result = await createManualShoppingItem({
+      familyId,
+      mealPlanId,
+      userId: user.id,
+      values: parseManualShoppingItemValues(formData),
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        intent,
+        manualFieldErrors: result.fieldErrors,
+        manualValues: result.values,
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "manual-shopping-item-added",
+      request,
+    });
+  }
+
+  if (intent === "update-manual-shopping-item") {
+    const manualItemId = String(formData.get("manualItemId") ?? "").trim();
+    const result = await updateManualShoppingItem({
+      familyId,
+      manualItemId,
+      mealPlanId,
+      userId: user.id,
+      values: parseManualShoppingItemValues(formData),
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        intent,
+        itemTarget: {
+          sourceKey: manualItemId,
+          sourceType: ShoppingItemSource.MANUAL,
+        },
+        manualFieldErrors: result.fieldErrors,
+        manualValues: result.values,
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "manual-shopping-item-updated",
+      request,
+    });
+  }
+
+  if (intent === "delete-manual-shopping-item") {
+    const manualItemId = String(formData.get("manualItemId") ?? "").trim();
+    const result = await deleteManualShoppingItem({
+      familyId,
+      manualItemId,
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "manual-shopping-item-deleted",
+      request,
+    });
+  }
+
+  if (intent === "toggle-shopping-item-checked") {
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+    const sourceType = parseShoppingItemSource(formData.get("sourceType"));
+    const checked = String(formData.get("checked") ?? "") === "true";
+
+    if (!sourceKey || !sourceType) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    const result = await toggleShoppingItemChecked({
+      checked,
+      familyId,
+      mealPlanId,
+      sourceKey,
+      sourceType,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "shopping-item-check-state-updated",
+      request,
+    });
+  }
+
+  if (intent === "update-generated-shopping-item") {
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+
+    if (!sourceKey) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    const result = await updateGeneratedShoppingItemOverride({
+      familyId,
+      mealPlanId,
+      sourceKey,
+      userId: user.id,
+      values: parseGeneratedShoppingItemOverrideValues(formData),
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        generatedOverrideFieldErrors: result.fieldErrors,
+        intent,
+        itemTarget: {
+          sourceKey,
+          sourceType: ShoppingItemSource.GENERATED,
+        },
+        overrideValues: result.values,
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "generated-shopping-item-updated",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies ShoppingActionData;
+}
+
+export default function FamilyMealPlanShoppingRoute({
+  actionData,
+  loaderData,
+}: FamilyMealPlanShoppingRouteProps) {
+  const navigation = useNavigation();
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingSourceKey = getPendingSourceKey(navigation.formData);
+  const addManualValues =
+    actionData?.intent === "add-manual-shopping-item" && actionData.manualValues
+      ? actionData.manualValues
+      : defaultManualShoppingItemValues;
+  const noticeContent = loaderData.notice ? getShoppingNoticeContent(loaderData.notice) : null;
+
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
-      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
         <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
           <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
             <div>
@@ -76,8 +311,8 @@ export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPl
               </span>
               <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.mealPlan.title}</h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
-                Dette er en servergenerert projeksjon av ingrediensene fra planlagte middager i den aktive
-                perioden. Listen er deterministisk og viser hvilke oppskrifter hvert punkt kommer fra.
+                Handlelisten kombinerer deterministisk genererte ingredienser fra ukeplanen med manuelle
+                varelinjer. Avkryssing, notater, handledato og butikkvalg lagres pa serveren.
               </p>
             </div>
 
@@ -98,13 +333,27 @@ export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPl
           </div>
         </section>
 
-        <section className="grid gap-4 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">Kunne ikke oppdatere handlelisten</h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Projeksjon</h2>
+              <h2 className="text-lg font-semibold text-slate-950">Oversikt</h2>
               <p className="text-sm leading-6 text-slate-600">
                 Listen dekker perioden {formatMealPlanWindow(loaderData.mealPlan.startDate, loaderData.mealPlan.endDate)}
-                {" "}og inneholder {loaderData.projectedItemCount} genererte varelinjer.
+                {" "}og inneholder {loaderData.itemCounts.total} varelinjer totalt.
               </p>
             </div>
 
@@ -113,6 +362,13 @@ export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPl
                 <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Status</dt>
                 <dd className="mt-2 text-base font-semibold text-slate-950">
                   {loaderData.mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+                </dd>
+              </div>
+
+              <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Varelinjer</dt>
+                <dd className="mt-2 text-sm leading-6 text-slate-700">
+                  {loaderData.itemCounts.generated} genererte og {loaderData.itemCounts.manual} manuelle linjer.
                 </dd>
               </div>
 
@@ -127,13 +383,132 @@ export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPl
 
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Hvordan dette bygges</h2>
+              <h2 className="text-lg font-semibold text-slate-950">Legg til manuell varelinje</h2>
               <p className="text-sm leading-6 text-slate-600">
-                Hvert punkt er laget fra lagrede oppskriftsingredienser pa serveren. Like ingredienser blir
-                bare slaatt sammen nar navn, mengde, enhet, kategori og foretrukket butikk matcher eksakt.
+                Bruk dette for varer som ikke kommer direkte fra oppskriftene, men som skal med i samme
+                handleliste og sortering.
               </p>
             </div>
+
+            <Form className="mt-6 space-y-4" method="post">
+              <input name="intent" type="hidden" value="add-manual-shopping-item" />
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="block text-sm font-medium text-slate-700">
+                  Varenavn
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={addManualValues.name}
+                    name="name"
+                    type="text"
+                  />
+                </label>
+
+                <label className="block text-sm font-medium text-slate-700">
+                  Mengde
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={addManualValues.quantity}
+                    name="quantity"
+                    placeholder="F.eks. 2 poser"
+                    type="text"
+                  />
+                </label>
+              </div>
+
+              {actionData?.intent === "add-manual-shopping-item" && actionData.manualFieldErrors?.name ? (
+                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.name}</p>
+              ) : null}
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                <label className="block text-sm font-medium text-slate-700">
+                  Kategori
+                  <select
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={addManualValues.categoryId}
+                    name="categoryId"
+                  >
+                    <option value="">Velg kategori</option>
+                    {loaderData.categories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block text-sm font-medium text-slate-700">
+                  Foretrukket butikk
+                  <select
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={addManualValues.preferredStoreId}
+                    name="preferredStoreId"
+                  >
+                    <option value="">Ingen valgt butikk</option>
+                    {loaderData.stores.map((store) => (
+                      <option key={store.id} value={store.id}>
+                        {store.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block text-sm font-medium text-slate-700">
+                  Handledato
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={addManualValues.buyOnDate}
+                    max={loaderData.mealPlan.endDate}
+                    min={loaderData.mealPlan.startDate}
+                    name="buyOnDate"
+                    type="date"
+                  />
+                </label>
+              </div>
+
+              {actionData?.intent === "add-manual-shopping-item" && actionData.manualFieldErrors?.categoryId ? (
+                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.categoryId}</p>
+              ) : null}
+              {actionData?.intent === "add-manual-shopping-item" &&
+              actionData.manualFieldErrors?.preferredStoreId ? (
+                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.preferredStoreId}</p>
+              ) : null}
+              {actionData?.intent === "add-manual-shopping-item" && actionData.manualFieldErrors?.buyOnDate ? (
+                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.buyOnDate}</p>
+              ) : null}
+
+              <label className="block text-sm font-medium text-slate-700">
+                Notat
+                <textarea
+                  className="mt-2 min-h-28 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={addManualValues.note}
+                  name="note"
+                  placeholder="F.eks. husk kampanjepris eller at varen skal kjopes senere i uken"
+                />
+              </label>
+
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={navigation.state === "submitting" && pendingIntent === "add-manual-shopping-item"}
+                type="submit"
+              >
+                {navigation.state === "submitting" && pendingIntent === "add-manual-shopping-item"
+                  ? "Legger til..."
+                  : "Legg til varelinje"}
+              </button>
+            </Form>
           </article>
+        </section>
+
+        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <div className="flex flex-col gap-2">
+            <h2 className="text-lg font-semibold text-slate-950">Hvordan dette bygges</h2>
+            <p className="text-sm leading-6 text-slate-600">
+              Genererte linjer bygger pa lagrede oppskriftsingredienser. Like ingredienser slas bare sammen
+              nar navn, mengde, enhet, kategori og foretrukket butikk matcher eksakt. Manuelle linjer blir
+              lagt oppa samme sortering uten a endre den deterministiske projeksjonen.
+            </p>
+          </div>
         </section>
 
         {loaderData.storeGroups.length ? (
@@ -162,56 +537,351 @@ export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPl
                       </h3>
 
                       <div className="mt-3 grid gap-3">
-                        {section.items.map((item) => (
-                          <article
-                            key={item.sourceKey}
-                            className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
-                          >
-                            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                              <div>
-                                <div className="flex flex-wrap items-center gap-2">
-                                  <h4 className="text-base font-semibold text-slate-950">{item.name}</h4>
-                                  {item.quantityLabel ? (
-                                    <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
-                                      {item.quantityLabel}
-                                    </span>
-                                  ) : null}
-                                  {item.checked ? (
-                                    <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
-                                      Avkrysset
-                                    </span>
-                                  ) : null}
-                                  {item.postponedUntilDate ? (
-                                    <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
-                                      Utsatt til {formatDateLabel(item.postponedUntilDate)}
-                                    </span>
-                                  ) : null}
-                                </div>
+                        {section.items.map((item) => {
+                          const isPendingCheckToggle =
+                            navigation.state === "submitting" &&
+                            pendingIntent === "toggle-shopping-item-checked" &&
+                            pendingSourceKey === item.sourceKey;
+                          const isPendingManualSave =
+                            navigation.state === "submitting" &&
+                            pendingIntent === "update-manual-shopping-item" &&
+                            pendingSourceKey === item.sourceKey;
+                          const isPendingManualDelete =
+                            navigation.state === "submitting" &&
+                            pendingIntent === "delete-manual-shopping-item" &&
+                            pendingSourceKey === item.sourceKey;
+                          const isPendingGeneratedSave =
+                            navigation.state === "submitting" &&
+                            pendingIntent === "update-generated-shopping-item" &&
+                            pendingSourceKey === item.sourceKey;
+                          const manualValues =
+                            actionData?.intent === "update-manual-shopping-item" &&
+                            actionData.itemTarget?.sourceKey === item.sourceKey &&
+                            actionData.manualValues
+                              ? actionData.manualValues
+                              : item.sourceType === "MANUAL"
+                                ? {
+                                    buyOnDate: item.buyOnDate ?? "",
+                                    categoryId: item.category.id,
+                                    name: item.name,
+                                    note: item.note ?? "",
+                                    preferredStoreId: item.preferredStore?.id ?? "",
+                                    quantity: item.quantity ?? "",
+                                  }
+                                : null;
+                          const overrideValues =
+                            actionData?.intent === "update-generated-shopping-item" &&
+                            actionData.itemTarget?.sourceKey === item.sourceKey &&
+                            actionData.overrideValues
+                              ? actionData.overrideValues
+                              : item.sourceType === "GENERATED"
+                                ? {
+                                    note: item.note ?? "",
+                                    postponedUntilDate: item.postponedUntilDate ?? "",
+                                    preferredStoreId: item.preferredStore?.id ?? "",
+                                  }
+                                : null;
 
-                                <p className="mt-3 text-sm leading-6 text-slate-600">
-                                  Fra {item.occurrenceCount} planlagte {item.occurrenceCount === 1 ? "middag" : "middager"}
-                                  {" "}mellom {formatDateLabel(item.firstDate)} og {formatDateLabel(item.lastDate)}.
-                                </p>
-                                {item.note ? (
-                                  <p className="mt-2 text-sm leading-6 text-slate-700">Notat: {item.note}</p>
+                          return (
+                            <article
+                              key={item.sourceKey}
+                              className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                            >
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="text-base font-semibold text-slate-950">{item.name}</h4>
+                                {item.quantityLabel ? (
+                                  <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                                    {item.quantityLabel}
+                                  </span>
+                                ) : null}
+                                {item.sourceType === "MANUAL" ? (
+                                  <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">
+                                    Manuell
+                                  </span>
+                                ) : null}
+                                {item.checked ? (
+                                  <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
+                                    Avkrysset
+                                  </span>
+                                ) : null}
+                                {item.sourceType === "GENERATED" && item.postponedUntilDate ? (
+                                  <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+                                    Utsatt til {formatDateLabel(item.postponedUntilDate)}
+                                  </span>
+                                ) : null}
+                                {item.sourceType === "MANUAL" && item.buyOnDate ? (
+                                  <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+                                    Kjopes {formatDateLabel(item.buyOnDate)}
+                                  </span>
                                 ) : null}
                               </div>
 
-                              <div className="rounded-[20px] bg-white p-4 ring-1 ring-slate-200 md:max-w-sm">
-                                <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
-                                  Kilder
-                                </p>
-                                <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
-                                  {item.occurrences.map((occurrence) => (
-                                    <li key={`${occurrence.mealPlanEntryId}:${occurrence.recipeIngredientId}`}>
-                                      {formatDateLabel(occurrence.date)}: {occurrence.recipeTitle}
-                                    </li>
-                                  ))}
-                                </ul>
+                              <p className="mt-3 text-sm leading-6 text-slate-600">
+                                {item.sourceType === "GENERATED"
+                                  ? `Fra ${item.occurrenceCount} planlagte ${
+                                      item.occurrenceCount === 1 ? "middag" : "middager"
+                                    } mellom ${formatDateLabel(item.firstDate)} og ${formatDateLabel(item.lastDate)}.`
+                                  : item.buyOnDate
+                                    ? `Lagt til manuelt og planlagt for ${formatDateLabel(item.buyOnDate)}.`
+                                    : "Lagt til manuelt uten spesifikk handledato."}
+                              </p>
+                              {item.note ? (
+                                <p className="mt-2 text-sm leading-6 text-slate-700">Notat: {item.note}</p>
+                              ) : null}
+
+                              <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+                                <div className="rounded-[20px] bg-white p-4 ring-1 ring-slate-200">
+                                  {item.sourceType === "GENERATED" ? (
+                                    <>
+                                      <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                                        Kilder
+                                      </p>
+                                      <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
+                                        {item.occurrences.map((occurrence) => (
+                                          <li key={`${occurrence.mealPlanEntryId}:${occurrence.recipeIngredientId}`}>
+                                            {formatDateLabel(occurrence.date)}: {occurrence.recipeTitle}
+                                          </li>
+                                        ))}
+                                      </ul>
+                                    </>
+                                  ) : (
+                                    <>
+                                      <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                                        Manuell rad
+                                      </p>
+                                      <p className="mt-3 text-sm leading-6 text-slate-700">
+                                        Denne varelinjen kommer ikke fra en oppskrift og kan redigeres eller slettes
+                                        direkte her.
+                                      </p>
+                                    </>
+                                  )}
+                                </div>
+
+                                <div className="grid gap-3">
+                                  <Form method="post">
+                                    <input name="intent" type="hidden" value="toggle-shopping-item-checked" />
+                                    <input name="sourceKey" type="hidden" value={item.sourceKey} />
+                                    <input name="sourceType" type="hidden" value={item.sourceType} />
+                                    <input name="checked" type="hidden" value={item.checked ? "false" : "true"} />
+                                    <button
+                                      className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                                      disabled={isPendingCheckToggle}
+                                      type="submit"
+                                    >
+                                      {isPendingCheckToggle
+                                        ? item.checked
+                                          ? "Oppdaterer..."
+                                          : "Krysser av..."
+                                        : item.checked
+                                          ? "Fjern avkryssing"
+                                          : "Marker som kjopt"}
+                                    </button>
+                                  </Form>
+
+                                  {item.sourceType === "GENERATED" && overrideValues ? (
+                                    <Form className="grid gap-3" method="post">
+                                      <input name="intent" type="hidden" value="update-generated-shopping-item" />
+                                      <input name="sourceKey" type="hidden" value={item.sourceKey} />
+
+                                      <label className="block text-sm font-medium text-slate-700">
+                                        Foretrukket butikk
+                                        <select
+                                          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                          defaultValue={overrideValues.preferredStoreId}
+                                          name="preferredStoreId"
+                                        >
+                                          <option value="">Ingen valgt butikk</option>
+                                          {loaderData.stores.map((store) => (
+                                            <option key={store.id} value={store.id}>
+                                              {store.name}
+                                            </option>
+                                          ))}
+                                        </select>
+                                      </label>
+
+                                      <label className="block text-sm font-medium text-slate-700">
+                                        Utsatt til
+                                        <input
+                                          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                          defaultValue={overrideValues.postponedUntilDate}
+                                          max={loaderData.mealPlan.endDate}
+                                          min={loaderData.mealPlan.startDate}
+                                          name="postponedUntilDate"
+                                          type="date"
+                                        />
+                                      </label>
+
+                                      <label className="block text-sm font-medium text-slate-700">
+                                        Notat
+                                        <textarea
+                                          className="mt-2 min-h-24 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                          defaultValue={overrideValues.note}
+                                          name="note"
+                                        />
+                                      </label>
+
+                                      {actionData?.intent === "update-generated-shopping-item" &&
+                                      actionData.itemTarget?.sourceKey === item.sourceKey &&
+                                      actionData.generatedOverrideFieldErrors?.preferredStoreId ? (
+                                        <p className="text-sm text-rose-600">
+                                          {actionData.generatedOverrideFieldErrors.preferredStoreId}
+                                        </p>
+                                      ) : null}
+                                      {actionData?.intent === "update-generated-shopping-item" &&
+                                      actionData.itemTarget?.sourceKey === item.sourceKey &&
+                                      actionData.generatedOverrideFieldErrors?.postponedUntilDate ? (
+                                        <p className="text-sm text-rose-600">
+                                          {actionData.generatedOverrideFieldErrors.postponedUntilDate}
+                                        </p>
+                                      ) : null}
+
+                                      <button
+                                        className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+                                        disabled={isPendingGeneratedSave}
+                                        type="submit"
+                                      >
+                                        {isPendingGeneratedSave ? "Lagrer tilpasninger..." : "Lagre tilpasninger"}
+                                      </button>
+                                    </Form>
+                                  ) : null}
+
+                                  {item.sourceType === "MANUAL" && manualValues ? (
+                                    <>
+                                      <Form className="grid gap-3" method="post">
+                                        <input name="intent" type="hidden" value="update-manual-shopping-item" />
+                                        <input name="manualItemId" type="hidden" value={item.sourceKey} />
+
+                                        <label className="block text-sm font-medium text-slate-700">
+                                          Varenavn
+                                          <input
+                                            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                            defaultValue={manualValues.name}
+                                            name="name"
+                                            type="text"
+                                          />
+                                        </label>
+
+                                        <div className="grid gap-3 sm:grid-cols-2">
+                                          <label className="block text-sm font-medium text-slate-700">
+                                            Mengde
+                                            <input
+                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                              defaultValue={manualValues.quantity}
+                                              name="quantity"
+                                              type="text"
+                                            />
+                                          </label>
+
+                                          <label className="block text-sm font-medium text-slate-700">
+                                            Handledato
+                                            <input
+                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                              defaultValue={manualValues.buyOnDate}
+                                              max={loaderData.mealPlan.endDate}
+                                              min={loaderData.mealPlan.startDate}
+                                              name="buyOnDate"
+                                              type="date"
+                                            />
+                                          </label>
+                                        </div>
+
+                                        <div className="grid gap-3 sm:grid-cols-2">
+                                          <label className="block text-sm font-medium text-slate-700">
+                                            Kategori
+                                            <select
+                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                              defaultValue={manualValues.categoryId}
+                                              name="categoryId"
+                                            >
+                                              <option value="">Velg kategori</option>
+                                              {loaderData.categories.map((category) => (
+                                                <option key={category.id} value={category.id}>
+                                                  {category.displayName}
+                                                </option>
+                                              ))}
+                                            </select>
+                                          </label>
+
+                                          <label className="block text-sm font-medium text-slate-700">
+                                            Foretrukket butikk
+                                            <select
+                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                              defaultValue={manualValues.preferredStoreId}
+                                              name="preferredStoreId"
+                                            >
+                                              <option value="">Ingen valgt butikk</option>
+                                              {loaderData.stores.map((store) => (
+                                                <option key={store.id} value={store.id}>
+                                                  {store.name}
+                                                </option>
+                                              ))}
+                                            </select>
+                                          </label>
+                                        </div>
+
+                                        <label className="block text-sm font-medium text-slate-700">
+                                          Notat
+                                          <textarea
+                                            className="mt-2 min-h-24 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                                            defaultValue={manualValues.note}
+                                            name="note"
+                                          />
+                                        </label>
+
+                                        {actionData?.intent === "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
+                                        actionData.manualFieldErrors?.name ? (
+                                          <p className="text-sm text-rose-600">{actionData.manualFieldErrors.name}</p>
+                                        ) : null}
+                                        {actionData?.intent === "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
+                                        actionData.manualFieldErrors?.categoryId ? (
+                                          <p className="text-sm text-rose-600">
+                                            {actionData.manualFieldErrors.categoryId}
+                                          </p>
+                                        ) : null}
+                                        {actionData?.intent === "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
+                                        actionData.manualFieldErrors?.preferredStoreId ? (
+                                          <p className="text-sm text-rose-600">
+                                            {actionData.manualFieldErrors.preferredStoreId}
+                                          </p>
+                                        ) : null}
+                                        {actionData?.intent === "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
+                                        actionData.manualFieldErrors?.buyOnDate ? (
+                                          <p className="text-sm text-rose-600">
+                                            {actionData.manualFieldErrors.buyOnDate}
+                                          </p>
+                                        ) : null}
+
+                                        <button
+                                          className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+                                          disabled={isPendingManualSave}
+                                          type="submit"
+                                        >
+                                          {isPendingManualSave ? "Lagrer varelinje..." : "Lagre varelinje"}
+                                        </button>
+                                      </Form>
+
+                                      <Form method="post">
+                                        <input name="intent" type="hidden" value="delete-manual-shopping-item" />
+                                        <input name="manualItemId" type="hidden" value={item.sourceKey} />
+                                        <button
+                                          className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
+                                          disabled={isPendingManualDelete}
+                                          type="submit"
+                                        >
+                                          {isPendingManualDelete ? "Sletter varelinje..." : "Slett varelinje"}
+                                        </button>
+                                      </Form>
+                                    </>
+                                  ) : null}
+                                </div>
                               </div>
-                            </div>
-                          </article>
-                        ))}
+                            </article>
+                          );
+                        })}
                       </div>
                     </section>
                   ))}
@@ -223,7 +893,7 @@ export default function FamilyMealPlanShoppingRoute({ loaderData }: FamilyMealPl
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <h2 className="text-lg font-semibold text-slate-950">Ingen varer ennå</h2>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-              Legg til middager i ukeplanen for a generere handlelisten pa serveren.
+              Legg til middager i ukeplanen eller opprett en manuell varelinje for a starte handlelisten.
             </p>
           </section>
         )}
@@ -262,6 +932,13 @@ export function ErrorBoundary({ error }: { error: unknown }) {
   );
 }
 
+function buildMealPlanNotFoundResponse() {
+  return new Response("Fant ikke ukeplanen.", {
+    status: 404,
+    statusText: "Not Found",
+  });
+}
+
 function requireRouteParam(value: string | undefined, message: string) {
   if (!value) {
     throw new Response(message, {
@@ -271,6 +948,138 @@ function requireRouteParam(value: string | undefined, message: string) {
   }
 
   return value;
+}
+
+function serializeProjectedShoppingItem(
+  item: Awaited<ReturnType<typeof getMealPlanShoppingData>>["projectedItems"][number],
+) {
+  if (item.sourceType === ShoppingItemSource.GENERATED) {
+    return {
+      ...item,
+      firstDate: formatDateOnly(item.firstDate),
+      lastDate: formatDateOnly(item.lastDate),
+      occurrences: item.occurrences.map((occurrence) => ({
+        ...occurrence,
+        date: formatDateOnly(occurrence.date),
+      })),
+      postponedUntilDate: item.postponedUntilDate ? formatDateOnly(item.postponedUntilDate) : null,
+    };
+  }
+
+  return {
+    ...item,
+    buyOnDate: item.buyOnDate ? formatDateOnly(item.buyOnDate) : null,
+  };
+}
+
+function parseManualShoppingItemValues(formData: FormData): ManualShoppingItemValues {
+  return {
+    buyOnDate: String(formData.get("buyOnDate") ?? ""),
+    categoryId: String(formData.get("categoryId") ?? ""),
+    name: String(formData.get("name") ?? ""),
+    note: String(formData.get("note") ?? ""),
+    preferredStoreId: String(formData.get("preferredStoreId") ?? ""),
+    quantity: String(formData.get("quantity") ?? ""),
+  };
+}
+
+function parseGeneratedShoppingItemOverrideValues(formData: FormData): GeneratedShoppingItemOverrideValues {
+  return {
+    note: String(formData.get("note") ?? ""),
+    postponedUntilDate: String(formData.get("postponedUntilDate") ?? ""),
+    preferredStoreId: String(formData.get("preferredStoreId") ?? ""),
+  };
+}
+
+function parseShoppingItemSource(value: FormDataEntryValue | null) {
+  if (value === ShoppingItemSource.GENERATED || value === ShoppingItemSource.MANUAL) {
+    return value;
+  }
+
+  return null;
+}
+
+function getPendingSourceKey(formData: FormData | undefined) {
+  if (!formData) {
+    return null;
+  }
+
+  const sourceKey = formData.get("sourceKey");
+
+  if (typeof sourceKey === "string" && sourceKey.trim()) {
+    return sourceKey;
+  }
+
+  const manualItemId = formData.get("manualItemId");
+
+  if (typeof manualItemId === "string" && manualItemId.trim()) {
+    return manualItemId;
+  }
+
+  return null;
+}
+
+function getShoppingNotice(request: Request): ShoppingNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (
+    notice === "generated-shopping-item-updated" ||
+    notice === "manual-shopping-item-added" ||
+    notice === "manual-shopping-item-deleted" ||
+    notice === "manual-shopping-item-updated" ||
+    notice === "shopping-item-check-state-updated"
+  ) {
+    return notice;
+  }
+
+  return null;
+}
+
+function buildShoppingRedirect({
+  familyId,
+  mealPlanId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  notice: ShoppingNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/meal-plans/${mealPlanId}/shopping`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function getShoppingNoticeContent(notice: ShoppingNotice) {
+  switch (notice) {
+    case "manual-shopping-item-added":
+      return {
+        description: "Den manuelle varelinjen ble lagt til i handlelisten og sortert sammen med de andre varene.",
+        title: "Varelinje lagt til",
+      };
+    case "manual-shopping-item-updated":
+      return {
+        description: "Endringene i den manuelle varelinjen ble lagret.",
+        title: "Varelinje oppdatert",
+      };
+    case "manual-shopping-item-deleted":
+      return {
+        description: "Den manuelle varelinjen og eventuell avkryssing ble fjernet fra handlelisten.",
+        title: "Varelinje slettet",
+      };
+    case "generated-shopping-item-updated":
+      return {
+        description: "Butikkvalg, notat og handledato for den genererte varelinjen ble lagret.",
+        title: "Tilpasninger lagret",
+      };
+    case "shopping-item-check-state-updated":
+      return {
+        description: "Avkryssingen for varelinjen ble oppdatert.",
+        title: "Handleliste oppdatert",
+      };
+  }
 }
 
 function formatDateOnly(date: Date) {
@@ -285,6 +1094,7 @@ function formatDateLabel(value: string) {
   return new Intl.DateTimeFormat("nb-NO", {
     day: "numeric",
     month: "long",
+    timeZone: "UTC",
   }).format(new Date(`${value}T00:00:00.000Z`));
 }
 


### PR DESCRIPTION
## Summary
- merge generated shopping projections with manual meal-plan shopping items, categories, stores, and grouped counts in the server read model
- add validated shopping write helpers for manual item CRUD, generated override persistence, checked-state updates, and manual override cleanup
- upgrade the shopping route to support manual item forms, generated item override editing, notices, and focused route coverage

## Test plan
- [x] `npm run test:run -- app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-meal-plan-shopping.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [ ] Manual browser smoke test of `/families/:familyId/meal-plans/:mealPlanId/shopping`

Closes #12