### PR TITLE
Add store mode and family store management

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,41 @@
 
 ## Current Objective
 
-Implement issue `#12`'s persisted shopping interactions so meal-plan shopping lists can mix deterministic generated items with manual rows and saved user state.
+Implement issue `#13`'s store configuration and in-store shopping flow: family store CRUD, persisted active shopping date, persisted per-user selected store, and a compact mobile-first store mode route.
 
 ## Completed
 
-- Expanded `app/lib/shopping.server.ts` so the shopping read model now loads manual shopping items, all shopping overrides, available categories/stores, merged item counts, and a discriminated generated/manual projection grouped by store and section.
-- Added `app/lib/shopping-write.server.ts` with validated manual item create/update/delete flows, generated override updates, checked-state persistence, and transactional cleanup of manual override rows.
-- Reworked `app/routes/family-meal-plan-shopping.tsx` from a loader-only page into a multi-intent shopping route with add/edit/delete forms for manual rows, generated-item override controls, checked toggles, notices, and serialized loader data for both item types.
-- Expanded focused coverage in `app/lib/shopping.server.test.ts`, `app/lib/shopping-write.server.test.ts`, and `app/routes/family-meal-plan-shopping.test.ts` for merged projection, write-path validation, override behavior, cleanup, redirects, and route action payloads.
+- Extended `prisma/schema.prisma` with `MealPlan.activeShoppingDate` and a new `UserStorePreference` model, plus a matching migration in `prisma/migrations/20260514184500_store_mode_preferences/migration.sql`.
+- Added `app/lib/store.server.ts` and `app/lib/store-write.server.ts` for scoped store reads plus family store create/update/reorder/delete and per-user selected-store persistence.
+- Expanded `app/lib/shopping.server.ts` with `getMealPlanStoreModeData()` so store mode reuses the merged shopping projection but filters to due items by active shopping date and re-groups them using the selected store's section order.
+- Added `updateActiveShoppingDate()` to `app/lib/shopping-write.server.ts` and updated `app/lib/meal-plan.server.ts` so new meal plans start with a valid active shopping date and range edits clamp it safely.
+- Added `app/routes/family-stores.tsx` plus `app/components/family-store-editor-card.tsx` so family stores now use an explicit edit mode with staged React DnD section ordering and a single save instead of per-move server round-trips, then wired the new flow into the existing store CRUD route.
+- Added `app/routes/family-meal-plan-store-mode.tsx` for the mobile shopping flow, then wired navigation in `app/routes.ts`, `app/routes/family.tsx`, `app/routes/family-meal-plan.tsx`, and `app/routes/family-meal-plan-shopping.tsx`.
+- Added focused coverage in `app/lib/store-write.server.test.ts`, `app/lib/shopping.server.test.ts`, `app/lib/shopping-write.server.test.ts`, `app/routes/family-stores.test.ts`, and `app/routes/family-meal-plan-store-mode.test.ts`, plus updated existing meal-plan/shopping route tests for serialized `activeShoppingDate`.
 
 ## Files To Read First
 
-- `app/lib/shopping.server.ts` - Combined generated/manual shopping read model, grouping, counts, and projected item types.
-- `app/lib/shopping-write.server.ts` - Validated shopping mutations for manual rows and generated/manual persisted state.
-- `app/routes/family-meal-plan-shopping.tsx` - Loader/action route, notice flow, and all shopping forms and controls.
-- `app/lib/shopping-write.server.test.ts` - Focused write-path coverage for validation, cleanup, and override persistence rules.
+- `app/lib/store-write.server.ts` - Family store CRUD rules, section reorder behavior, and selected-store persistence.
+- `app/components/family-store-editor-card.tsx` - Local edit mode, staged section drafts, and React DnD row reordering before save.
+- `app/lib/shopping.server.ts` - Shared shopping projection plus the new store-mode view model.
+- `app/routes/family-stores.tsx` - Store management route, action intents, and editable family-store UI.
+- `app/routes/family-meal-plan-store-mode.tsx` - Compact in-store shopping route, serialized loader data, and action handling.
 
 ## Validation
 
-- `npm run test:run -- app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-meal-plan-shopping.test.ts`
+- `npm run test:run -- app/lib/store-write.server.test.ts app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-stores.test.ts app/routes/family-meal-plan-store-mode.test.ts app/routes/family-meal-plan-shopping.test.ts app/routes/family-meal-plan.test.ts app/routes/family-meal-plans.test.ts`
+- `npm run test:run` (all tests passed except the two existing `crypto is not defined` failures in `app/lib/session.server.test.ts` and `app/lib/auth.server.test.ts`)
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
-- No manual browser smoke test has been run yet for `families/:familyId/meal-plans/:mealPlanId/shopping`.
-- Generated source keys are still only stable for the same merged occurrence set, so recipe or meal-plan changes that alter a merge bucket will naturally stop matching any existing generated override row for that bucket.
-- Generated override writes currently trust the posted `sourceKey`; the UI only submits live keys, but there is no extra server-side verification that a generated key still exists in the current projection before persisting an override.
-- The route now supports full-page form submissions only; there is still no fetcher-based or mobile store-mode shopping UX.
+- No manual browser smoke test has been run yet for `families/:familyId/stores` or `families/:familyId/meal-plans/:mealPlanId/store-mode`.
+- The new store editor uses the HTML5 React DnD backend, so drag-and-drop should be manually verified in the browser environment you care about most.
+- `npm run typecheck` currently fails before project checks run because the local Node runtime is `v18.20.8` while the installed React Router toolchain now expects `>20`; plain `tsc --noEmit` succeeds.
+- The only remaining automated test failures are pre-existing environment/runtime issues where React Router cookie/session helpers expect `crypto.subtle` during `app/lib/session.server.test.ts` and `app/lib/auth.server.test.ts`.
+- Family store creation currently starts from the full category list ordered by category display name. There is no "copy from seeded store" shortcut yet.
+- Seeded/global stores remain visible alongside family stores in selectors and management views; there is no hide/archive behavior for seeded stores.
 
 ## Next Step
 
-Run a manual end-to-end smoke test of the shopping route with both generated and manual rows, especially add/edit/delete, checked toggles, and generated override persistence across a refresh.
+Run a manual end-to-end smoke test covering store creation/reordering/deletion and the new store-mode flow, then rerun `npm run typecheck` in a Node `>20` environment to confirm the full React Router/typegen pipeline.

--- a/app/components/family-store-editor-card.tsx
+++ b/app/components/family-store-editor-card.tsx
@@ -1,0 +1,382 @@
+import { useDrag, useDrop } from "react-dnd";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Form, useNavigation } from "react-router";
+
+import type {
+  FamilyStoreFieldErrors,
+  FamilyStoreValues,
+} from "../lib/store-write.server";
+
+const STORE_SECTION_ITEM_TYPE = "family-store-section";
+
+interface FamilyStoreSection {
+  categoryId: string;
+  displayName: string;
+  id: string;
+}
+
+interface FamilyStoreEditorCardProps {
+  canManageStores: boolean;
+  store: {
+    id: string;
+    name: string;
+    sections: FamilyStoreSection[];
+  };
+  updateFieldErrors?: FamilyStoreFieldErrors;
+  updateValues?: FamilyStoreValues;
+}
+
+interface DragItem {
+  index: number;
+  type: typeof STORE_SECTION_ITEM_TYPE;
+}
+
+export function FamilyStoreEditorCard({
+  canManageStores,
+  store,
+  updateFieldErrors,
+  updateValues,
+}: FamilyStoreEditorCardProps) {
+  const navigation = useNavigation();
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingStoreId = String(navigation.formData?.get("storeId") ?? "");
+  const isUpdatingStore =
+    navigation.state === "submitting" &&
+    pendingIntent === "update-store" &&
+    pendingStoreId === store.id;
+  const isDeletingStore =
+    navigation.state === "submitting" &&
+    pendingIntent === "delete-store" &&
+    pendingStoreId === store.id;
+  const persistedValues = useMemo<FamilyStoreValues>(
+    () => ({
+      name: store.name,
+      sections: store.sections.map((section) => ({
+        categoryId: section.categoryId,
+        displayName: section.displayName,
+      })),
+    }),
+    [store.name, store.sections],
+  );
+  const [ignoreSubmittedValues, setIgnoreSubmittedValues] = useState(false);
+  const sourceValues =
+    updateValues && !ignoreSubmittedValues ? updateValues : persistedValues;
+  const sourceKey = JSON.stringify(sourceValues);
+  const [draftName, setDraftName] = useState(sourceValues.name);
+  const [draftSections, setDraftSections] = useState<FamilyStoreSection[]>(
+    toDraftSections(store.sections, sourceValues.sections),
+  );
+  const [isEditing, setIsEditing] = useState(Boolean(updateValues));
+
+  useEffect(() => {
+    if (updateValues) {
+      setIgnoreSubmittedValues(false);
+    }
+  }, [updateValues]);
+
+  useEffect(() => {
+    setDraftName(sourceValues.name);
+    setDraftSections(toDraftSections(store.sections, sourceValues.sections));
+    setIsEditing(Boolean(updateValues && !ignoreSubmittedValues));
+  }, [ignoreSubmittedValues, sourceKey, store.sections, updateValues]);
+
+  function handleSectionDisplayNameChange(
+    categoryId: string,
+    displayName: string,
+  ) {
+    setDraftSections((current) =>
+      current.map((section) =>
+        section.categoryId === categoryId
+          ? {
+              ...section,
+              displayName,
+            }
+          : section,
+      ),
+    );
+  }
+
+  function moveSection(fromIndex: number, toIndex: number) {
+    setDraftSections((current) => {
+      const next = [...current];
+      const [movedSection] = next.splice(fromIndex, 1);
+
+      if (!movedSection) {
+        return current;
+      }
+
+      next.splice(toIndex, 0, movedSection);
+      return next;
+    });
+  }
+
+  function handleStartEditing() {
+    setIgnoreSubmittedValues(false);
+    setDraftName(persistedValues.name);
+    setDraftSections(toDraftSections(store.sections, persistedValues.sections));
+    setIsEditing(true);
+  }
+
+  function handleCancelEditing() {
+    setIgnoreSubmittedValues(true);
+    setDraftName(persistedValues.name);
+    setDraftSections(toDraftSections(store.sections, persistedValues.sections));
+    setIsEditing(false);
+  }
+
+  return (
+    <article className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-slate-950">
+            {store.name}
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            {isEditing
+              ? "Dra og slipp seksjonene i den rekkefolgen dere faktisk gar gjennom butikken, og lagre nar alt ser riktig ut."
+              : "Aapne redigering for a endre navn, seksjonsnavn og rekkefolge i en samlet lagring."}
+          </p>
+        </div>
+
+        {canManageStores && !isEditing ? (
+          <button
+            className="rounded-2xl bg-slate-950 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-slate-800"
+            onClick={handleStartEditing}
+            type="button"
+          >
+            Rediger
+          </button>
+        ) : null}
+      </div>
+
+      {isEditing ? (
+        <Form className="mt-6 space-y-4" method="post">
+          <input name="intent" type="hidden" value="update-store" />
+          <input name="storeId" type="hidden" value={store.id} />
+
+          <label className="block text-sm font-medium text-slate-700">
+            Butikknavn
+            <input
+              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+              name="name"
+              onChange={(event) => setDraftName(event.target.value)}
+              type="text"
+              value={draftName}
+            />
+          </label>
+          {updateFieldErrors?.name ? (
+            <p className="text-sm text-rose-600">{updateFieldErrors.name}</p>
+          ) : null}
+
+          <div className="space-y-3">
+            {draftSections.map((section, index) => (
+              <StoreSectionEditorRow
+                index={index}
+                isEditing={isEditing}
+                key={`${store.id}:${section.categoryId}`}
+                onDisplayNameChange={handleSectionDisplayNameChange}
+                onMove={moveSection}
+                section={section}
+                validationError={
+                  updateFieldErrors?.sectionDisplayNames?.[section.categoryId]
+                }
+              />
+            ))}
+          </div>
+
+          {updateFieldErrors?.sections ? (
+            <p className="text-sm text-rose-600">
+              {updateFieldErrors.sections}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              className="inline-flex flex-1 items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+              disabled={isUpdatingStore}
+              type="submit"
+            >
+              {isUpdatingStore ? "Lagrer..." : "Lagre endringer"}
+            </button>
+            <button
+              className="inline-flex flex-1 items-center justify-center rounded-2xl bg-white px-5 py-3 text-sm font-medium text-slate-700 ring-1 ring-slate-300 transition hover:bg-slate-50"
+              onClick={handleCancelEditing}
+              type="button"
+            >
+              Avbryt
+            </button>
+          </div>
+        </Form>
+      ) : (
+        <div className="mt-6 grid gap-3">
+          {store.sections.map((section, index) => (
+            <div
+              className="flex items-center justify-between rounded-[20px] border border-slate-200 bg-white px-4 py-3"
+              key={`${store.id}:${section.id}:summary`}
+            >
+              <div>
+                <p className="text-sm text-slate-500">Plass {index + 1}</p>
+                <p className="font-medium text-slate-900">
+                  {section.displayName}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {canManageStores && !isEditing ? (
+        <div className="mt-4">
+          <Form method="post">
+            <input name="intent" type="hidden" value="delete-store" />
+            <input name="storeId" type="hidden" value={store.id} />
+            <button
+              className="inline-flex w-full items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+              disabled={isDeletingStore}
+              type="submit"
+            >
+              {isDeletingStore ? "Sletter..." : "Slett butikk"}
+            </button>
+          </Form>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function StoreSectionEditorRow({
+  index,
+  isEditing,
+  onDisplayNameChange,
+  onMove,
+  section,
+  validationError,
+}: {
+  index: number;
+  isEditing: boolean;
+  onDisplayNameChange: (categoryId: string, displayName: string) => void;
+  onMove: (fromIndex: number, toIndex: number) => void;
+  section: FamilyStoreSection;
+  validationError?: string;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [{ isDragging }, drag] = useDrag(
+    () => ({
+      canDrag: isEditing,
+      collect: (monitor) => ({
+        isDragging: monitor.isDragging(),
+      }),
+      item: {
+        index,
+        type: STORE_SECTION_ITEM_TYPE,
+      } satisfies DragItem,
+      type: STORE_SECTION_ITEM_TYPE,
+    }),
+    [index, isEditing],
+  );
+  const [, drop] = useDrop<DragItem>(
+    () => ({
+      accept: STORE_SECTION_ITEM_TYPE,
+      hover: (dragItem, monitor) => {
+        if (!ref.current) {
+          return;
+        }
+
+        const dragIndex = dragItem.index;
+        const hoverIndex = index;
+
+        if (dragIndex === hoverIndex) {
+          return;
+        }
+
+        const hoverBoundingRect = ref.current.getBoundingClientRect();
+        const hoverMiddleY =
+          (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+        const clientOffset = monitor.getClientOffset();
+
+        if (!clientOffset) {
+          return;
+        }
+
+        const hoverClientY = clientOffset.y - hoverBoundingRect.top;
+
+        if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
+          return;
+        }
+
+        if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
+          return;
+        }
+
+        onMove(dragIndex, hoverIndex);
+        dragItem.index = hoverIndex;
+      },
+    }),
+    [index, onMove],
+  );
+
+  drag(drop(ref));
+
+  return (
+    <div
+      className={
+        isDragging
+          ? "rounded-[20px] border border-emerald-300 bg-emerald-50 p-4 opacity-60"
+          : "rounded-[20px] border border-slate-200 bg-white p-4"
+      }
+      ref={ref}
+    >
+      <input
+        name="sectionCategoryId"
+        type="hidden"
+        value={section.categoryId}
+      />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex items-center gap-3 text-slate-500">
+          <div className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium">
+            {index + 1}
+          </div>
+          <div
+            className={
+              isEditing
+                ? "cursor-grab rounded-xl border border-dashed border-slate-300 px-3 py-2 text-xs font-medium uppercase tracking-[0.2em]"
+                : "rounded-xl border border-dashed border-slate-200 px-3 py-2 text-xs font-medium uppercase tracking-[0.2em]"
+            }
+          >
+            Dra
+          </div>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <input
+            className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            name={`sectionDisplayName:${section.categoryId}`}
+            onChange={(event) =>
+              onDisplayNameChange(section.categoryId, event.target.value)
+            }
+            type="text"
+            value={section.displayName}
+          />
+          {validationError ? (
+            <p className="mt-2 text-sm text-rose-600">{validationError}</p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function toDraftSections(
+  persistedSections: FamilyStoreSection[],
+  valueSections: FamilyStoreValues["sections"],
+) {
+  const persistedSectionIds = new Map(
+    persistedSections.map((section) => [section.categoryId, section.id]),
+  );
+
+  return valueSections.map((section) => ({
+    categoryId: section.categoryId,
+    displayName: section.displayName,
+    id: persistedSectionIds.get(section.categoryId) ?? section.categoryId,
+  }));
+}

--- a/app/lib/db.server.ts
+++ b/app/lib/db.server.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 
 import { env } from "./env.server";
 
@@ -6,16 +6,51 @@ const globalForPrisma = globalThis as typeof globalThis & {
   __db?: PrismaClient;
 };
 
-export const db =
-  globalForPrisma.__db ??
-  new PrismaClient({
-    datasources: {
-      db: {
-        url: env.DATABASE_URL,
+type PrismaClientWithRuntimeModel = PrismaClient & {
+  _runtimeDataModel?: {
+    models?: Record<string, { fields?: Array<{ name: string }> }>;
+  };
+};
+
+const generatedModelSignature = buildGeneratedModelSignature();
+const cachedModelSignature = buildCachedModelSignature(globalForPrisma.__db);
+const shouldReuseCachedClient =
+  globalForPrisma.__db && cachedModelSignature === generatedModelSignature;
+
+if (globalForPrisma.__db && !shouldReuseCachedClient) {
+  void globalForPrisma.__db.$disconnect().catch(() => undefined);
+}
+
+export const db = shouldReuseCachedClient
+  ? globalForPrisma.__db!
+  : new PrismaClient({
+      datasources: {
+        db: {
+          url: env.DATABASE_URL,
+        },
       },
-    },
-  });
+    });
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.__db = db;
+}
+
+function buildGeneratedModelSignature() {
+  return Prisma.dmmf.datamodel.models
+    .map((model) => `${model.name}:${model.fields.map((field) => field.name).join(",")}`)
+    .sort()
+    .join("|");
+}
+
+function buildCachedModelSignature(client: PrismaClient | undefined) {
+  const runtimeModels = (client as PrismaClientWithRuntimeModel | undefined)?._runtimeDataModel?.models;
+
+  if (!runtimeModels) {
+    return null;
+  }
+
+  return Object.entries(runtimeModels)
+    .map(([modelName, model]) => `${modelName}:${(model.fields ?? []).map((field) => field.name).join(",")}`)
+    .sort()
+    .join("|");
 }

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -154,6 +154,7 @@ describe("meal-plan.server", () => {
     expect(dbMock.mealPlan.findMany).toHaveBeenCalledWith({
       orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
       select: {
+        activeShoppingDate: true,
         createdAt: true,
         endDate: true,
         id: true,
@@ -292,6 +293,7 @@ describe("meal-plan.server", () => {
     });
     expect(dbMock.mealPlan.create).toHaveBeenCalledWith({
       data: {
+        activeShoppingDate: new Date("2026-05-20T00:00:00.000Z"),
         copiedFromMealPlanId: "meal-plan-source",
         endDate: new Date("2026-05-22T00:00:00.000Z"),
         familyId: "family-1",
@@ -299,6 +301,7 @@ describe("meal-plan.server", () => {
         title: "Neste uke",
       },
       select: {
+        activeShoppingDate: true,
         approvedAt: true,
         approvedByUserId: true,
         copiedFromMealPlanId: true,
@@ -552,6 +555,7 @@ describe("meal-plan.server", () => {
         status: "APPROVED",
       }),
       select: {
+        activeShoppingDate: true,
         approvedAt: true,
         approvedByUserId: true,
         copiedFromMealPlanId: true,
@@ -601,6 +605,7 @@ describe("meal-plan.server", () => {
         status: "DRAFT",
       },
       select: {
+        activeShoppingDate: true,
         approvedAt: true,
         approvedByUserId: true,
         copiedFromMealPlanId: true,

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -7,6 +7,7 @@ const MEAL_PLAN_MAX_SPAN_DAYS = 7;
 const MEAL_PLAN_MAX_DAY_OFFSET = MEAL_PLAN_MAX_SPAN_DAYS - 1;
 
 const mealPlanSummarySelect = {
+  activeShoppingDate: true,
   createdAt: true,
   endDate: true,
   id: true,
@@ -47,6 +48,7 @@ const mealPlanEntrySelect = Prisma.validator<Prisma.MealPlanEntrySelect>()({
 });
 
 const mealPlanPlanningDetailSelect = Prisma.validator<Prisma.MealPlanSelect>()({
+  activeShoppingDate: true,
   approvedAt: true,
   approvedByUserId: true,
   copiedFromMealPlanId: true,
@@ -346,11 +348,14 @@ export async function createMealPlan(input: MealPlanMutationInput) {
     };
   }
 
+  const startDate = parseDateOnly(validation.values.startDate)!;
+  const endDate = parseDateOnly(validation.values.endDate)!;
   const mealPlan = await db.mealPlan.create({
     data: {
-      endDate: parseDateOnly(validation.values.endDate)!,
+      activeShoppingDate: startDate,
+      endDate,
       familyId: input.familyId,
-      startDate: parseDateOnly(validation.values.startDate)!,
+      startDate,
       title: validation.values.title,
     },
     select: mealPlanDetailSelect,
@@ -414,6 +419,7 @@ export async function copyMealPlan(input: CopyMealPlanInput) {
     const endDate = parseDateOnly(validation.values.endDate)!;
     const mealPlan = await tx.mealPlan.create({
       data: {
+        activeShoppingDate: startDate,
         copiedFromMealPlanId: sourceMealPlan.id,
         endDate,
         familyId: input.familyId,
@@ -487,6 +493,7 @@ export async function updateMealPlan(input: MealPlanMutationInput & { mealPlanId
 
   const existingMealPlan = await db.mealPlan.findFirst({
     select: {
+      activeShoppingDate: true,
       id: true,
     },
     where: {
@@ -511,10 +518,17 @@ export async function updateMealPlan(input: MealPlanMutationInput & { mealPlanId
     };
   }
 
+  const nextStartDate = parseDateOnly(validation.values.startDate)!;
+  const nextEndDate = parseDateOnly(validation.values.endDate)!;
   const mealPlan = await db.mealPlan.update({
     data: {
-      endDate: parseDateOnly(validation.values.endDate)!,
-      startDate: parseDateOnly(validation.values.startDate)!,
+      activeShoppingDate: clampShoppingDateToRange(
+        existingMealPlan.activeShoppingDate,
+        nextStartDate,
+        nextEndDate,
+      ),
+      endDate: nextEndDate,
+      startDate: nextStartDate,
       title: validation.values.title,
     },
     select: mealPlanDetailSelect,
@@ -869,4 +883,24 @@ function differenceInUtcDays(startDate: Date, endDate: Date) {
 
 function addUtcDays(date: Date, amount: number) {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + amount));
+}
+
+function clampShoppingDateToRange(
+  activeShoppingDate: Date | null,
+  startDate: Date,
+  endDate: Date,
+) {
+  if (!activeShoppingDate) {
+    return null;
+  }
+
+  if (activeShoppingDate.getTime() < startDate.getTime()) {
+    return startDate;
+  }
+
+  if (activeShoppingDate.getTime() > endDate.getTime()) {
+    return startDate;
+  }
+
+  return activeShoppingDate;
 }

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -24,6 +24,7 @@ const { dbMock, requireFamilyMembershipMock, transactionMock } = vi.hoisted(() =
       },
       mealPlan: {
         findFirst: vi.fn(),
+        update: vi.fn(),
       },
       shoppingItemOverride: {
         delete: vi.fn(),
@@ -56,6 +57,7 @@ import {
   createManualShoppingItem,
   deleteManualShoppingItem,
   toggleShoppingItemChecked,
+  updateActiveShoppingDate,
   updateGeneratedShoppingItemOverride,
 } from "./shopping-write.server";
 
@@ -274,6 +276,27 @@ describe("shopping-write.server", () => {
           sourceKey: "entry-1:ingredient-1",
           sourceType: ShoppingItemSource.GENERATED,
         },
+      },
+    });
+  });
+
+  it("updates the meal plan active shopping date within range", async () => {
+    const result = await updateActiveShoppingDate({
+      activeShoppingDate: "2026-05-17",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.mealPlan.update).toHaveBeenCalledWith({
+      data: {
+        activeShoppingDate: new Date("2026-05-17T00:00:00.000Z"),
+      },
+      where: {
+        id: "meal-plan-1",
       },
     });
   });

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -30,6 +30,10 @@ export interface GeneratedShoppingItemOverrideFieldErrors {
   preferredStoreId?: string;
 }
 
+export interface ActiveShoppingDateFieldErrors {
+  activeShoppingDate?: string;
+}
+
 export async function createManualShoppingItem({
   familyId,
   mealPlanId,
@@ -413,6 +417,63 @@ export async function updateGeneratedShoppingItemOverride({
         sourceKey,
         sourceType: ShoppingItemSource.GENERATED,
       },
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+export async function updateActiveShoppingDate({
+  activeShoppingDate,
+  familyId,
+  mealPlanId,
+  userId,
+}: {
+  activeShoppingDate: string;
+  familyId: string;
+  mealPlanId: string;
+  userId: string;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const normalizedDate = activeShoppingDate.trim();
+  const validation = validateOptionalDateInRange(
+    normalizedDate,
+    mealPlan.startDate,
+    mealPlan.endDate,
+    "Velg en gyldig handledato.",
+  );
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: {
+        activeShoppingDate: validation.fieldError,
+      },
+      status: "VALIDATION_ERROR" as const,
+      values: {
+        activeShoppingDate: normalizedDate,
+      },
+    };
+  }
+
+  await db.mealPlan.update({
+    data: {
+      activeShoppingDate: validation.date ?? mealPlan.startDate,
+    },
+    where: {
+      id: mealPlan.id,
     },
   });
 

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -12,6 +12,9 @@ const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
       store: {
         findMany: vi.fn(),
       },
+      userStorePreference: {
+        findUnique: vi.fn(),
+      },
     },
     requireFamilyMembershipMock: vi.fn(),
   };
@@ -29,7 +32,7 @@ vi.mock("./family.server", () => {
   };
 });
 
-import { getMealPlanShoppingData } from "./shopping.server";
+import { getMealPlanShoppingData, getMealPlanStoreModeData } from "./shopping.server";
 
 const mockMembership = {
   family: {
@@ -47,6 +50,7 @@ describe("shopping.server", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     requireFamilyMembershipMock.mockResolvedValue(mockMembership);
+    dbMock.userStorePreference.findUnique.mockResolvedValue(null);
     dbMock.ingredientCategory.findMany.mockResolvedValue([
       {
         displayName: "Brod",
@@ -65,6 +69,7 @@ describe("shopping.server", () => {
 
   it("projects deterministic generated and manual shopping items with exact-match merge, overrides, and store ordering", async () => {
     dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
       endDate: new Date("2026-05-18T00:00:00.000Z"),
       entries: [
         {
@@ -422,6 +427,7 @@ describe("shopping.server", () => {
 
   it("keeps generated items separate when exact-match fields differ", async () => {
     dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: null,
       endDate: new Date("2026-05-18T00:00:00.000Z"),
       entries: [
         {
@@ -525,6 +531,176 @@ describe("shopping.server", () => {
       "entry-2:ingredient-2",
     ]);
     expect(result.projectedItems.map((item) => item.quantityLabel)).toEqual(["1 beger", "2 beger"]);
+  });
+
+  it("builds store mode with all due items ordered by the selected store layout", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  id: "category-bakery",
+                  name: "Brod",
+                },
+                categoryId: "category-bakery",
+                displayName: "Wraps",
+                id: "ingredient-1",
+                ingredientId: "canonical-wraps",
+                preferredStore: {
+                  id: "store-1",
+                  name: "Coop Mega",
+                },
+                preferredStoreId: "store-1",
+                sortOrder: 1,
+                unit: "pk",
+              },
+              {
+                amount: "1",
+                category: {
+                  id: "category-produce",
+                  name: "Frukt og gront",
+                },
+                categoryId: "category-produce",
+                displayName: "Paprika",
+                id: "ingredient-2",
+                ingredientId: "canonical-paprika",
+                preferredStore: {
+                  id: "store-2",
+                  name: "Meny",
+                },
+                preferredStoreId: "store-2",
+                sortOrder: 2,
+                unit: "stk",
+              },
+            ],
+            title: "Tacofredag",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [
+        {
+          buyOnDate: new Date("2026-05-18T00:00:00.000Z"),
+          category: {
+            displayName: "Meieri",
+            id: "category-dairy",
+          },
+          categoryId: "category-dairy",
+          id: "manual-item-1",
+          name: "Yoghurt",
+          note: null,
+          preferredStore: {
+            id: "store-1",
+            name: "Coop Mega",
+          },
+          preferredStoreId: "store-1",
+          quantity: "2 beger",
+        },
+      ],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Helgehandel",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-1",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-2",
+            sortOrder: 2,
+          },
+          {
+            categoryId: "category-dairy",
+            displayName: "Meieri",
+            id: "section-3",
+            sortOrder: 3,
+          },
+        ],
+      },
+      {
+        familyId: "family-1",
+        id: "store-2",
+        name: "Meny",
+        sections: [
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-4",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-5",
+            sortOrder: 2,
+          },
+          {
+            categoryId: "category-dairy",
+            displayName: "Meieri",
+            id: "section-6",
+            sortOrder: 3,
+          },
+        ],
+      },
+    ]);
+    dbMock.userStorePreference.findUnique.mockResolvedValue({
+      selectedStoreId: "store-2",
+    });
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.userStorePreference.findUnique).toHaveBeenCalledWith({
+      select: {
+        selectedStoreId: true,
+      },
+      where: {
+        userId_familyId: {
+          familyId: "family-1",
+          userId: "user-1",
+        },
+      },
+    });
+    expect(result.selectedStore).toEqual({
+      id: "store-2",
+      name: "Meny",
+    });
+    expect(result.activeShoppingDate).toEqual(new Date("2026-05-16T00:00:00.000Z"));
+    expect(result.dueSectionGroups.map((section) => section.displayName)).toEqual([
+      "Brod",
+      "Frukt og gront",
+    ]);
+    expect(result.dueSectionGroups[0]?.items.map((item) => item.name)).toEqual(["Wraps"]);
+    expect(result.dueSectionGroups[1]?.items.map((item) => item.name)).toEqual(["Paprika"]);
+    expect(result.laterItems.map((item) => item.name)).toEqual(["Yoghurt"]);
+    expect(result.progress).toEqual({
+      checkedCount: 0,
+      totalCount: 2,
+    });
   });
 
   it("throws a not-found response when the meal plan is outside the family scope", async () => {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -84,6 +84,7 @@ const manualShoppingItemSelect =
   });
 
 const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
+  activeShoppingDate: true,
   endDate: true,
   entries: {
     orderBy: [{ date: "asc" }, { id: "asc" }],
@@ -223,6 +224,11 @@ export interface ProjectedShoppingStoreGroup {
   store: StoreSummary;
 }
 
+export interface StoreModeProgress {
+  checkedCount: number;
+  totalCount: number;
+}
+
 export async function getMealPlanShoppingData({
   familyId,
   mealPlanId,
@@ -292,6 +298,108 @@ export async function getMealPlanShoppingData({
     mealPlan,
     projectedItems,
     storeGroups: buildProjectedStoreGroups(projectedItems),
+    stores: stores.map((store) => ({
+      id: store.id,
+      name: store.name,
+    })),
+    userRole: membership.role,
+    visibleDates: getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate),
+  };
+}
+
+export async function getMealPlanStoreModeData({
+  familyId,
+  mealPlanId,
+  userId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const [mealPlan, stores, selectedStorePreference] = await Promise.all([
+    db.mealPlan.findFirst({
+      select: shoppingMealPlanSelect,
+      where: {
+        familyId,
+        id: mealPlanId,
+      },
+    }),
+    db.store.findMany({
+      orderBy: [{ name: "asc" }],
+      select: shoppingStoreSelect,
+      where: {
+        OR: [{ familyId: null }, { familyId }],
+      },
+    }),
+    db.userStorePreference.findUnique({
+      select: {
+        selectedStoreId: true,
+      },
+      where: {
+        userId_familyId: {
+          familyId,
+          userId,
+        },
+      },
+    }),
+  ]);
+
+  if (!mealPlan) {
+    throw new Response("Fant ikke ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  const generatedItems = projectGeneratedShoppingItems({
+    mealPlan,
+    stores,
+  });
+  const manualItems = projectManualShoppingItems({
+    mealPlan,
+    stores,
+  });
+  const projectedItems = [...generatedItems, ...manualItems];
+  const activeShoppingDate = mealPlan.activeShoppingDate ?? mealPlan.startDate;
+  const selectedStore = resolveSelectedStoreSummary(
+    stores,
+    selectedStorePreference?.selectedStoreId ?? null,
+  );
+  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
+  const dueItems = projectedItems
+    .filter((item) => isProjectedItemDueBy(item, activeShoppingDate))
+    .sort((left, right) =>
+      compareProjectedItemsForStoreMode(
+        left,
+        right,
+        selectedStore,
+        storeSectionsByStoreId,
+      ),
+    );
+  const laterItems = projectedItems
+    .filter((item) => !isProjectedItemDueBy(item, activeShoppingDate))
+    .sort(compareProjectedItemsByRelevantDate);
+
+  return {
+    activeShoppingDate,
+    dueSectionGroups: buildStoreModeSectionGroups({
+      items: dueItems,
+      selectedStore,
+      storeSectionsByStoreId,
+    }),
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    laterItems,
+    mealPlan,
+    progress: buildStoreModeProgress(dueItems),
+    selectedStore,
     stores: stores.map((store) => ({
       id: store.id,
       name: store.name,
@@ -528,6 +636,68 @@ function buildProjectedStoreGroups(
     .sort((left, right) => compareStoreSummaries(left.store, right.store));
 }
 
+function buildStoreModeSectionGroups({
+  items,
+  selectedStore,
+  storeSectionsByStoreId,
+}: {
+  items: ProjectedShoppingItem[];
+  selectedStore: StoreSummary;
+  storeSectionsByStoreId: Map<string, Map<string, StoreSectionSummary>>;
+}) {
+  const sectionMap = new Map<
+    string,
+    ProjectedShoppingSectionGroup & {
+      sortOrder: number;
+    }
+  >();
+
+  for (const item of items) {
+    const section = resolveStoreSection({
+      category: item.category,
+      preferredStore: selectedStore,
+      storeSectionsByStoreId,
+    });
+    const sectionKey = `${item.category.id}:${section.displayName}`;
+    const existingSection = sectionMap.get(sectionKey);
+
+    if (!existingSection) {
+      sectionMap.set(sectionKey, {
+        category: item.category,
+        displayName: section.displayName,
+        items: [item],
+        sortOrder: section.sortOrder,
+      });
+      continue;
+    }
+
+    existingSection.items.push(item);
+  }
+
+  return [...sectionMap.values()]
+    .map((section) => ({
+      category: section.category,
+      displayName: section.displayName,
+      items: [...section.items],
+      sortOrder: section.sortOrder,
+    }))
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) {
+        return left.sortOrder - right.sortOrder;
+      }
+
+      return left.displayName.localeCompare(right.displayName, "nb");
+    })
+    .map(({ sortOrder: _sortOrder, ...section }) => section);
+}
+
+function buildStoreModeProgress(items: ProjectedShoppingItem[]): StoreModeProgress {
+  return {
+    checkedCount: items.filter((item) => item.checked).length,
+    totalCount: items.length,
+  };
+}
+
 function buildStoreSectionsByStoreId(stores: ShoppingStore[]) {
   return new Map(
     stores.map((store) => [
@@ -625,6 +795,51 @@ function resolveStoreSection({
   }
 
   return section;
+}
+
+function resolveSelectedStoreSummary(
+  stores: ShoppingStore[],
+  selectedStoreId: string | null,
+): StoreSummary {
+  if (selectedStoreId) {
+    const matchingStore = stores.find((store) => store.id === selectedStoreId);
+
+    if (matchingStore) {
+      return {
+        id: matchingStore.id,
+        name: matchingStore.name,
+      };
+    }
+  }
+
+  const fallbackStore = stores[0];
+
+  if (!fallbackStore) {
+    return null;
+  }
+
+  return {
+    id: fallbackStore.id,
+    name: fallbackStore.name,
+  };
+}
+
+function isProjectedItemDueBy(item: ProjectedShoppingItem, activeShoppingDate: Date) {
+  const relevantDate = getProjectedItemRelevantDate(item);
+
+  if (!relevantDate) {
+    return true;
+  }
+
+  return relevantDate.getTime() <= activeShoppingDate.getTime();
+}
+
+function getProjectedItemRelevantDate(item: ProjectedShoppingItem) {
+  if (item.sourceType === "GENERATED") {
+    return item.postponedUntilDate ?? item.firstDate;
+  }
+
+  return item.buyOnDate;
 }
 
 function buildQuantityLabel(amount: string | null, unit: string | null) {
@@ -734,10 +949,89 @@ function compareProjectedItems(
   return left.sourceKey.localeCompare(right.sourceKey, "nb");
 }
 
+function compareProjectedItemsForStoreMode(
+  left: ProjectedShoppingItem,
+  right: ProjectedShoppingItem,
+  selectedStore: StoreSummary,
+  storeSectionsByStoreId: Map<string, Map<string, StoreSectionSummary>>,
+) {
+  const leftSection = resolveStoreSection({
+    category: left.category,
+    preferredStore: selectedStore,
+    storeSectionsByStoreId,
+  });
+  const rightSection = resolveStoreSection({
+    category: right.category,
+    preferredStore: selectedStore,
+    storeSectionsByStoreId,
+  });
+
+  if (leftSection.sortOrder !== rightSection.sortOrder) {
+    return leftSection.sortOrder - rightSection.sortOrder;
+  }
+
+  const sectionComparison = leftSection.displayName.localeCompare(
+    rightSection.displayName,
+    "nb",
+  );
+
+  if (sectionComparison !== 0) {
+    return sectionComparison;
+  }
+
+  const leftRelevantTimestamp = getProjectedItemRelevantTimestamp(left);
+  const rightRelevantTimestamp = getProjectedItemRelevantTimestamp(right);
+
+  if (leftRelevantTimestamp !== rightRelevantTimestamp) {
+    return leftRelevantTimestamp - rightRelevantTimestamp;
+  }
+
+  const leftPreferredStoreComparison = compareStoreSummaries(
+    left.preferredStore,
+    right.preferredStore,
+  );
+
+  if (leftPreferredStoreComparison !== 0) {
+    return leftPreferredStoreComparison;
+  }
+
+  const nameComparison = left.name.localeCompare(right.name, "nb");
+
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  return left.sourceKey.localeCompare(right.sourceKey, "nb");
+}
+
+function compareProjectedItemsByRelevantDate(
+  left: ProjectedShoppingItem,
+  right: ProjectedShoppingItem,
+) {
+  const leftRelevantTimestamp = getProjectedItemRelevantTimestamp(left);
+  const rightRelevantTimestamp = getProjectedItemRelevantTimestamp(right);
+
+  if (leftRelevantTimestamp !== rightRelevantTimestamp) {
+    return leftRelevantTimestamp - rightRelevantTimestamp;
+  }
+
+  const nameComparison = left.name.localeCompare(right.name, "nb");
+
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  return left.sourceKey.localeCompare(right.sourceKey, "nb");
+}
+
 function getProjectedItemSortTimestamp(item: ProjectedShoppingItem) {
   if (item.sourceType === "GENERATED") {
     return item.firstDate.getTime();
   }
 
   return item.buyOnDate ? item.buyOnDate.getTime() : Number.MIN_SAFE_INTEGER;
+}
+
+function getProjectedItemRelevantTimestamp(item: ProjectedShoppingItem) {
+  return getProjectedItemRelevantDate(item)?.getTime() ?? Number.MIN_SAFE_INTEGER;
 }

--- a/app/lib/store-write.server.test.ts
+++ b/app/lib/store-write.server.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyAdminMock, requireFamilyMembershipMock, transactionMock } = vi.hoisted(() => {
+  const transactionMock = {
+    store: {
+      update: vi.fn(),
+    },
+    storeSection: {
+      update: vi.fn(),
+    },
+  };
+
+  return {
+    dbMock: {
+      $transaction: vi.fn(),
+      ingredientCategory: {
+        findMany: vi.fn(),
+      },
+      store: {
+        create: vi.fn(),
+        delete: vi.fn(),
+        findFirst: vi.fn(),
+      },
+      storeSection: {
+        update: vi.fn(),
+      },
+      userStorePreference: {
+        deleteMany: vi.fn(),
+        upsert: vi.fn(),
+      },
+    },
+    requireFamilyAdminMock: vi.fn(),
+    requireFamilyMembershipMock: vi.fn(),
+    transactionMock,
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+vi.mock("./family.server", () => {
+  return {
+    requireFamilyAdmin: requireFamilyAdminMock,
+    requireFamilyMembership: requireFamilyMembershipMock,
+  };
+});
+
+import {
+  createFamilyStore,
+  deleteFamilyStore,
+  updateFamilyStore,
+  updateSelectedStorePreference,
+} from "./store-write.server";
+
+describe("store-write.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyAdminMock.mockResolvedValue({
+      familyId: "family-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+    requireFamilyMembershipMock.mockResolvedValue({
+      familyId: "family-1",
+      role: "MEMBER",
+      userId: "user-1",
+    });
+    dbMock.ingredientCategory.findMany.mockResolvedValue([
+      {
+        displayName: "Bakst og brod",
+        id: "category-bakery",
+      },
+      {
+        displayName: "Frukt og gront",
+        id: "category-produce",
+      },
+    ]);
+    dbMock.$transaction.mockImplementation(async (callback: (tx: typeof transactionMock) => unknown) =>
+      callback(transactionMock),
+    );
+  });
+
+  it("returns validation errors before creating a family store", async () => {
+    const result = await createFamilyStore({
+      familyId: "family-1",
+      name: "   ",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      fieldErrors: {
+        name: "Skriv inn et butikknavn.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        name: "",
+      },
+    });
+    expect(dbMock.store.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a family store with default sections for all categories", async () => {
+    dbMock.store.findFirst.mockResolvedValue(null);
+    dbMock.store.create.mockResolvedValue({
+      id: "store-1",
+      name: "Helgebutikk",
+    });
+
+    const result = await createFamilyStore({
+      familyId: "family-1",
+      name: "  Helgebutikk  ",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "CREATED",
+      store: {
+        id: "store-1",
+        name: "Helgebutikk",
+      },
+    });
+    expect(dbMock.store.create).toHaveBeenCalledWith({
+      data: {
+        familyId: "family-1",
+        name: "Helgebutikk",
+        sections: {
+          create: [
+            {
+              categoryId: "category-bakery",
+              displayName: "Bakst og brod",
+              sortOrder: 1,
+            },
+            {
+              categoryId: "category-produce",
+              displayName: "Frukt og gront",
+              sortOrder: 2,
+            },
+          ],
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+  });
+
+  it("updates a family store name and section labels", async () => {
+    dbMock.store.findFirst
+      .mockResolvedValueOnce({
+        id: "store-1",
+        sections: [
+          {
+            categoryId: "category-bakery",
+            id: "section-1",
+          },
+          {
+            categoryId: "category-produce",
+            id: "section-2",
+          },
+        ],
+      })
+      .mockResolvedValueOnce(null);
+
+    const result = await updateFamilyStore({
+      familyId: "family-1",
+      storeId: "store-1",
+      userId: "user-1",
+      values: {
+        name: "  Helgebutikk  ",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Gront først",
+          },
+          {
+            categoryId: "category-bakery",
+            displayName: "Brodhylla",
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(transactionMock.store.update).toHaveBeenCalledWith({
+      data: {
+        name: "Helgebutikk",
+      },
+      where: {
+        id: "store-1",
+      },
+    });
+    expect(transactionMock.storeSection.update).toHaveBeenNthCalledWith(1, {
+      data: {
+        displayName: "Gront først",
+        sortOrder: 1,
+      },
+      where: {
+        storeId_categoryId: {
+          categoryId: "category-produce",
+          storeId: "store-1",
+        },
+      },
+    });
+    expect(transactionMock.storeSection.update).toHaveBeenNthCalledWith(2, {
+      data: {
+        displayName: "Brodhylla",
+        sortOrder: 2,
+      },
+      where: {
+        storeId_categoryId: {
+          categoryId: "category-bakery",
+          storeId: "store-1",
+        },
+      },
+    });
+  });
+
+  it("deletes a scoped family store", async () => {
+    dbMock.store.findFirst.mockResolvedValue({
+      id: "store-1",
+    });
+
+    const result = await deleteFamilyStore({
+      familyId: "family-1",
+      storeId: "store-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "DELETED",
+    });
+    expect(dbMock.store.delete).toHaveBeenCalledWith({
+      where: {
+        id: "store-1",
+      },
+    });
+  });
+
+  it("upserts the selected store preference for a user", async () => {
+    dbMock.store.findFirst.mockResolvedValue({
+      id: "store-2",
+    });
+
+    const result = await updateSelectedStorePreference({
+      familyId: "family-1",
+      selectedStoreId: "store-2",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.userStorePreference.upsert).toHaveBeenCalledWith({
+      create: {
+        familyId: "family-1",
+        selectedStoreId: "store-2",
+        userId: "user-1",
+      },
+      update: {
+        selectedStoreId: "store-2",
+      },
+      where: {
+        userId_familyId: {
+          familyId: "family-1",
+          userId: "user-1",
+        },
+      },
+    });
+  });
+});

--- a/app/lib/store-write.server.ts
+++ b/app/lib/store-write.server.ts
@@ -1,0 +1,383 @@
+import { Prisma } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyAdmin, requireFamilyMembership } from "./family.server";
+import { listIngredientCategories } from "./store.server";
+
+export interface FamilyStoreSectionValues {
+  categoryId: string;
+  displayName: string;
+}
+
+export interface FamilyStoreValues {
+  name: string;
+  sections: FamilyStoreSectionValues[];
+}
+
+export interface FamilyStoreFieldErrors {
+  name?: string;
+  sections?: string;
+  sectionDisplayNames?: Record<string, string>;
+}
+
+export async function createFamilyStore({
+  familyId,
+  name,
+  userId,
+}: {
+  familyId: string;
+  name: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const normalizedName = name.trim();
+
+  if (!normalizedName) {
+    return {
+      fieldErrors: {
+        name: "Skriv inn et butikknavn.",
+      },
+      status: "VALIDATION_ERROR" as const,
+      values: {
+        name: normalizedName,
+      },
+    };
+  }
+
+  const [categories, existingStore] = await Promise.all([
+    listIngredientCategories(),
+    db.store.findFirst({
+      select: {
+        id: true,
+      },
+      where: {
+        familyId,
+        name: normalizedName,
+      },
+    }),
+  ]);
+
+  if (existingStore) {
+    return {
+      fieldErrors: {
+        name: "Butikknavnet brukes allerede i familien.",
+      },
+      status: "VALIDATION_ERROR" as const,
+      values: {
+        name: normalizedName,
+      },
+    };
+  }
+
+  const store = await db.store.create({
+    data: {
+      familyId,
+      name: normalizedName,
+      sections: {
+        create: categories.map((category, index) => ({
+          categoryId: category.id,
+          displayName: category.displayName,
+          sortOrder: index + 1,
+        })),
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+
+  return {
+    status: "CREATED" as const,
+    store,
+  };
+}
+
+export async function updateFamilyStore({
+  familyId,
+  storeId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  storeId: string;
+  userId: string;
+  values: FamilyStoreValues;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const existingStore = await db.store.findFirst({
+    select: {
+      id: true,
+      sections: {
+        orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+        select: {
+          categoryId: true,
+          id: true,
+        },
+      },
+    },
+    where: {
+      familyId,
+      id: storeId,
+    },
+  });
+
+  if (!existingStore) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const validation = await validateFamilyStoreValues({
+    familyId,
+    storeId,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  await db.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.store.update({
+      data: {
+        name: validation.values.name,
+      },
+      where: {
+        id: existingStore.id,
+      },
+    });
+
+    await Promise.all(
+      validation.values.sections.map((section, index) =>
+        tx.storeSection.update({
+          data: {
+            displayName: section.displayName,
+            sortOrder: index + 1,
+          },
+          where: {
+            storeId_categoryId: {
+              categoryId: section.categoryId,
+              storeId: existingStore.id,
+            },
+          },
+        }),
+      ),
+    );
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+export async function deleteFamilyStore({
+  familyId,
+  storeId,
+  userId,
+}: {
+  familyId: string;
+  storeId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const store = await db.store.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId,
+      id: storeId,
+    },
+  });
+
+  if (!store) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  await db.store.delete({
+    where: {
+      id: store.id,
+    },
+  });
+
+  return {
+    status: "DELETED" as const,
+  };
+}
+
+export async function updateSelectedStorePreference({
+  familyId,
+  selectedStoreId,
+  userId,
+}: {
+  familyId: string;
+  selectedStoreId: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const normalizedStoreId = selectedStoreId.trim();
+
+  if (!normalizedStoreId) {
+    await db.userStorePreference.deleteMany({
+      where: {
+        familyId,
+        userId,
+      },
+    });
+
+    return {
+      status: "UPDATED" as const,
+    };
+  }
+
+  const scopedStoreId = await resolveScopedStoreId(normalizedStoreId, familyId);
+
+  if (!scopedStoreId) {
+    return {
+      fieldErrors: {
+        selectedStoreId: "Velg en gyldig butikk for familien.",
+      },
+      status: "VALIDATION_ERROR" as const,
+      values: {
+        selectedStoreId: normalizedStoreId,
+      },
+    };
+  }
+
+  await db.userStorePreference.upsert({
+    create: {
+      familyId,
+      selectedStoreId: scopedStoreId,
+      userId,
+    },
+    update: {
+      selectedStoreId: scopedStoreId,
+    },
+    where: {
+      userId_familyId: {
+        familyId,
+        userId,
+      },
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+async function validateFamilyStoreValues({
+  familyId,
+  storeId,
+  values,
+}: {
+  familyId: string;
+  storeId: string;
+  values: FamilyStoreValues;
+}) {
+  const normalizedValues = {
+    name: values.name.trim(),
+    sections: values.sections.map((section) => ({
+      categoryId: section.categoryId.trim(),
+      displayName: section.displayName.trim(),
+    })),
+  };
+  const fieldErrors: FamilyStoreFieldErrors = {};
+  const sectionDisplayNames: Record<string, string> = {};
+
+  if (!normalizedValues.name) {
+    fieldErrors.name = "Skriv inn et butikknavn.";
+  }
+
+  const categories = await listIngredientCategories();
+  const expectedCategoryIds = new Set(categories.map((category) => category.id));
+  const submittedCategoryIds = normalizedValues.sections.map((section) => section.categoryId);
+  const uniqueCategoryIds = new Set(submittedCategoryIds);
+
+  if (
+    normalizedValues.sections.length !== categories.length ||
+    uniqueCategoryIds.size !== categories.length ||
+    submittedCategoryIds.some((categoryId) => !expectedCategoryIds.has(categoryId))
+  ) {
+    fieldErrors.sections = "Butikken ma ha en seksjon for hver kategori i familien.";
+  }
+
+  for (const section of normalizedValues.sections) {
+    if (!section.displayName) {
+      sectionDisplayNames[section.categoryId] = "Skriv inn et seksjonsnavn.";
+    }
+  }
+
+  if (Object.keys(sectionDisplayNames).length > 0) {
+    fieldErrors.sectionDisplayNames = sectionDisplayNames;
+  }
+
+  const duplicateStore = normalizedValues.name
+    ? await db.store.findFirst({
+        select: {
+          id: true,
+        },
+        where: {
+          familyId,
+          id: {
+            not: storeId,
+          },
+          name: normalizedValues.name,
+        },
+      })
+    : null;
+
+  if (duplicateStore) {
+    fieldErrors.name = "Butikknavnet brukes allerede i familien.";
+  }
+
+  if (fieldErrors.name || fieldErrors.sections || fieldErrors.sectionDisplayNames) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  return {
+    ok: true as const,
+    values: normalizedValues,
+  };
+}
+
+async function resolveScopedStoreId(storeId: string, familyId: string) {
+  const store = await db.store.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      id: storeId,
+      OR: [{ familyId: null }, { familyId }],
+    },
+  });
+
+  return store?.id ?? null;
+}

--- a/app/lib/store.server.ts
+++ b/app/lib/store.server.ts
@@ -1,0 +1,82 @@
+import { Prisma } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+
+export const storeCategorySelect =
+  Prisma.validator<Prisma.IngredientCategorySelect>()({
+    displayName: true,
+    id: true,
+  });
+
+export const managedStoreSectionSelect =
+  Prisma.validator<Prisma.StoreSectionSelect>()({
+    categoryId: true,
+    displayName: true,
+    id: true,
+    sortOrder: true,
+  });
+
+export const managedStoreSelect = Prisma.validator<Prisma.StoreSelect>()({
+  familyId: true,
+  id: true,
+  key: true,
+  name: true,
+  sections: {
+    orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+    select: managedStoreSectionSelect,
+  },
+});
+
+export type StoreCategory = Prisma.IngredientCategoryGetPayload<{
+  select: typeof storeCategorySelect;
+}>;
+
+export type ManagedStore = Prisma.StoreGetPayload<{
+  select: typeof managedStoreSelect;
+}>;
+
+export async function listIngredientCategories() {
+  return db.ingredientCategory.findMany({
+    orderBy: [{ displayName: "asc" }],
+    select: storeCategorySelect,
+  });
+}
+
+export async function listScopedStores(familyId: string) {
+  return db.store.findMany({
+    orderBy: [{ name: "asc" }],
+    select: managedStoreSelect,
+    where: {
+      OR: [{ familyId: null }, { familyId }],
+    },
+  });
+}
+
+export async function getStoreManagementData({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+  const [categories, stores] = await Promise.all([
+    listIngredientCategories(),
+    listScopedStores(familyId),
+  ]);
+
+  return {
+    categories,
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    globalStores: stores.filter((store) => store.familyId === null),
+    familyStores: stores.filter((store) => store.familyId === familyId),
+    userRole: membership.role,
+  };
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -7,6 +7,8 @@ export default [
   route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
   route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
   route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
+  route("families/:familyId/meal-plans/:mealPlanId/store-mode", "routes/family-meal-plan-store-mode.tsx"),
+  route("families/:familyId/stores", "routes/family-stores.tsx"),
   route("login", "routes/login.tsx"),
   route("logout", "routes/logout.tsx"),
   route("prototype", "routes/prototype.tsx"),

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -72,6 +72,7 @@ describe("family meal plan shopping route", () => {
         total: 2,
       },
       mealPlan: {
+        activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
         endDate: new Date("2026-05-18T00:00:00.000Z"),
         entries: [],
         id: "meal-plan-1",
@@ -250,6 +251,7 @@ describe("family meal plan shopping route", () => {
         total: 2,
       },
       mealPlan: {
+        activeShoppingDate: "2026-05-16",
         endDate: "2026-05-18",
         entries: undefined,
         id: "meal-plan-1",

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -88,6 +88,9 @@ export async function loader({
     itemCounts: result.itemCounts,
     mealPlan: {
       ...result.mealPlan,
+      activeShoppingDate: result.mealPlan.activeShoppingDate
+        ? formatDateOnly(result.mealPlan.activeShoppingDate)
+        : null,
       endDate: formatDateOnly(result.mealPlan.endDate),
       entries: undefined,
       manualShoppingItems: undefined,
@@ -319,6 +322,12 @@ export default function FamilyMealPlanShoppingRoute({
             <div className="flex flex-wrap gap-3">
               <Link
                 className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/store-mode`}
+              >
+                Apne butikkmodus
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}`}
               >
                 Tilbake til ukeplan

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>("../lib/auth.server");
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping.server", () => {
+  return {
+    getMealPlanStoreModeData: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping-write.server", () => {
+  return {
+    toggleShoppingItemChecked: vi.fn(),
+    updateActiveShoppingDate: vi.fn(),
+  };
+});
+
+vi.mock("../lib/store-write.server", () => {
+  return {
+    updateSelectedStorePreference: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanStoreModeData } from "../lib/shopping.server";
+import { toggleShoppingItemChecked, updateActiveShoppingDate } from "../lib/shopping-write.server";
+import { updateSelectedStorePreference } from "../lib/store-write.server";
+import { action, loader } from "./family-meal-plan-store-mode";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/meal-plans/meal-plan-1/store-mode",
+  formData?: FormData,
+) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family meal plan store mode route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads and serializes store mode data", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanStoreModeData).mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
+      dueSectionGroups: [
+        {
+          category: {
+            id: "category-produce",
+            name: "Frukt og gront",
+          },
+          displayName: "Frukt og gront",
+          items: [
+            {
+              amount: "1",
+              category: {
+                id: "category-produce",
+                name: "Frukt og gront",
+              },
+              checked: false,
+              firstDate: new Date("2026-05-15T00:00:00.000Z"),
+              lastDate: new Date("2026-05-15T00:00:00.000Z"),
+              name: "Paprika",
+              note: null,
+              occurrenceCount: 1,
+              occurrences: [
+                {
+                  date: new Date("2026-05-15T00:00:00.000Z"),
+                  mealPlanEntryId: "entry-1",
+                  recipeId: "recipe-1",
+                  recipeIngredientId: "ingredient-1",
+                  recipeTitle: "Taco",
+                },
+              ],
+              postponedUntilDate: null,
+              preferredStore: {
+                id: "store-1",
+                name: "Meny",
+              },
+              quantityLabel: "1 stk",
+              section: {
+                displayName: "Frukt og gront",
+                sortOrder: 1,
+              },
+              sourceKey: "entry-1:ingredient-1",
+              sourceType: "GENERATED",
+              unit: "stk",
+            },
+          ],
+        },
+      ],
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      laterItems: [],
+      mealPlan: {
+        activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        entries: [],
+        id: "meal-plan-1",
+        manualShoppingItems: [],
+        shoppingOverrides: [],
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Langhelg",
+      },
+      progress: {
+        checkedCount: 0,
+        totalCount: 1,
+      },
+      selectedStore: {
+        id: "store-1",
+        name: "Meny",
+      },
+      stores: [
+        {
+          id: "store-1",
+          name: "Meny",
+        },
+      ],
+      userRole: "ADMIN",
+      visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(getMealPlanStoreModeData).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result.activeShoppingDate).toBe("2026-05-16");
+    expect(result.mealPlan.activeShoppingDate).toBe("2026-05-16");
+    expect(result.dueSectionGroups[0]?.items[0]).toEqual(
+      expect.objectContaining({
+        firstDate: "2026-05-15",
+        lastDate: "2026-05-15",
+        name: "Paprika",
+      }),
+    );
+  });
+
+  it("returns active shopping date validation errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateActiveShoppingDate).mockResolvedValue({
+      fieldErrors: {
+        activeShoppingDate: "Datoen ma ligge innenfor ukeplanens aktive periode.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        activeShoppingDate: "2026-05-20",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-active-shopping-date");
+    formData.set("activeShoppingDate", "2026-05-20");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(updateActiveShoppingDate).toHaveBeenCalledWith({
+      activeShoppingDate: "2026-05-20",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      activeShoppingDateFieldErrors: {
+        activeShoppingDate: "Datoen ma ligge innenfor ukeplanens aktive periode.",
+      },
+      activeShoppingDateValue: "2026-05-20",
+      intent: "update-active-shopping-date",
+    });
+  });
+
+  it("redirects after updating the selected store", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateSelectedStorePreference).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-selected-store");
+    formData.set("selectedStoreId", "store-2");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(updateSelectedStorePreference).toHaveBeenCalledWith({
+      familyId: "family-1",
+      selectedStoreId: "store-2",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1/store-mode?notice=selected-store-updated",
+    );
+    expect(toggleShoppingItemChecked).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1,0 +1,638 @@
+import { ShoppingItemSource } from "@prisma/client";
+import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanStoreModeData } from "../lib/shopping.server";
+import {
+  toggleShoppingItemChecked,
+  updateActiveShoppingDate,
+} from "../lib/shopping-write.server";
+import { updateSelectedStorePreference } from "../lib/store-write.server";
+
+type StoreModeNotice =
+  | "active-shopping-date-updated"
+  | "selected-store-updated"
+  | "shopping-item-check-state-updated";
+
+type StoreModeIntent =
+  | "toggle-shopping-item-checked"
+  | "update-active-shopping-date"
+  | "update-selected-store";
+
+interface StoreModeActionData {
+  activeShoppingDateFieldErrors?: {
+    activeShoppingDate?: string;
+  };
+  activeShoppingDateValue?: string;
+  formError?: string;
+  intent?: StoreModeIntent;
+  selectedStoreFieldErrors?: {
+    selectedStoreId?: string;
+  };
+  selectedStoreValue?: string;
+}
+
+interface FamilyMealPlanStoreModeRouteProps {
+  actionData?: StoreModeActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Butikkmodus | Mealplanner" },
+    { name: "description", content: "Kompakt butikkmodus for handlelisten i Mealplanner." },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const result = await getMealPlanStoreModeData({
+    familyId,
+    mealPlanId,
+    userId: user.id,
+  });
+
+  return {
+    activeShoppingDate: formatDateOnly(result.activeShoppingDate),
+    dueSectionGroups: result.dueSectionGroups.map((section) => ({
+      ...section,
+      items: section.items.map(serializeProjectedShoppingItem),
+    })),
+    family: result.family,
+    laterItems: result.laterItems.map(serializeProjectedShoppingItem),
+    mealPlan: {
+      ...result.mealPlan,
+      activeShoppingDate: result.mealPlan.activeShoppingDate
+        ? formatDateOnly(result.mealPlan.activeShoppingDate)
+        : null,
+      endDate: formatDateOnly(result.mealPlan.endDate),
+      entries: undefined,
+      manualShoppingItems: undefined,
+      shoppingOverrides: undefined,
+      startDate: formatDateOnly(result.mealPlan.startDate),
+    },
+    notice: getStoreModeNotice(request),
+    progress: result.progress,
+    selectedStore: result.selectedStore,
+    stores: result.stores,
+    userRole: result.userRole,
+    visibleDates: result.visibleDates,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "update-active-shopping-date") {
+    const activeShoppingDate = String(formData.get("activeShoppingDate") ?? "");
+    const result = await updateActiveShoppingDate({
+      activeShoppingDate,
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        activeShoppingDateFieldErrors: result.fieldErrors,
+        activeShoppingDateValue: result.values.activeShoppingDate,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    return buildStoreModeRedirect({
+      familyId,
+      mealPlanId,
+      notice: "active-shopping-date-updated",
+      request,
+    });
+  }
+
+  if (intent === "update-selected-store") {
+    const selectedStoreId = String(formData.get("selectedStoreId") ?? "");
+    const result = await updateSelectedStorePreference({
+      familyId,
+      selectedStoreId,
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        intent,
+        selectedStoreFieldErrors: result.fieldErrors,
+        selectedStoreValue: result.values.selectedStoreId,
+      } satisfies StoreModeActionData;
+    }
+
+    return buildStoreModeRedirect({
+      familyId,
+      mealPlanId,
+      notice: "selected-store-updated",
+      request,
+    });
+  }
+
+  if (intent === "toggle-shopping-item-checked") {
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+    const sourceType = parseShoppingItemSource(formData.get("sourceType"));
+    const checked = String(formData.get("checked") ?? "") === "true";
+
+    if (!sourceKey || !sourceType) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const result = await toggleShoppingItemChecked({
+      checked,
+      familyId,
+      mealPlanId,
+      sourceKey,
+      sourceType,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    return buildStoreModeRedirect({
+      familyId,
+      mealPlanId,
+      notice: "shopping-item-check-state-updated",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies StoreModeActionData;
+}
+
+export default function FamilyMealPlanStoreModeRoute({
+  actionData,
+  loaderData,
+}: FamilyMealPlanStoreModeRouteProps) {
+  const navigation = useNavigation();
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingSourceKey = getPendingSourceKey(navigation.formData);
+  const noticeContent = loaderData.notice ? getStoreModeNoticeContent(loaderData.notice) : null;
+  const selectedStoreValue =
+    actionData?.intent === "update-selected-store" && actionData.selectedStoreValue !== undefined
+      ? actionData.selectedStoreValue
+      : loaderData.selectedStore?.id ?? "";
+  const activeShoppingDateValue =
+    actionData?.intent === "update-active-shopping-date" && actionData.activeShoppingDateValue
+      ? actionData.activeShoppingDateValue
+      : loaderData.activeShoppingDate;
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-8 text-slate-900">
+      <div className="mx-auto flex max-w-4xl flex-col gap-5">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                  Butikkmodus
+                </span>
+                <h1 className="mt-4 text-3xl font-semibold tracking-tight">{loaderData.mealPlan.title}</h1>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300">
+                  Storflatevisning for handleturen med seksjonsrekkefolge fra valgt butikk og bare varer
+                  som er relevante innen handledatoen.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                  to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
+                >
+                  Apne handleliste
+                </Link>
+                <Link
+                  className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                  to={`/families/${loaderData.family.id}/stores`}
+                >
+                  Administrer butikker
+                </Link>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-[24px] bg-white/10 p-4">
+                <p className="text-sm text-slate-300">Aktiv butikk</p>
+                <p className="mt-1 text-lg font-semibold">
+                  {loaderData.selectedStore?.name ?? "Ingen valgt butikk"}
+                </p>
+              </div>
+              <div className="rounded-[24px] bg-white/10 p-4">
+                <p className="text-sm text-slate-300">Handledato</p>
+                <p className="mt-1 text-lg font-semibold">{formatDateLabel(loaderData.activeShoppingDate)}</p>
+              </div>
+              <div className="rounded-[24px] bg-emerald-500/20 p-4 ring-1 ring-emerald-400/30">
+                <p className="text-sm text-emerald-100">Fremdrift</p>
+                <p className="mt-1 text-lg font-semibold">
+                  {loaderData.progress.checkedCount}/{loaderData.progress.totalCount} varer krysset av
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">Kunne ikke oppdatere butikkmodus</h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        <section className="grid gap-4 sm:grid-cols-2">
+          <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">Velg butikk</h2>
+            <Form className="mt-4 space-y-3" method="post">
+              <input name="intent" type="hidden" value="update-selected-store" />
+              <select
+                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={selectedStoreValue}
+                name="selectedStoreId"
+              >
+                {loaderData.stores.map((store) => (
+                  <option key={store.id} value={store.id}>
+                    {store.name}
+                  </option>
+                ))}
+              </select>
+              {actionData?.intent === "update-selected-store" &&
+              actionData.selectedStoreFieldErrors?.selectedStoreId ? (
+                <p className="text-sm text-rose-600">{actionData.selectedStoreFieldErrors.selectedStoreId}</p>
+              ) : null}
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={navigation.state === "submitting" && pendingIntent === "update-selected-store"}
+                type="submit"
+              >
+                {navigation.state === "submitting" && pendingIntent === "update-selected-store"
+                  ? "Lagrer butikk..."
+                  : "Lagre butikkvalg"}
+              </button>
+            </Form>
+          </article>
+
+          <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">Velg handledato</h2>
+            <Form className="mt-4 space-y-3" method="post">
+              <input name="intent" type="hidden" value="update-active-shopping-date" />
+              <select
+                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={activeShoppingDateValue}
+                name="activeShoppingDate"
+              >
+                {loaderData.visibleDates.map((date) => (
+                  <option key={date} value={date}>
+                    {formatDateLabel(date)}
+                  </option>
+                ))}
+              </select>
+              {actionData?.intent === "update-active-shopping-date" &&
+              actionData.activeShoppingDateFieldErrors?.activeShoppingDate ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.activeShoppingDateFieldErrors.activeShoppingDate}
+                </p>
+              ) : null}
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={navigation.state === "submitting" && pendingIntent === "update-active-shopping-date"}
+                type="submit"
+              >
+                {navigation.state === "submitting" && pendingIntent === "update-active-shopping-date"
+                  ? "Lagrer dato..."
+                  : "Lagre handledato"}
+              </button>
+            </Form>
+          </article>
+        </section>
+
+        {loaderData.dueSectionGroups.length > 0 ? (
+          <section className="grid gap-4">
+            {loaderData.dueSectionGroups.map((section) => (
+              <article
+                key={`${loaderData.selectedStore?.id ?? "no-store"}:${section.category.id}`}
+                className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <h2 className="text-lg font-semibold text-slate-950">{section.displayName}</h2>
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                    {section.items.length} varer
+                  </span>
+                </div>
+
+                <div className="mt-4 grid gap-3">
+                  {section.items.map((item) => {
+                    const isPendingToggle =
+                      navigation.state === "submitting" &&
+                      pendingIntent === "toggle-shopping-item-checked" &&
+                      pendingSourceKey === item.sourceKey;
+
+                    return (
+                      <article
+                        key={item.sourceKey}
+                        className={
+                          item.checked
+                            ? "rounded-[24px] border border-emerald-200 bg-emerald-50 p-4"
+                            : "rounded-[24px] border border-slate-200 bg-slate-50 p-4"
+                        }
+                      >
+                        <div className="flex items-start gap-4">
+                          <Form method="post">
+                            <input name="intent" type="hidden" value="toggle-shopping-item-checked" />
+                            <input name="sourceKey" type="hidden" value={item.sourceKey} />
+                            <input name="sourceType" type="hidden" value={item.sourceType} />
+                            <input name="checked" type="hidden" value={item.checked ? "false" : "true"} />
+                            <button
+                              className={
+                                item.checked
+                                  ? "flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500 text-lg font-semibold text-white"
+                                  : "flex h-12 w-12 items-center justify-center rounded-full border-2 border-slate-300 bg-white text-lg font-semibold text-slate-400"
+                              }
+                              disabled={isPendingToggle}
+                              type="submit"
+                            >
+                              {item.checked ? "✓" : ""}
+                            </button>
+                          </Form>
+
+                          <div className="min-w-0 flex-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h3 className="text-base font-semibold text-slate-950">{item.name}</h3>
+                              {item.quantityLabel ? (
+                                <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                                  {item.quantityLabel}
+                                </span>
+                              ) : null}
+                              {item.sourceType === "MANUAL" ? (
+                                <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">
+                                  Manuell
+                                </span>
+                              ) : null}
+                              {item.preferredStore && item.preferredStore.id !== loaderData.selectedStore?.id ? (
+                                <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+                                  Foretrekker {item.preferredStore.name}
+                                </span>
+                              ) : null}
+                            </div>
+
+                            <p className="mt-2 text-sm leading-6 text-slate-600">
+                              {item.sourceType === "GENERATED"
+                                ? `Fra ${item.occurrenceCount} planlagte ${
+                                    item.occurrenceCount === 1 ? "middag" : "middager"
+                                  } fram til ${formatDateLabel(item.lastDate)}.`
+                                : item.buyOnDate
+                                  ? `Manuell vare planlagt for ${formatDateLabel(item.buyOnDate)}.`
+                                  : "Manuell vare uten spesifikk handledato."}
+                            </p>
+
+                            {item.note ? (
+                              <p className="mt-2 text-sm leading-6 text-slate-700">Notat: {item.note}</p>
+                            ) : null}
+                            {item.sourceType === "GENERATED" && item.postponedUntilDate ? (
+                              <p className="mt-2 text-sm leading-6 text-amber-800">
+                                Utsatt til {formatDateLabel(item.postponedUntilDate)}.
+                              </p>
+                            ) : null}
+                          </div>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </article>
+            ))}
+          </section>
+        ) : (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">Ingen varer ma handles na</h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Alt er enten ferdig handlet eller planlagt for senere i den aktive ukeplanen.
+            </p>
+          </section>
+        )}
+
+        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <h2 className="text-lg font-semibold text-slate-950">Senere i perioden</h2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {loaderData.laterItems.length > 0 ? (
+              loaderData.laterItems.map((item) => (
+                <span
+                  key={`later:${item.sourceKey}`}
+                  className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-700"
+                >
+                  {item.name}
+                  {" · "}
+                  {item.sourceType === "GENERATED"
+                    ? formatDateLabel(item.postponedUntilDate ?? item.firstDate)
+                    : item.buyOnDate
+                      ? formatDateLabel(item.buyOnDate)
+                      : "Ingen dato"}
+                </span>
+              ))
+            ) : (
+              <p className="text-sm leading-6 text-slate-600">Ingen senere varer akkurat na.</p>
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi klarte ikke a laste butikkmodus akkurat na.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke ukeplanen" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-16 text-slate-900">
+      <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
+        <Link className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white" to="/app">
+          Til appen
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function serializeProjectedShoppingItem(
+  item: Awaited<ReturnType<typeof getMealPlanStoreModeData>>["laterItems"][number],
+) {
+  if (item.sourceType === ShoppingItemSource.GENERATED) {
+    return {
+      ...item,
+      firstDate: formatDateOnly(item.firstDate),
+      lastDate: formatDateOnly(item.lastDate),
+      occurrences: item.occurrences.map((occurrence) => ({
+        ...occurrence,
+        date: formatDateOnly(occurrence.date),
+      })),
+      postponedUntilDate: item.postponedUntilDate ? formatDateOnly(item.postponedUntilDate) : null,
+    };
+  }
+
+  return {
+    ...item,
+    buyOnDate: item.buyOnDate ? formatDateOnly(item.buyOnDate) : null,
+  };
+}
+
+function getStoreModeNotice(request: Request): StoreModeNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (
+    notice === "active-shopping-date-updated" ||
+    notice === "selected-store-updated" ||
+    notice === "shopping-item-check-state-updated"
+  ) {
+    return notice;
+  }
+
+  return null;
+}
+
+function getStoreModeNoticeContent(notice: StoreModeNotice) {
+  switch (notice) {
+    case "selected-store-updated":
+      return {
+        description: "Butikkvalget ditt ble lagret for denne familien.",
+        title: "Butikkvalg lagret",
+      };
+    case "active-shopping-date-updated":
+      return {
+        description: "Handledatoen for ukeplanen ble oppdatert.",
+        title: "Handledato lagret",
+      };
+    case "shopping-item-check-state-updated":
+      return {
+        description: "Avkryssingen for varelinjen ble oppdatert.",
+        title: "Vare oppdatert",
+      };
+  }
+}
+
+function buildStoreModeRedirect({
+  familyId,
+  mealPlanId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  notice: StoreModeNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/meal-plans/${mealPlanId}/store-mode`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function parseShoppingItemSource(value: FormDataEntryValue | null) {
+  if (value === ShoppingItemSource.GENERATED || value === ShoppingItemSource.MANUAL) {
+    return value;
+  }
+
+  return null;
+}
+
+function getPendingSourceKey(formData: FormData | undefined) {
+  if (!formData) {
+    return null;
+  }
+
+  const sourceKey = formData.get("sourceKey");
+
+  if (typeof sourceKey === "string" && sourceKey.trim()) {
+    return sourceKey;
+  }
+
+  return null;
+}
+
+function buildMealPlanNotFoundResponse() {
+  return new Response("Fant ikke ukeplanen.", {
+    status: 404,
+    statusText: "Not Found",
+  });
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}
+
+function formatDateOnly(date: Date) {
+  return [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+  ].join("-");
+}
+
+function formatDateLabel(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00.000Z`));
+}

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -57,6 +57,7 @@ describe("family meal plan route", () => {
         name: "Solberg",
       },
       mealPlan: {
+        activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
         approvedAt: null,
         approvedByUserId: null,
         copiedFromMealPlanId: null,
@@ -114,6 +115,7 @@ describe("family meal plan route", () => {
         name: "Solberg",
       },
       mealPlan: {
+        activeShoppingDate: "2026-05-15",
         approvedByUserId: null,
         approvedAt: null,
         copiedFromMealPlanId: null,
@@ -262,6 +264,7 @@ describe("family meal plan route", () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(approveMealPlan).mockResolvedValue({
       mealPlan: {
+        activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
         approvedAt: new Date("2026-05-16T09:30:00.000Z"),
         approvedByUserId: "user-1",
         copiedFromMealPlanId: null,
@@ -305,6 +308,7 @@ describe("family meal plan route", () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(reopenMealPlan).mockResolvedValue({
       mealPlan: {
+        activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
         approvedAt: null,
         approvedByUserId: null,
         copiedFromMealPlanId: null,

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -97,6 +97,9 @@ export async function loader({
     family: result.family,
     mealPlan: {
       ...result.mealPlan,
+      activeShoppingDate: result.mealPlan.activeShoppingDate
+        ? formatDateOnly(result.mealPlan.activeShoppingDate)
+        : null,
       approvedAt: result.mealPlan.approvedAt ? result.mealPlan.approvedAt.toISOString() : null,
       endDate: formatDateOnly(result.mealPlan.endDate),
       entries: undefined,
@@ -284,6 +287,12 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
               >
                 Apne handleliste
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/store-mode`}
+              >
+                Apne butikkmodus
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"

--- a/app/routes/family-meal-plans.test.ts
+++ b/app/routes/family-meal-plans.test.ts
@@ -51,6 +51,7 @@ describe("family meal plans route", () => {
       },
       mealPlans: [
         {
+          activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
           createdAt: new Date("2026-05-01T12:00:00.000Z"),
           endDate: new Date("2026-05-18T00:00:00.000Z"),
           id: "meal-plan-1",
@@ -81,6 +82,7 @@ describe("family meal plans route", () => {
       },
       mealPlans: [
         {
+          activeShoppingDate: "2026-05-15",
           createdAt: new Date("2026-05-01T12:00:00.000Z"),
           endDate: "2026-05-18",
           id: "meal-plan-1",
@@ -201,6 +203,7 @@ describe("family meal plans route", () => {
         name: "Solberg",
       },
       mealPlan: {
+        activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
         approvedAt: null,
         approvedByUserId: null,
         copiedFromMealPlanId: null,
@@ -245,6 +248,7 @@ describe("family meal plans route", () => {
         name: "Solberg",
       },
       mealPlan: {
+        activeShoppingDate: new Date("2026-05-20T00:00:00.000Z"),
         approvedAt: null,
         approvedByUserId: null,
         copiedFromMealPlanId: "meal-plan-source",

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -60,6 +60,7 @@ export async function loader({
     family: result.family,
     mealPlans: result.mealPlans.map((mealPlan) => ({
       ...mealPlan,
+      activeShoppingDate: mealPlan.activeShoppingDate ? formatDateOnly(mealPlan.activeShoppingDate) : null,
       endDate: formatDateOnly(mealPlan.endDate),
       startDate: formatDateOnly(mealPlan.startDate),
     })),

--- a/app/routes/family-stores.test.ts
+++ b/app/routes/family-stores.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>("../lib/auth.server");
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/store.server", () => {
+  return {
+    getStoreManagementData: vi.fn(),
+  };
+});
+
+vi.mock("../lib/store-write.server", () => {
+  return {
+    createFamilyStore: vi.fn(),
+    deleteFamilyStore: vi.fn(),
+    updateFamilyStore: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getStoreManagementData } from "../lib/store.server";
+import { createFamilyStore, deleteFamilyStore, updateFamilyStore } from "../lib/store-write.server";
+import { action, loader } from "./family-stores";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(url = "http://localhost/families/family-1/stores", formData?: FormData) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family stores route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads scoped store management data", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getStoreManagementData).mockResolvedValue({
+      categories: [
+        {
+          displayName: "Frukt og gront",
+          id: "category-produce",
+        },
+      ],
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      familyStores: [
+        {
+          familyId: "family-1",
+          id: "store-1",
+          key: null,
+          name: "Helgebutikk",
+          sections: [
+            {
+              categoryId: "category-produce",
+              displayName: "Gront",
+              id: "section-1",
+              sortOrder: 1,
+            },
+          ],
+        },
+      ],
+      globalStores: [],
+      userRole: "ADMIN",
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(getStoreManagementData).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      categories: [
+        {
+          displayName: "Frukt og gront",
+          id: "category-produce",
+        },
+      ],
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      familyStores: [
+        {
+          familyId: "family-1",
+          id: "store-1",
+          key: null,
+          name: "Helgebutikk",
+          sections: [
+            {
+              categoryId: "category-produce",
+              displayName: "Gront",
+              id: "section-1",
+              sortOrder: 1,
+            },
+          ],
+        },
+      ],
+      globalStores: [],
+      notice: null,
+      userRole: "ADMIN",
+    });
+  });
+
+  it("returns create validation errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createFamilyStore).mockResolvedValue({
+      fieldErrors: {
+        name: "Skriv inn et butikknavn.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        name: "",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-store");
+    formData.set("name", "   ");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/stores", formData),
+    });
+
+    expect(createFamilyStore).toHaveBeenCalledWith({
+      familyId: "family-1",
+      name: "   ",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      createFieldErrors: {
+        name: "Skriv inn et butikknavn.",
+      },
+      createValues: {
+        name: "",
+      },
+      intent: "create-store",
+    });
+  });
+
+  it("redirects after deleting a store", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(deleteFamilyStore).mockResolvedValue({
+      status: "DELETED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "delete-store");
+    formData.set("storeId", "store-1");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/stores", formData),
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/stores?notice=store-deleted",
+    );
+  });
+
+  it("submits the full staged section order when updating a store", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateFamilyStore).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-store");
+    formData.set("storeId", "store-1");
+    formData.set("name", "Helgebutikk");
+    formData.append("sectionCategoryId", "category-produce");
+    formData.append("sectionCategoryId", "category-bakery");
+    formData.set("sectionDisplayName:category-produce", "Frukt og gront");
+    formData.set("sectionDisplayName:category-bakery", "Brod");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/stores", formData),
+    });
+
+    expect(updateFamilyStore).toHaveBeenCalledWith({
+      familyId: "family-1",
+      storeId: "store-1",
+      userId: "user-1",
+      values: {
+        name: "Helgebutikk",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+          },
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+          },
+        ],
+      },
+    });
+    expect((result as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/stores?notice=store-updated",
+    );
+  });
+});

--- a/app/routes/family-stores.tsx
+++ b/app/routes/family-stores.tsx
@@ -1,0 +1,450 @@
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { FamilyStoreEditorCard } from "../components/family-store-editor-card";
+import { getStoreManagementData } from "../lib/store.server";
+import {
+  createFamilyStore,
+  deleteFamilyStore,
+  updateFamilyStore,
+  type FamilyStoreFieldErrors,
+  type FamilyStoreValues,
+} from "../lib/store-write.server";
+
+type StoresNotice =
+  | "store-created"
+  | "store-deleted"
+  | "store-updated";
+
+type StoresIntent =
+  | "create-store"
+  | "delete-store"
+  | "update-store";
+
+interface StoresActionData {
+  createFieldErrors?: {
+    name?: string;
+  };
+  createValues?: {
+    name: string;
+  };
+  formError?: string;
+  intent?: StoresIntent;
+  targetStoreId?: string;
+  updateFieldErrors?: FamilyStoreFieldErrors;
+  updateValues?: FamilyStoreValues;
+}
+
+interface FamilyStoresRouteProps {
+  actionData?: StoresActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Butikker | Mealplanner" },
+    { name: "description", content: "Administrer familiebutikker og seksjonsrekkefolge i Mealplanner." },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const result = await getStoreManagementData({
+    familyId,
+    userId: user.id,
+  });
+
+  return {
+    categories: result.categories,
+    family: result.family,
+    familyStores: result.familyStores,
+    globalStores: result.globalStores,
+    notice: getStoresNotice(request),
+    userRole: result.userRole,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "create-store") {
+    const name = String(formData.get("name") ?? "");
+    const result = await createFamilyStore({
+      familyId,
+      name,
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        createFieldErrors: result.fieldErrors,
+        createValues: result.values,
+        intent,
+      } satisfies StoresActionData;
+    }
+
+    return buildStoresRedirect({
+      familyId,
+      notice: "store-created",
+      request,
+    });
+  }
+
+  if (intent === "update-store") {
+    const storeId = String(formData.get("storeId") ?? "").trim();
+    const values = parseFamilyStoreValues(formData);
+
+    if (!storeId) {
+      return {
+        formError: "Fant ikke butikken som skulle oppdateres.",
+        intent,
+      } satisfies StoresActionData;
+    }
+
+    const result = await updateFamilyStore({
+      familyId,
+      storeId,
+      userId: user.id,
+      values,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke butikken som skulle oppdateres.",
+        intent,
+        targetStoreId: storeId,
+      } satisfies StoresActionData;
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        intent,
+        targetStoreId: storeId,
+        updateFieldErrors: result.fieldErrors,
+        updateValues: result.values,
+      } satisfies StoresActionData;
+    }
+
+    return buildStoresRedirect({
+      familyId,
+      notice: "store-updated",
+      request,
+    });
+  }
+
+  if (intent === "delete-store") {
+    const storeId = String(formData.get("storeId") ?? "").trim();
+
+    if (!storeId) {
+      return {
+        formError: "Fant ikke butikken som skulle slettes.",
+        intent,
+      } satisfies StoresActionData;
+    }
+
+    const result = await deleteFamilyStore({
+      familyId,
+      storeId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke butikken som skulle slettes.",
+        intent,
+        targetStoreId: storeId,
+      } satisfies StoresActionData;
+    }
+
+    return buildStoresRedirect({
+      familyId,
+      notice: "store-deleted",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies StoresActionData;
+}
+
+export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStoresRouteProps) {
+  const navigation = useNavigation();
+  const noticeContent = loaderData.notice ? getStoresNoticeContent(loaderData.notice) : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const createValues = actionData?.intent === "create-store" && actionData.createValues
+    ? actionData.createValues
+    : { name: "" };
+  const canManageStores = loaderData.userRole === "ADMIN";
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Butikker
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.family.name}</h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Administrer familiebutikker og bestem seksjonsrekkefolgen slik at butikkmodus folger
+                handleturen deres.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Apne ukeplaner
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}`}
+              >
+                Tilbake til familie
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">Kunne ikke oppdatere butikkene</h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        {canManageStores ? (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Opprett familiebutikk</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Nye butikker starter med alle kategorier og kan tilpasses videre under.
+              </p>
+            </div>
+
+            <Form className="mt-6 space-y-4" method="post">
+              <input name="intent" type="hidden" value="create-store" />
+              <label className="block text-sm font-medium text-slate-700">
+                Butikknavn
+                <input
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={createValues.name}
+                  name="name"
+                  placeholder="For eksempel Helgebutikk"
+                  type="text"
+                />
+              </label>
+              {actionData?.intent === "create-store" && actionData.createFieldErrors?.name ? (
+                <p className="text-sm text-rose-600">{actionData.createFieldErrors.name}</p>
+              ) : null}
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={navigation.state === "submitting" && pendingIntent === "create-store"}
+                type="submit"
+              >
+                {navigation.state === "submitting" && pendingIntent === "create-store"
+                  ? "Oppretter..."
+                  : "Opprett butikk"}
+              </button>
+            </Form>
+          </section>
+        ) : null}
+
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Seedede standardbutikker</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Disse butikkene er tilgjengelige for familien som faste utgangspunkt og kan ikke redigeres.
+              </p>
+            </div>
+
+            <div className="mt-6 grid gap-4">
+              {loaderData.globalStores.map((store) => (
+                <article key={store.id} className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                  <h3 className="text-base font-semibold text-slate-950">{store.name}</h3>
+                  <ol className="mt-4 grid gap-2 text-sm leading-6 text-slate-700">
+                    {store.sections.map((section, index) => (
+                      <li key={section.id}>
+                        {index + 1}. {section.displayName}
+                      </li>
+                    ))}
+                  </ol>
+                </article>
+              ))}
+            </div>
+          </article>
+
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">Familiebutikker</h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Gi butikkene egne navn og tilpass seksjonsrekkefolgen for akkurat denne familien.
+              </p>
+            </div>
+
+            {loaderData.familyStores.length > 0 ? (
+              <DndProvider backend={HTML5Backend}>
+                <div className="mt-6 grid gap-5">
+                  {loaderData.familyStores.map((store) => (
+                    <FamilyStoreEditorCard
+                      canManageStores={canManageStores}
+                      key={store.id}
+                      store={store}
+                      updateFieldErrors={
+                        actionData?.intent === "update-store" && actionData.targetStoreId === store.id
+                          ? actionData.updateFieldErrors
+                          : undefined
+                      }
+                      updateValues={
+                        actionData?.intent === "update-store" && actionData.targetStoreId === store.id
+                          ? actionData.updateValues
+                          : undefined
+                      }
+                    />
+                  ))}
+                </div>
+              </DndProvider>
+            ) : (
+              <p className="mt-6 text-sm leading-6 text-slate-600">
+                Familien har ingen egne butikker ennå. Opprett en butikk for a fa en egen seksjonsrekkefolge.
+              </p>
+            )}
+          </article>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi klarte ikke a laste butikkoppsettet akkurat na.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke familien" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-16 text-slate-900">
+      <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
+        <Link className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white" to="/app">
+          Til appen
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function getStoresNotice(request: Request): StoresNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (
+    notice === "store-created" ||
+    notice === "store-deleted" ||
+    notice === "store-updated"
+  ) {
+    return notice;
+  }
+
+  return null;
+}
+
+function getStoresNoticeContent(notice: StoresNotice) {
+  switch (notice) {
+    case "store-created":
+      return {
+        description: "Butikken ble opprettet med alle kategorier klare for videre tilpasning.",
+        title: "Butikken er opprettet",
+      };
+    case "store-updated":
+      return {
+        description: "Butikknavn og seksjonsnavn ble lagret.",
+        title: "Butikken er oppdatert",
+      };
+    case "store-deleted":
+      return {
+        description: "Butikken ble slettet. Eventuelle preferanser peker na ikke lenger til denne butikken.",
+        title: "Butikken er slettet",
+      };
+  }
+}
+
+function buildStoresRedirect({
+  familyId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  notice: StoresNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/stores`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function parseFamilyStoreValues(formData: FormData): FamilyStoreValues {
+  const categoryIds = formData.getAll("sectionCategoryId").map((value) => String(value));
+
+  return {
+    name: String(formData.get("name") ?? ""),
+    sections: categoryIds.map((categoryId) => ({
+      categoryId,
+      displayName: String(formData.get(`sectionDisplayName:${categoryId}`) ?? ""),
+    })),
+  };
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -183,6 +183,12 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/stores`}
+              >
+                Administrer butikker
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to="/app"
               >
                 Tilbake til oversikten

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
         "@react-router/serve": "7.15.0",
         "isbot": "^5.1.36",
         "react": "^19.2.6",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^19.2.6",
         "react-router": "7.15.0",
         "zod": "^4.4.3"
@@ -483,7 +485,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1520,6 +1521,24 @@
       "dependencies": {
         "@prisma/debug": "6.19.3"
       }
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
     },
     "node_modules/@react-router/dev": {
       "version": "7.15.0",
@@ -2689,7 +2708,7 @@
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2699,7 +2718,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3736,7 +3755,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3871,6 +3890,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -4397,7 +4427,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4750,6 +4779,21 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -6077,6 +6121,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
@@ -6168,6 +6251,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/resolve-from": {
@@ -6869,7 +6961,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@react-router/serve": "7.15.0",
     "isbot": "^5.1.36",
     "react": "^19.2.6",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.2.6",
     "react-router": "7.15.0",
     "zod": "^4.4.3"

--- a/prisma/migrations/20260514184500_store_mode_preferences/migration.sql
+++ b/prisma/migrations/20260514184500_store_mode_preferences/migration.sql
@@ -1,0 +1,39 @@
+-- AlterTable
+ALTER TABLE "MealPlan"
+ADD COLUMN "activeShoppingDate" DATE;
+
+-- CreateTable
+CREATE TABLE "UserStorePreference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "selectedStoreId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserStorePreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserStorePreference_userId_familyId_key" ON "UserStorePreference"("userId", "familyId");
+
+-- CreateIndex
+CREATE INDEX "UserStorePreference_userId_idx" ON "UserStorePreference"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserStorePreference_familyId_idx" ON "UserStorePreference"("familyId");
+
+-- CreateIndex
+CREATE INDEX "UserStorePreference_selectedStoreId_idx" ON "UserStorePreference"("selectedStoreId");
+
+-- AddForeignKey
+ALTER TABLE "UserStorePreference"
+ADD CONSTRAINT "UserStorePreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserStorePreference"
+ADD CONSTRAINT "UserStorePreference_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserStorePreference"
+ADD CONSTRAINT "UserStorePreference_selectedStoreId_fkey" FOREIGN KEY ("selectedStoreId") REFERENCES "Store"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   memberships       FamilyMembership[]
   createdRecipes    Recipe[]           @relation("RecipeCreatedBy")
   approvedMealPlans MealPlan[]         @relation("MealPlanApprovedBy")
+  storePreferences  UserStorePreference[]
 
   @@index([displayName])
 }
@@ -63,6 +64,7 @@ model Family {
   recipes         Recipe[]
   mealPlans       MealPlan[]
   stores          Store[]
+  storePreferences UserStorePreference[]
 
   @@index([createdByUserId])
   @@index([name])
@@ -161,6 +163,7 @@ model MealPlan {
   title                String
   startDate            DateTime               @db.Date
   endDate              DateTime               @db.Date
+  activeShoppingDate   DateTime?              @db.Date
   status               MealPlanStatus         @default(DRAFT)
   approvedByUserId     String?
   approvedAt           DateTime?
@@ -252,6 +255,7 @@ model Store {
   recipeIngredientsPreferred RecipeIngredient[]     @relation("RecipeIngredientPreferredStore")
   manualItemsPreferred       ManualShoppingItem[]   @relation("ManualShoppingItemPreferredStore")
   shoppingOverridesPreferred ShoppingItemOverride[] @relation("ShoppingItemOverridePreferredStore")
+  selectedByPreferences      UserStorePreference[]  @relation("UserStorePreferenceSelectedStore")
 
   @@unique([familyId, name])
   @@index([familyId])
@@ -271,4 +275,21 @@ model StoreSection {
   @@unique([storeId, categoryId])
   @@index([storeId, sortOrder])
   @@index([categoryId])
+}
+
+model UserStorePreference {
+  id              String   @id @default(cuid())
+  userId          String
+  familyId        String
+  selectedStoreId String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  family          Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  selectedStore   Store?   @relation("UserStorePreferenceSelectedStore", fields: [selectedStoreId], references: [id], onDelete: SetNull)
+
+  @@unique([userId, familyId])
+  @@index([userId])
+  @@index([familyId])
+  @@index([selectedStoreId])
 }


### PR DESCRIPTION
## Summary
- add persisted meal-plan shopping date and per-user selected store support for store mode
- add family store CRUD, including staged drag-and-drop section ordering before save
- add a compact store-mode route plus navigation from the family, meal-plan, and shopping flows

Closes #13.

## Test plan
- [x] `npm run test:run -- app/lib/store-write.server.test.ts app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-stores.test.ts app/routes/family-meal-plan-store-mode.test.ts app/routes/family-meal-plan-shopping.test.ts app/routes/family-meal-plan.test.ts app/routes/family-meal-plans.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `npm run prisma:migrate:dev -- --name store_mode_preferences`
- [ ] `npm run test:run` still has the pre-existing `crypto is not defined` failures in `app/lib/session.server.test.ts` and `app/lib/auth.server.test.ts`
- [ ] Manual browser smoke test not run yet for `families/:familyId/stores` and `families/:familyId/meal-plans/:mealPlanId/store-mode`