### PR TITLE
Add server-side meal plan calendar exports

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,41 +2,33 @@
 
 ## Current Objective
 
-Implement issue `#13`'s store configuration and in-store shopping flow: family store CRUD, persisted active shopping date, persisted per-user selected store, and a compact mobile-first store mode route.
+Implement issue `#14`'s server-side calendar export flow: family-scoped `.ics` downloads for a whole meal plan and a single day, plus entry points from the meal plan UI.
 
 ## Completed
 
-- Extended `prisma/schema.prisma` with `MealPlan.activeShoppingDate` and a new `UserStorePreference` model, plus a matching migration in `prisma/migrations/20260514184500_store_mode_preferences/migration.sql`.
-- Added `app/lib/store.server.ts` and `app/lib/store-write.server.ts` for scoped store reads plus family store create/update/reorder/delete and per-user selected-store persistence.
-- Expanded `app/lib/shopping.server.ts` with `getMealPlanStoreModeData()` so store mode reuses the merged shopping projection but filters to due items by active shopping date and re-groups them using the selected store's section order.
-- Added `updateActiveShoppingDate()` to `app/lib/shopping-write.server.ts` and updated `app/lib/meal-plan.server.ts` so new meal plans start with a valid active shopping date and range edits clamp it safely.
-- Added `app/routes/family-stores.tsx` plus `app/components/family-store-editor-card.tsx` so family stores now use an explicit edit mode with staged React DnD section ordering and a single save instead of per-move server round-trips, then wired the new flow into the existing store CRUD route.
-- Added `app/routes/family-meal-plan-store-mode.tsx` for the mobile shopping flow, then wired navigation in `app/routes.ts`, `app/routes/family.tsx`, `app/routes/family-meal-plan.tsx`, and `app/routes/family-meal-plan-shopping.tsx`.
-- Added focused coverage in `app/lib/store-write.server.test.ts`, `app/lib/shopping.server.test.ts`, `app/lib/shopping-write.server.test.ts`, `app/routes/family-stores.test.ts`, and `app/routes/family-meal-plan-store-mode.test.ts`, plus updated existing meal-plan/shopping route tests for serialized `activeShoppingDate`.
+- Added `app/lib/calendar.server.ts` to fetch family-scoped dinner entries, generate timed ICS output for `16:00-17:00` dinners in `Europe/Oslo`, validate requested day exports, and produce download-friendly filenames.
+- Added explicit calendar export routes in `app/routes.ts` plus thin loaders in `app/routes/family-meal-plan-calendar.ts` and `app/routes/family-meal-plan-day-calendar.ts`.
+- Updated `app/routes/family-meal-plan.tsx` so the meal plan page now shows a whole-plan export action and per-day export links for saved dinner entries, with downloads routed through a hidden iframe so the page does not navigate away.
+- Added focused coverage in `app/lib/calendar.server.test.ts`, `app/routes/family-meal-plan-calendar.test.ts`, and `app/routes/family-meal-plan-day-calendar.test.ts`.
 
 ## Files To Read First
 
-- `app/lib/store-write.server.ts` - Family store CRUD rules, section reorder behavior, and selected-store persistence.
-- `app/components/family-store-editor-card.tsx` - Local edit mode, staged section drafts, and React DnD row reordering before save.
-- `app/lib/shopping.server.ts` - Shared shopping projection plus the new store-mode view model.
-- `app/routes/family-stores.tsx` - Store management route, action intents, and editable family-store UI.
-- `app/routes/family-meal-plan-store-mode.tsx` - Compact in-store shopping route, serialized loader data, and action handling.
+- `app/lib/calendar.server.ts` - Server-side ICS formatting, meal-plan/day export rules, and family-scoped read behavior.
+- `app/routes/family-meal-plan-calendar.ts` - Whole-plan download route and response headers.
+- `app/routes/family-meal-plan-day-calendar.ts` - Single-day download route and invalid-day handling.
+- `app/routes/family-meal-plan.tsx` - UI links for whole-plan and per-day exports.
 
 ## Validation
 
-- `npm run test:run -- app/lib/store-write.server.test.ts app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-stores.test.ts app/routes/family-meal-plan-store-mode.test.ts app/routes/family-meal-plan-shopping.test.ts app/routes/family-meal-plan.test.ts app/routes/family-meal-plans.test.ts`
-- `npm run test:run` (all tests passed except the two existing `crypto is not defined` failures in `app/lib/session.server.test.ts` and `app/lib/auth.server.test.ts`)
+- `npm run test:run -- app/lib/calendar.server.test.ts app/routes/family-meal-plan-calendar.test.ts app/routes/family-meal-plan-day-calendar.test.ts app/routes/family-meal-plan.test.ts`
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
-- No manual browser smoke test has been run yet for `families/:familyId/stores` or `families/:familyId/meal-plans/:mealPlanId/store-mode`.
-- The new store editor uses the HTML5 React DnD backend, so drag-and-drop should be manually verified in the browser environment you care about most.
-- `npm run typecheck` currently fails before project checks run because the local Node runtime is `v18.20.8` while the installed React Router toolchain now expects `>20`; plain `tsc --noEmit` succeeds.
-- The only remaining automated test failures are pre-existing environment/runtime issues where React Router cookie/session helpers expect `crypto.subtle` during `app/lib/session.server.test.ts` and `app/lib/auth.server.test.ts`.
-- Family store creation currently starts from the full category list ordered by category display name. There is no "copy from seeded store" shortcut yet.
-- Seeded/global stores remain visible alongside family stores in selectors and management views; there is no hide/archive behavior for seeded stores.
+- No manual browser smoke test has been run yet for the new `.ics` downloads from `families/:familyId/meal-plans/:mealPlanId`, including verification that the hidden-iframe download flow keeps the user on the meal plan page and that calendar clients import them as same-day `16:00-17:00` dinners.
+- Draft meal plans are currently exportable because calendar routes follow the same family-member read rules as the existing planner and shopping views.
+- `npm run typecheck` still needs a Node `>20` environment if you want to verify the full React Router/typegen pipeline instead of plain `tsc --noEmit`.
 
 ## Next Step
 
-Run a manual end-to-end smoke test covering store creation/reordering/deletion and the new store-mode flow, then rerun `npm run typecheck` in a Node `>20` environment to confirm the full React Router/typegen pipeline.
+Run a browser smoke test for whole-plan and single-day `.ics` downloads, then confirm whether product wants to keep draft meal plans exportable or gate exports on approval later.

--- a/app/components/family-store-editor-card.tsx
+++ b/app/components/family-store-editor-card.tsx
@@ -134,7 +134,7 @@ export function FamilyStoreEditorCard({
           <p className="mt-2 text-sm leading-6 text-slate-600">
             {isEditing
               ? "Dra og slipp seksjonene i den rekkefolgen dere faktisk gar gjennom butikken, og lagre nar alt ser riktig ut."
-              : "Aapne redigering for a endre navn, seksjonsnavn og rekkefolge i en samlet lagring."}
+              : "Åpne redigering for a endre navn, seksjonsnavn og rekkefolge i en samlet lagring."}
           </p>
         </div>
 

--- a/app/lib/calendar.server.test.ts
+++ b/app/lib/calendar.server.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      mealPlan: {
+        findFirst: vi.fn(),
+      },
+    },
+    requireFamilyMembershipMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+vi.mock("./family.server", () => {
+  return {
+    requireFamilyMembership: requireFamilyMembershipMock,
+  };
+});
+
+import {
+  createCalendarFile,
+  getMealPlanCalendarExport,
+  getMealPlanDayCalendarExport,
+} from "./calendar.server";
+
+const mockMembership = {
+  family: {
+    id: "family-1",
+    joinCode: "ABC123",
+    name: "Solberg",
+  },
+  familyId: "family-1",
+  id: "membership-1",
+  role: "ADMIN",
+  userId: "user-1",
+};
+
+describe("calendar.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T09:30:45.000Z"));
+    requireFamilyMembershipMock.mockResolvedValue(mockMembership);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("creates timed ICS content with CRLF line endings and escaped values", () => {
+    const content = createCalendarFile("Mealplanner - Langhelg", [
+      {
+        date: "2026-05-15",
+        description: "Linje 1,\nLinje 2; med \\ tegn",
+        title: "Middag, pesto; pasta",
+        uid: "meal-plan-1\\2026-05-15",
+      },
+    ]);
+
+    expect(content).toContain("\r\nBEGIN:VEVENT\r\n");
+    expect(content).toContain("DTSTAMP:20260514T093045Z");
+    expect(content).toContain("X-WR-TIMEZONE:Europe/Oslo");
+    expect(content).toContain("SUMMARY:Middag\\, pesto\\; pasta");
+    expect(content).toContain("DESCRIPTION:Linje 1\\,\\nLinje 2\\; med \\\\ tegn");
+    expect(content).toContain("UID:meal-plan-1\\\\2026-05-15");
+    expect(content).toContain("DTSTART;TZID=Europe/Oslo:20260515T160000");
+    expect(content).toContain("DTEND;TZID=Europe/Oslo:20260515T170000");
+  });
+
+  it("exports only recipe-backed meal-plan dinners", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          recipe: {
+            description: null,
+            title: "Taco fredag",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          recipe: null,
+          recipeId: "",
+        },
+      ],
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      title: "Langhelg",
+    });
+
+    const result = await getMealPlanCalendarExport({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyMembershipMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result.fileName).toBe("langhelg-ukeplan.ics");
+    expect(result.content.match(/BEGIN:VEVENT/g)).toHaveLength(1);
+    expect(result.content).toContain("SUMMARY:Middag: Taco fredag");
+    expect(result.content).toContain("DESCRIPTION:Planlagt for");
+    expect(result.content).toContain("i Langhelg. Ingen beskrivelse.");
+  });
+
+  it("exports a single day as a timed dinner calendar file", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          recipe: {
+            description: "Rask middagsfavoritt.",
+            title: "Kyllingtaco",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      title: "Langhelg",
+    });
+
+    const result = await getMealPlanDayCalendarExport({
+      date: "2026-05-16",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.fileName).toBe("langhelg-2026-05-16.ics");
+    expect(result.content.match(/BEGIN:VEVENT/g)).toHaveLength(1);
+    expect(result.content).toContain("SUMMARY:Middag: Kyllingtaco");
+    expect(result.content).toContain("DTSTART;TZID=Europe/Oslo:20260516T160000");
+    expect(result.content).toContain("DTEND;TZID=Europe/Oslo:20260516T170000");
+    expect(result.content).toContain("Rask middagsfavoritt.");
+  });
+
+  it("rejects invalid day exports before creating a file", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [],
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      title: "Langhelg",
+    });
+
+    await expect(
+      getMealPlanDayCalendarExport({
+        date: "2026-05-32",
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+});

--- a/app/lib/calendar.server.ts
+++ b/app/lib/calendar.server.ts
@@ -1,0 +1,301 @@
+import { MealType, Prisma } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+
+const CALENDAR_TIME_ZONE = "Europe/Oslo";
+const DINNER_END_HOUR = 17;
+const DINNER_START_HOUR = 16;
+
+const mealPlanCalendarSelect = Prisma.validator<Prisma.MealPlanSelect>()({
+  endDate: true,
+  entries: {
+    orderBy: [{ date: "asc" }],
+    select: {
+      date: true,
+      recipe: {
+        select: {
+          description: true,
+          title: true,
+        },
+      },
+      recipeId: true,
+    },
+    where: {
+      mealType: MealType.DINNER,
+    },
+  },
+  id: true,
+  startDate: true,
+  title: true,
+});
+
+export interface CalendarEventInput {
+  date: string;
+  description: string;
+  title: string;
+  uid: string;
+}
+
+interface MealPlanCalendarExportInput {
+  familyId: string;
+  mealPlanId: string;
+  userId: string;
+}
+
+interface MealPlanDayCalendarExportInput extends MealPlanCalendarExportInput {
+  date: string;
+}
+
+interface CalendarFileResult {
+  content: string;
+  fileName: string;
+}
+
+export async function getMealPlanCalendarExport(
+  input: MealPlanCalendarExportInput,
+): Promise<CalendarFileResult> {
+  const mealPlan = await getMealPlanCalendarData(input);
+  const events = buildMealPlanEvents(mealPlan);
+
+  if (!events.length) {
+    throw new Response("Fant ingen planlagte middager a eksportere.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return {
+    content: createCalendarFile(getCalendarName(mealPlan.title), events),
+    fileName: `${getMealPlanFileSlug(mealPlan.title)}-ukeplan.ics`,
+  };
+}
+
+export async function getMealPlanDayCalendarExport(
+  input: MealPlanDayCalendarExportInput,
+): Promise<CalendarFileResult> {
+  const mealPlan = await getMealPlanCalendarData(input);
+  const requestedDate = parseDateOnly(input.date);
+
+  if (!requestedDate || !isDateWithinRange(requestedDate, mealPlan.startDate, mealPlan.endDate)) {
+    throw new Response("Fant ikke dagen i ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  const event = buildMealPlanEventForDate(mealPlan, input.date);
+
+  if (!event) {
+    throw new Response("Fant ingen planlagt middag denne dagen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return {
+    content: createCalendarFile(getCalendarName(mealPlan.title), [event]),
+    fileName: `${getMealPlanFileSlug(mealPlan.title)}-${input.date}.ics`,
+  };
+}
+
+export function createCalendarFile(
+  calendarName: string,
+  events: CalendarEventInput[],
+  stamp = new Date(),
+): string {
+  const eventContent = events.map((event) => createCalendarEvent(event, stamp)).join("\r\n");
+
+  return [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Mealplanner//NO",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    `X-WR-TIMEZONE:${CALENDAR_TIME_ZONE}`,
+    `X-WR-CALNAME:${escapeText(calendarName)}`,
+    eventContent,
+    "END:VCALENDAR",
+  ].join("\r\n");
+}
+
+async function getMealPlanCalendarData({ familyId, mealPlanId, userId }: MealPlanCalendarExportInput) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: mealPlanCalendarSelect,
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    throw new Response("Fant ikke ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return mealPlan;
+}
+
+function buildMealPlanEvents(mealPlan: Awaited<ReturnType<typeof getMealPlanCalendarData>>) {
+  return mealPlan.entries.flatMap((entry) => {
+    const date = formatDateOnly(entry.date);
+
+    if (!entry.recipeId || !entry.recipe) {
+      return [];
+    }
+
+    return [createMealPlanEvent({ date, mealPlanId: mealPlan.id, mealPlanTitle: mealPlan.title, recipe: entry.recipe })];
+  });
+}
+
+function buildMealPlanEventForDate(
+  mealPlan: Awaited<ReturnType<typeof getMealPlanCalendarData>>,
+  date: string,
+) {
+  const entry = mealPlan.entries.find((mealPlanEntry) => formatDateOnly(mealPlanEntry.date) === date);
+
+  if (!entry?.recipeId || !entry.recipe) {
+    return null;
+  }
+
+  return createMealPlanEvent({
+    date,
+    mealPlanId: mealPlan.id,
+    mealPlanTitle: mealPlan.title,
+    recipe: entry.recipe,
+  });
+}
+
+function createMealPlanEvent({
+  date,
+  mealPlanId,
+  mealPlanTitle,
+  recipe,
+}: {
+  date: string;
+  mealPlanId: string;
+  mealPlanTitle: string;
+  recipe: {
+    description: string | null;
+    title: string;
+  };
+}): CalendarEventInput {
+  return {
+    date,
+    description: createMealPlanDescription(date, mealPlanTitle, recipe.description),
+    title: `Middag: ${recipe.title}`,
+    uid: `${mealPlanId}-${date}@mealplanner`,
+  };
+}
+
+function createCalendarEvent(event: CalendarEventInput, stamp: Date) {
+  const startDateTime = formatIcsLocalDateTime(event.date, DINNER_START_HOUR);
+  const endDateTime = formatIcsLocalDateTime(event.date, DINNER_END_HOUR);
+
+  return [
+    "BEGIN:VEVENT",
+    `UID:${escapeText(event.uid)}`,
+    `DTSTAMP:${formatDateTimeStamp(stamp)}`,
+    `SUMMARY:${escapeText(event.title)}`,
+    `DTSTART;TZID=${CALENDAR_TIME_ZONE}:${startDateTime}`,
+    `DTEND;TZID=${CALENDAR_TIME_ZONE}:${endDateTime}`,
+    `DESCRIPTION:${escapeText(event.description)}`,
+    "END:VEVENT",
+  ].join("\r\n");
+}
+
+function createMealPlanDescription(date: string, mealPlanTitle: string, recipeDescription: string | null) {
+  const formattedDate = new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    weekday: "long",
+    year: "numeric",
+  }).format(parseDateOnly(date)!);
+  const normalizedDescription = recipeDescription?.trim() || "Ingen beskrivelse.";
+
+  return `Planlagt for ${formattedDate} i ${mealPlanTitle}. ${normalizedDescription}`;
+}
+
+function getCalendarName(mealPlanTitle: string) {
+  return `Mealplanner - ${mealPlanTitle}`;
+}
+
+function getMealPlanFileSlug(mealPlanTitle: string) {
+  const slug = mealPlanTitle
+    .toLowerCase()
+    .trim()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "");
+
+  return slug || "meal-plan";
+}
+
+function formatDateOnly(date: Date) {
+  return [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+  ].join("-");
+}
+
+function parseDateOnly(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearValue, monthValue, dayValue] = value.split("-");
+  const year = Number(yearValue);
+  const month = Number(monthValue);
+  const day = Number(dayValue);
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    Number.isNaN(parsedDate.getTime()) ||
+    parsedDate.getUTCFullYear() !== year ||
+    parsedDate.getUTCMonth() !== month - 1 ||
+    parsedDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsedDate;
+}
+
+function isDateWithinRange(date: Date, startDate: Date, endDate: Date) {
+  return date.getTime() >= startDate.getTime() && date.getTime() <= endDate.getTime();
+}
+
+function formatIcsDate(value: string) {
+  return value.replaceAll("-", "");
+}
+
+function formatIcsLocalDateTime(value: string, hour: number) {
+  return `${formatIcsDate(value)}T${hour.toString().padStart(2, "0")}0000`;
+}
+
+function formatDateTimeStamp(value: Date) {
+  const year = value.getUTCFullYear();
+  const month = `${value.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${value.getUTCDate()}`.padStart(2, "0");
+  const hours = `${value.getUTCHours()}`.padStart(2, "0");
+  const minutes = `${value.getUTCMinutes()}`.padStart(2, "0");
+  const seconds = `${value.getUTCSeconds()}`.padStart(2, "0");
+
+  return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
+}
+
+function escapeText(value: string) {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll(";", "\\;")
+    .replaceAll(",", "\\,")
+    .replaceAll("\n", "\\n");
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -6,6 +6,11 @@ export default [
   route("families/:familyId", "routes/family.tsx"),
   route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
   route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
+  route("families/:familyId/meal-plans/:mealPlanId/calendar.ics", "routes/family-meal-plan-calendar.ts"),
+  route(
+    "families/:familyId/meal-plans/:mealPlanId/days/:date/calendar.ics",
+    "routes/family-meal-plan-day-calendar.ts",
+  ),
   route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
   route("families/:familyId/meal-plans/:mealPlanId/store-mode", "routes/family-meal-plan-store-mode.tsx"),
   route("families/:familyId/stores", "routes/family-stores.tsx"),

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -26,7 +26,11 @@ interface AppActionData {
 function getAppNotice(request: Request): AppNotice | null {
   const notice = new URL(request.url).searchParams.get("notice");
 
-  if (notice === "family-created" || notice === "family-joined" || notice === "family-already-member") {
+  if (
+    notice === "family-created" ||
+    notice === "family-joined" ||
+    notice === "family-already-member"
+  ) {
     return notice;
   }
 
@@ -44,17 +48,20 @@ function getNoticeContent(notice: AppNotice) {
   switch (notice) {
     case "family-created":
       return {
-        description: "Du opprettet en familie og ble lagt til som administrator.",
+        description:
+          "Du opprettet en familie og ble lagt til som administrator.",
         title: "Familien er klar",
       };
     case "family-joined":
       return {
-        description: "Du er lagt til i familien og kan fortsette i den beskyttede appen.",
+        description:
+          "Du er lagt til i familien og kan fortsette i den beskyttede appen.",
         title: "Du ble med i familien",
       };
     case "family-already-member":
       return {
-        description: "Du hadde allerede tilgang til denne familien, sa vi viste deg oversikten i stedet.",
+        description:
+          "Du hadde allerede tilgang til denne familien, sa vi viste deg oversikten i stedet.",
         title: "Du er allerede medlem",
       };
   }
@@ -148,11 +155,16 @@ export async function action({ request }: Route.ActionArgs) {
   } satisfies AppActionData;
 }
 
-export default function AppRoute({ actionData, loaderData }: Route.ComponentProps) {
+export default function AppRoute({
+  actionData,
+  loaderData,
+}: Route.ComponentProps) {
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
   const hasFamilies = loaderData.memberships.length > 0;
-  const noticeContent = loaderData.notice ? getNoticeContent(loaderData.notice) : null;
+  const noticeContent = loaderData.notice
+    ? getNoticeContent(loaderData.notice)
+    : null;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -163,7 +175,9 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
               <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                 Mealplanner
               </span>
-              <h1 className="mt-4 text-4xl font-semibold tracking-tight">Hei, {loaderData.user.displayName}</h1>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                Hei, {loaderData.user.displayName}
+              </h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
                 {hasFamilies
                   ? "Dette er den beskyttede familieoversikten din, klar for videre arbeid med ukeplaner og handlelister."
@@ -193,59 +207,73 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
         {noticeContent ? (
           <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
           </section>
         ) : null}
 
         {hasFamilies ? (
           <>
             <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-              <h2 className="text-lg font-semibold text-slate-950">Familier du har tilgang til</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Familier du har tilgang til
+              </h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                Dette er den forste beskyttede familieflaten i produksjonsappen. Hver familie er klar som
-                utgangspunkt for neste steg med ukeplaner, handlelister og samarbeid.
+                Dette er den forste beskyttede familieflaten i produksjonsappen.
+                Hver familie er klar som utgangspunkt for neste steg med
+                ukeplaner, handlelister og samarbeid.
               </p>
             </section>
 
             <section className="grid gap-4 md:grid-cols-3">
-              {loaderData.memberships.map((membership: (typeof loaderData.memberships)[number]) => (
-                <article
-                  key={membership.id}
-                  className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-slate-950">{membership.family.name}</h2>
-                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
-                      {membership.role === "ADMIN" ? "Admin" : "Medlem"}
-                    </span>
-                  </div>
-                  <p className="mt-3 text-sm leading-6 text-slate-600">
-                    {membership.role === "ADMIN"
-                      ? "Du er administrator for denne familien og kan administrere medlemmer fra familieoversikten."
-                      : "Du har tilgang til denne familien og kan apne familieoversikten for videre arbeid."}
-                  </p>
-                  <Link
-                    className="mt-5 inline-flex rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
-                    to={`/families/${membership.family.id}`}
+              {loaderData.memberships.map(
+                (membership: (typeof loaderData.memberships)[number]) => (
+                  <article
+                    key={membership.id}
+                    className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
                   >
-                    Apne familie
-                  </Link>
-                </article>
-              ))}
+                    <div className="flex items-center justify-between gap-3">
+                      <h2 className="text-lg font-semibold text-slate-950">
+                        {membership.family.name}
+                      </h2>
+                      <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
+                        {membership.role === "ADMIN" ? "Admin" : "Medlem"}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-slate-600">
+                      {membership.role === "ADMIN"
+                        ? "Du er administrator for denne familien og kan administrere medlemmer fra familieoversikten."
+                        : "Du har tilgang til denne familien og kan Åpne familieoversikten for videre arbeid."}
+                    </p>
+                    <Link
+                      className="mt-5 inline-flex rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                      to={`/families/${membership.family.id}`}
+                    >
+                      Åpne familie
+                    </Link>
+                  </article>
+                ),
+              )}
             </section>
 
             <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-              <h2 className="text-lg font-semibold text-slate-950">Hva kommer na</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Hva kommer na
+              </h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                Familieonboarding, auth, session og beskyttede ruter er pa plass. Neste steg er a bygge
-                familievisning, ukeplaner og handleliste pa toppen av ekte serverdata.
+                Familieonboarding, auth, session og beskyttede ruter er pa
+                plass. Neste steg er a bygge familievisning, ukeplaner og
+                handleliste pa toppen av ekte serverdata.
               </p>
             </section>
           </>
         ) : (
           <section className="grid gap-4 lg:grid-cols-2">
             <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-              <h2 className="text-lg font-semibold text-slate-950">Opprett familie</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Opprett familie
+              </h2>
               <p className="mt-2 text-sm leading-6 text-slate-600">
                 Lag en ny familie og bli automatisk administrator.
               </p>
@@ -257,15 +285,22 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
                   Familienavn
                   <input
                     className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                    defaultValue={actionData?.intent === "create-family" ? actionData.values?.familyName ?? "" : ""}
+                    defaultValue={
+                      actionData?.intent === "create-family"
+                        ? (actionData.values?.familyName ?? "")
+                        : ""
+                    }
                     name="familyName"
                     placeholder="For eksempel Solberg"
                     type="text"
                   />
                 </label>
 
-                {actionData?.intent === "create-family" && actionData.fieldErrors?.familyName ? (
-                  <p className="text-sm text-rose-600">{actionData.fieldErrors.familyName}</p>
+                {actionData?.intent === "create-family" &&
+                actionData.fieldErrors?.familyName ? (
+                  <p className="text-sm text-rose-600">
+                    {actionData.fieldErrors.familyName}
+                  </p>
                 ) : null}
 
                 <button
@@ -279,7 +314,9 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
             </article>
 
             <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-              <h2 className="text-lg font-semibold text-slate-950">Bli med i familie</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Bli med i familie
+              </h2>
               <p className="mt-2 text-sm leading-6 text-slate-600">
                 Har du allerede en familiekode? Skriv den inn her.
               </p>
@@ -291,17 +328,25 @@ export default function AppRoute({ actionData, loaderData }: Route.ComponentProp
                   Familiekode
                   <input
                     className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm uppercase tracking-[0.24em] text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                    defaultValue={actionData?.intent === "join-family" ? actionData.values?.joinCode ?? "" : ""}
+                    defaultValue={
+                      actionData?.intent === "join-family"
+                        ? (actionData.values?.joinCode ?? "")
+                        : ""
+                    }
                     name="joinCode"
                     placeholder="ABC123"
                     type="text"
                   />
                 </label>
 
-                {actionData?.intent === "join-family" && actionData.fieldErrors?.joinCode ? (
-                  <p className="text-sm text-rose-600">{actionData.fieldErrors.joinCode}</p>
+                {actionData?.intent === "join-family" &&
+                actionData.fieldErrors?.joinCode ? (
+                  <p className="text-sm text-rose-600">
+                    {actionData.fieldErrors.joinCode}
+                  </p>
                 ) : null}
-                {actionData?.intent === "join-family" && actionData.formError ? (
+                {actionData?.intent === "join-family" &&
+                actionData.formError ? (
                   <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
                     {actionData.formError}
                   </p>

--- a/app/routes/family-meal-plan-calendar.test.ts
+++ b/app/routes/family-meal-plan-calendar.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/calendar.server", () => {
+  return {
+    getMealPlanCalendarExport: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanCalendarExport } from "../lib/calendar.server";
+import { loader } from "./family-meal-plan-calendar";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/meal-plans/meal-plan-1/calendar.ics",
+) {
+  return new Request(url);
+}
+
+describe("family meal plan calendar route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a calendar attachment response", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanCalendarExport).mockResolvedValue({
+      content: "BEGIN:VCALENDAR\r\nEND:VCALENDAR",
+      fileName: "langhelg-ukeplan.ics",
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(getMealPlanCalendarExport).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result.headers.get("Content-Type")).toBe("text/calendar; charset=utf-8");
+    expect(result.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="langhelg-ukeplan.ics"',
+    );
+    await expect(result.text()).resolves.toBe("BEGIN:VCALENDAR\r\nEND:VCALENDAR");
+  });
+
+  it("throws a not-found response when the meal plan id route param is missing", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+
+    await expect(
+      loader({
+        params: {
+          familyId: "family-1",
+        },
+        request: buildRequest("http://localhost/families/family-1/meal-plans/calendar.ics"),
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+});

--- a/app/routes/family-meal-plan-calendar.ts
+++ b/app/routes/family-meal-plan-calendar.ts
@@ -1,0 +1,44 @@
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanCalendarExport } from "../lib/calendar.server";
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const result = await getMealPlanCalendarExport({
+    familyId,
+    mealPlanId,
+    userId: user.id,
+  });
+
+  return buildCalendarResponse(result.fileName, result.content);
+}
+
+function buildCalendarResponse(fileName: string, content: string) {
+  return new Response(content, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${fileName}"`,
+      "Content-Type": "text/calendar; charset=utf-8",
+    },
+  });
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}

--- a/app/routes/family-meal-plan-day-calendar.test.ts
+++ b/app/routes/family-meal-plan-day-calendar.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/calendar.server", () => {
+  return {
+    getMealPlanDayCalendarExport: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanDayCalendarExport } from "../lib/calendar.server";
+import { loader } from "./family-meal-plan-day-calendar";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/meal-plans/meal-plan-1/days/2026-05-16/calendar.ics",
+) {
+  return new Request(url);
+}
+
+describe("family meal plan day calendar route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a single-day calendar attachment response", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanDayCalendarExport).mockResolvedValue({
+      content: "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nEND:VEVENT\r\nEND:VCALENDAR",
+      fileName: "langhelg-2026-05-16.ics",
+    });
+
+    const result = await loader({
+      params: {
+        date: "2026-05-16",
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(getMealPlanDayCalendarExport).toHaveBeenCalledWith({
+      date: "2026-05-16",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result.headers.get("Content-Type")).toBe("text/calendar; charset=utf-8");
+    expect(result.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="langhelg-2026-05-16.ics"',
+    );
+    await expect(result.text()).resolves.toBe(
+      "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nEND:VEVENT\r\nEND:VCALENDAR",
+    );
+  });
+
+  it("propagates not-found responses from the export service", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanDayCalendarExport).mockRejectedValue(
+      new Response("Fant ikke dagen i ukeplanen.", {
+        status: 404,
+        statusText: "Not Found",
+      }),
+    );
+
+    await expect(
+      loader({
+        params: {
+          date: "2026-05-30",
+          familyId: "family-1",
+          mealPlanId: "meal-plan-1",
+        },
+        request: buildRequest(
+          "http://localhost/families/family-1/meal-plans/meal-plan-1/days/2026-05-30/calendar.ics",
+        ),
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+});

--- a/app/routes/family-meal-plan-day-calendar.ts
+++ b/app/routes/family-meal-plan-day-calendar.ts
@@ -1,0 +1,47 @@
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanDayCalendarExport } from "../lib/calendar.server";
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    date?: string;
+    familyId?: string;
+    mealPlanId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const date = requireRouteParam(params.date, "Fant ikke dagen i ukeplanen.");
+  const result = await getMealPlanDayCalendarExport({
+    date,
+    familyId,
+    mealPlanId,
+    userId: user.id,
+  });
+
+  return buildCalendarResponse(result.fileName, result.content);
+}
+
+function buildCalendarResponse(fileName: string, content: string) {
+  return new Response(content, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${fileName}"`,
+      "Content-Type": "text/calendar; charset=utf-8",
+    },
+  });
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1,5 +1,11 @@
 import { ShoppingItemSource } from "@prisma/client";
-import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
 
 import { requireUser } from "../lib/auth.server";
 import { getMealPlanShoppingData } from "../lib/shopping.server";
@@ -59,7 +65,11 @@ const defaultManualShoppingItemValues: ManualShoppingItemValues = {
 export const meta: MetaFunction = () => {
   return [
     { title: "Handleliste | Mealplanner" },
-    { name: "description", content: "Handleliste med genererte og manuelle varelinjer for valgt ukeplan." },
+    {
+      name: "description",
+      content:
+        "Handleliste med genererte og manuelle varelinjer for valgt ukeplan.",
+    },
   ];
 };
 
@@ -75,7 +85,10 @@ export async function loader({
 }) {
   const user = await requireUser(request);
   const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
-  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
   const result = await getMealPlanShoppingData({
     familyId,
     mealPlanId,
@@ -123,7 +136,10 @@ export async function action({
 }) {
   const user = await requireUser(request);
   const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
-  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
 
@@ -301,7 +317,9 @@ export default function FamilyMealPlanShoppingRoute({
     actionData?.intent === "add-manual-shopping-item" && actionData.manualValues
       ? actionData.manualValues
       : defaultManualShoppingItemValues;
-  const noticeContent = loaderData.notice ? getShoppingNoticeContent(loaderData.notice) : null;
+  const noticeContent = loaderData.notice
+    ? getShoppingNoticeContent(loaderData.notice)
+    : null;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -312,10 +330,13 @@ export default function FamilyMealPlanShoppingRoute({
               <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                 Handleliste
               </span>
-              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.mealPlan.title}</h1>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.mealPlan.title}
+              </h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
-                Handlelisten kombinerer deterministisk genererte ingredienser fra ukeplanen med manuelle
-                varelinjer. Avkryssing, notater, handledato og butikkvalg lagres pa serveren.
+                Handlelisten kombinerer deterministisk genererte ingredienser
+                fra ukeplanen med manuelle varelinjer. Avkryssing, notater,
+                handledato og butikkvalg lagres pa serveren.
               </p>
             </div>
 
@@ -324,7 +345,7 @@ export default function FamilyMealPlanShoppingRoute({
                 className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
                 to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/store-mode`}
               >
-                Apne butikkmodus
+                Åpne butikkmodus
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
@@ -345,13 +366,17 @@ export default function FamilyMealPlanShoppingRoute({
         {noticeContent ? (
           <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
           </section>
         ) : null}
 
         {actionData?.formError ? (
           <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
-            <h2 className="text-base font-semibold">Kunne ikke oppdatere handlelisten</h2>
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere handlelisten
+            </h2>
             <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
           </section>
         ) : null}
@@ -361,28 +386,41 @@ export default function FamilyMealPlanShoppingRoute({
             <div className="flex flex-col gap-2">
               <h2 className="text-lg font-semibold text-slate-950">Oversikt</h2>
               <p className="text-sm leading-6 text-slate-600">
-                Listen dekker perioden {formatMealPlanWindow(loaderData.mealPlan.startDate, loaderData.mealPlan.endDate)}
-                {" "}og inneholder {loaderData.itemCounts.total} varelinjer totalt.
+                Listen dekker perioden{" "}
+                {formatMealPlanWindow(
+                  loaderData.mealPlan.startDate,
+                  loaderData.mealPlan.endDate,
+                )}{" "}
+                og inneholder {loaderData.itemCounts.total} varelinjer totalt.
               </p>
             </div>
 
             <dl className="mt-6 grid gap-4">
               <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
-                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Status</dt>
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                  Status
+                </dt>
                 <dd className="mt-2 text-base font-semibold text-slate-950">
-                  {loaderData.mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+                  {loaderData.mealPlan.status === "APPROVED"
+                    ? "Godkjent"
+                    : "Utkast"}
                 </dd>
               </div>
 
               <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
-                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Varelinjer</dt>
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                  Varelinjer
+                </dt>
                 <dd className="mt-2 text-sm leading-6 text-slate-700">
-                  {loaderData.itemCounts.generated} genererte og {loaderData.itemCounts.manual} manuelle linjer.
+                  {loaderData.itemCounts.generated} genererte og{" "}
+                  {loaderData.itemCounts.manual} manuelle linjer.
                 </dd>
               </div>
 
               <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
-                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Synlige datoer</dt>
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                  Synlige datoer
+                </dt>
                 <dd className="mt-2 text-sm leading-6 text-slate-700">
                   {loaderData.visibleDates.map(formatDateLabel).join(", ")}
                 </dd>
@@ -392,15 +430,21 @@ export default function FamilyMealPlanShoppingRoute({
 
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Legg til manuell varelinje</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Legg til manuell varelinje
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Bruk dette for varer som ikke kommer direkte fra oppskriftene, men som skal med i samme
-                handleliste og sortering.
+                Bruk dette for varer som ikke kommer direkte fra oppskriftene,
+                men som skal med i samme handleliste og sortering.
               </p>
             </div>
 
             <Form className="mt-6 space-y-4" method="post">
-              <input name="intent" type="hidden" value="add-manual-shopping-item" />
+              <input
+                name="intent"
+                type="hidden"
+                value="add-manual-shopping-item"
+              />
 
               <div className="grid gap-4 sm:grid-cols-2">
                 <label className="block text-sm font-medium text-slate-700">
@@ -425,8 +469,11 @@ export default function FamilyMealPlanShoppingRoute({
                 </label>
               </div>
 
-              {actionData?.intent === "add-manual-shopping-item" && actionData.manualFieldErrors?.name ? (
-                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.name}</p>
+              {actionData?.intent === "add-manual-shopping-item" &&
+              actionData.manualFieldErrors?.name ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.name}
+                </p>
               ) : null}
 
               <div className="grid gap-4 sm:grid-cols-3">
@@ -475,15 +522,23 @@ export default function FamilyMealPlanShoppingRoute({
                 </label>
               </div>
 
-              {actionData?.intent === "add-manual-shopping-item" && actionData.manualFieldErrors?.categoryId ? (
-                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.categoryId}</p>
+              {actionData?.intent === "add-manual-shopping-item" &&
+              actionData.manualFieldErrors?.categoryId ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.categoryId}
+                </p>
               ) : null}
               {actionData?.intent === "add-manual-shopping-item" &&
               actionData.manualFieldErrors?.preferredStoreId ? (
-                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.preferredStoreId}</p>
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.preferredStoreId}
+                </p>
               ) : null}
-              {actionData?.intent === "add-manual-shopping-item" && actionData.manualFieldErrors?.buyOnDate ? (
-                <p className="text-sm text-rose-600">{actionData.manualFieldErrors.buyOnDate}</p>
+              {actionData?.intent === "add-manual-shopping-item" &&
+              actionData.manualFieldErrors?.buyOnDate ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.buyOnDate}
+                </p>
               ) : null}
 
               <label className="block text-sm font-medium text-slate-700">
@@ -498,10 +553,14 @@ export default function FamilyMealPlanShoppingRoute({
 
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={navigation.state === "submitting" && pendingIntent === "add-manual-shopping-item"}
+                disabled={
+                  navigation.state === "submitting" &&
+                  pendingIntent === "add-manual-shopping-item"
+                }
                 type="submit"
               >
-                {navigation.state === "submitting" && pendingIntent === "add-manual-shopping-item"
+                {navigation.state === "submitting" &&
+                pendingIntent === "add-manual-shopping-item"
                   ? "Legger til..."
                   : "Legg til varelinje"}
               </button>
@@ -511,11 +570,14 @@ export default function FamilyMealPlanShoppingRoute({
 
         <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
           <div className="flex flex-col gap-2">
-            <h2 className="text-lg font-semibold text-slate-950">Hvordan dette bygges</h2>
+            <h2 className="text-lg font-semibold text-slate-950">
+              Hvordan dette bygges
+            </h2>
             <p className="text-sm leading-6 text-slate-600">
-              Genererte linjer bygger pa lagrede oppskriftsingredienser. Like ingredienser slas bare sammen
-              nar navn, mengde, enhet, kategori og foretrukket butikk matcher eksakt. Manuelle linjer blir
-              lagt oppa samme sortering uten a endre den deterministiske projeksjonen.
+              Genererte linjer bygger pa lagrede oppskriftsingredienser. Like
+              ingredienser slas bare sammen nar navn, mengde, enhet, kategori og
+              foretrukket butikk matcher eksakt. Manuelle linjer blir lagt oppa
+              samme sortering uten a endre den deterministiske projeksjonen.
             </p>
           </div>
         </section>
@@ -540,7 +602,9 @@ export default function FamilyMealPlanShoppingRoute({
 
                 <div className="mt-6 grid gap-5">
                   {group.sections.map((section) => (
-                    <section key={`${group.store?.id ?? "no-store"}:${section.category.id}`}>
+                    <section
+                      key={`${group.store?.id ?? "no-store"}:${section.category.id}`}
+                    >
                       <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
                         {section.displayName}
                       </h3>
@@ -561,11 +625,14 @@ export default function FamilyMealPlanShoppingRoute({
                             pendingSourceKey === item.sourceKey;
                           const isPendingGeneratedSave =
                             navigation.state === "submitting" &&
-                            pendingIntent === "update-generated-shopping-item" &&
+                            pendingIntent ===
+                              "update-generated-shopping-item" &&
                             pendingSourceKey === item.sourceKey;
                           const manualValues =
-                            actionData?.intent === "update-manual-shopping-item" &&
-                            actionData.itemTarget?.sourceKey === item.sourceKey &&
+                            actionData?.intent ===
+                              "update-manual-shopping-item" &&
+                            actionData.itemTarget?.sourceKey ===
+                              item.sourceKey &&
                             actionData.manualValues
                               ? actionData.manualValues
                               : item.sourceType === "MANUAL"
@@ -574,20 +641,25 @@ export default function FamilyMealPlanShoppingRoute({
                                     categoryId: item.category.id,
                                     name: item.name,
                                     note: item.note ?? "",
-                                    preferredStoreId: item.preferredStore?.id ?? "",
+                                    preferredStoreId:
+                                      item.preferredStore?.id ?? "",
                                     quantity: item.quantity ?? "",
                                   }
                                 : null;
                           const overrideValues =
-                            actionData?.intent === "update-generated-shopping-item" &&
-                            actionData.itemTarget?.sourceKey === item.sourceKey &&
+                            actionData?.intent ===
+                              "update-generated-shopping-item" &&
+                            actionData.itemTarget?.sourceKey ===
+                              item.sourceKey &&
                             actionData.overrideValues
                               ? actionData.overrideValues
                               : item.sourceType === "GENERATED"
                                 ? {
                                     note: item.note ?? "",
-                                    postponedUntilDate: item.postponedUntilDate ?? "",
-                                    preferredStoreId: item.preferredStore?.id ?? "",
+                                    postponedUntilDate:
+                                      item.postponedUntilDate ?? "",
+                                    preferredStoreId:
+                                      item.preferredStore?.id ?? "",
                                   }
                                 : null;
 
@@ -597,7 +669,9 @@ export default function FamilyMealPlanShoppingRoute({
                               className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
                             >
                               <div className="flex flex-wrap items-center gap-2">
-                                <h4 className="text-base font-semibold text-slate-950">{item.name}</h4>
+                                <h4 className="text-base font-semibold text-slate-950">
+                                  {item.name}
+                                </h4>
                                 {item.quantityLabel ? (
                                   <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
                                     {item.quantityLabel}
@@ -613,12 +687,15 @@ export default function FamilyMealPlanShoppingRoute({
                                     Avkrysset
                                   </span>
                                 ) : null}
-                                {item.sourceType === "GENERATED" && item.postponedUntilDate ? (
+                                {item.sourceType === "GENERATED" &&
+                                item.postponedUntilDate ? (
                                   <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
-                                    Utsatt til {formatDateLabel(item.postponedUntilDate)}
+                                    Utsatt til{" "}
+                                    {formatDateLabel(item.postponedUntilDate)}
                                   </span>
                                 ) : null}
-                                {item.sourceType === "MANUAL" && item.buyOnDate ? (
+                                {item.sourceType === "MANUAL" &&
+                                item.buyOnDate ? (
                                   <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
                                     Kjopes {formatDateLabel(item.buyOnDate)}
                                   </span>
@@ -628,14 +705,18 @@ export default function FamilyMealPlanShoppingRoute({
                               <p className="mt-3 text-sm leading-6 text-slate-600">
                                 {item.sourceType === "GENERATED"
                                   ? `Fra ${item.occurrenceCount} planlagte ${
-                                      item.occurrenceCount === 1 ? "middag" : "middager"
+                                      item.occurrenceCount === 1
+                                        ? "middag"
+                                        : "middager"
                                     } mellom ${formatDateLabel(item.firstDate)} og ${formatDateLabel(item.lastDate)}.`
                                   : item.buyOnDate
                                     ? `Lagt til manuelt og planlagt for ${formatDateLabel(item.buyOnDate)}.`
                                     : "Lagt til manuelt uten spesifikk handledato."}
                               </p>
                               {item.note ? (
-                                <p className="mt-2 text-sm leading-6 text-slate-700">Notat: {item.note}</p>
+                                <p className="mt-2 text-sm leading-6 text-slate-700">
+                                  Notat: {item.note}
+                                </p>
                               ) : null}
 
                               <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
@@ -647,8 +728,11 @@ export default function FamilyMealPlanShoppingRoute({
                                       </p>
                                       <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
                                         {item.occurrences.map((occurrence) => (
-                                          <li key={`${occurrence.mealPlanEntryId}:${occurrence.recipeIngredientId}`}>
-                                            {formatDateLabel(occurrence.date)}: {occurrence.recipeTitle}
+                                          <li
+                                            key={`${occurrence.mealPlanEntryId}:${occurrence.recipeIngredientId}`}
+                                          >
+                                            {formatDateLabel(occurrence.date)}:{" "}
+                                            {occurrence.recipeTitle}
                                           </li>
                                         ))}
                                       </ul>
@@ -659,7 +743,8 @@ export default function FamilyMealPlanShoppingRoute({
                                         Manuell rad
                                       </p>
                                       <p className="mt-3 text-sm leading-6 text-slate-700">
-                                        Denne varelinjen kommer ikke fra en oppskrift og kan redigeres eller slettes
+                                        Denne varelinjen kommer ikke fra en
+                                        oppskrift og kan redigeres eller slettes
                                         direkte her.
                                       </p>
                                     </>
@@ -668,10 +753,26 @@ export default function FamilyMealPlanShoppingRoute({
 
                                 <div className="grid gap-3">
                                   <Form method="post">
-                                    <input name="intent" type="hidden" value="toggle-shopping-item-checked" />
-                                    <input name="sourceKey" type="hidden" value={item.sourceKey} />
-                                    <input name="sourceType" type="hidden" value={item.sourceType} />
-                                    <input name="checked" type="hidden" value={item.checked ? "false" : "true"} />
+                                    <input
+                                      name="intent"
+                                      type="hidden"
+                                      value="toggle-shopping-item-checked"
+                                    />
+                                    <input
+                                      name="sourceKey"
+                                      type="hidden"
+                                      value={item.sourceKey}
+                                    />
+                                    <input
+                                      name="sourceType"
+                                      type="hidden"
+                                      value={item.sourceType}
+                                    />
+                                    <input
+                                      name="checked"
+                                      type="hidden"
+                                      value={item.checked ? "false" : "true"}
+                                    />
                                     <button
                                       className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
                                       disabled={isPendingCheckToggle}
@@ -687,21 +788,37 @@ export default function FamilyMealPlanShoppingRoute({
                                     </button>
                                   </Form>
 
-                                  {item.sourceType === "GENERATED" && overrideValues ? (
+                                  {item.sourceType === "GENERATED" &&
+                                  overrideValues ? (
                                     <Form className="grid gap-3" method="post">
-                                      <input name="intent" type="hidden" value="update-generated-shopping-item" />
-                                      <input name="sourceKey" type="hidden" value={item.sourceKey} />
+                                      <input
+                                        name="intent"
+                                        type="hidden"
+                                        value="update-generated-shopping-item"
+                                      />
+                                      <input
+                                        name="sourceKey"
+                                        type="hidden"
+                                        value={item.sourceKey}
+                                      />
 
                                       <label className="block text-sm font-medium text-slate-700">
                                         Foretrukket butikk
                                         <select
                                           className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                          defaultValue={overrideValues.preferredStoreId}
+                                          defaultValue={
+                                            overrideValues.preferredStoreId
+                                          }
                                           name="preferredStoreId"
                                         >
-                                          <option value="">Ingen valgt butikk</option>
+                                          <option value="">
+                                            Ingen valgt butikk
+                                          </option>
                                           {loaderData.stores.map((store) => (
-                                            <option key={store.id} value={store.id}>
+                                            <option
+                                              key={store.id}
+                                              value={store.id}
+                                            >
                                               {store.name}
                                             </option>
                                           ))}
@@ -712,7 +829,9 @@ export default function FamilyMealPlanShoppingRoute({
                                         Utsatt til
                                         <input
                                           className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                          defaultValue={overrideValues.postponedUntilDate}
+                                          defaultValue={
+                                            overrideValues.postponedUntilDate
+                                          }
                                           max={loaderData.mealPlan.endDate}
                                           min={loaderData.mealPlan.startDate}
                                           name="postponedUntilDate"
@@ -729,18 +848,32 @@ export default function FamilyMealPlanShoppingRoute({
                                         />
                                       </label>
 
-                                      {actionData?.intent === "update-generated-shopping-item" &&
-                                      actionData.itemTarget?.sourceKey === item.sourceKey &&
-                                      actionData.generatedOverrideFieldErrors?.preferredStoreId ? (
+                                      {actionData?.intent ===
+                                        "update-generated-shopping-item" &&
+                                      actionData.itemTarget?.sourceKey ===
+                                        item.sourceKey &&
+                                      actionData.generatedOverrideFieldErrors
+                                        ?.preferredStoreId ? (
                                         <p className="text-sm text-rose-600">
-                                          {actionData.generatedOverrideFieldErrors.preferredStoreId}
+                                          {
+                                            actionData
+                                              .generatedOverrideFieldErrors
+                                              .preferredStoreId
+                                          }
                                         </p>
                                       ) : null}
-                                      {actionData?.intent === "update-generated-shopping-item" &&
-                                      actionData.itemTarget?.sourceKey === item.sourceKey &&
-                                      actionData.generatedOverrideFieldErrors?.postponedUntilDate ? (
+                                      {actionData?.intent ===
+                                        "update-generated-shopping-item" &&
+                                      actionData.itemTarget?.sourceKey ===
+                                        item.sourceKey &&
+                                      actionData.generatedOverrideFieldErrors
+                                        ?.postponedUntilDate ? (
                                         <p className="text-sm text-rose-600">
-                                          {actionData.generatedOverrideFieldErrors.postponedUntilDate}
+                                          {
+                                            actionData
+                                              .generatedOverrideFieldErrors
+                                              .postponedUntilDate
+                                          }
                                         </p>
                                       ) : null}
 
@@ -749,16 +882,30 @@ export default function FamilyMealPlanShoppingRoute({
                                         disabled={isPendingGeneratedSave}
                                         type="submit"
                                       >
-                                        {isPendingGeneratedSave ? "Lagrer tilpasninger..." : "Lagre tilpasninger"}
+                                        {isPendingGeneratedSave
+                                          ? "Lagrer tilpasninger..."
+                                          : "Lagre tilpasninger"}
                                       </button>
                                     </Form>
                                   ) : null}
 
-                                  {item.sourceType === "MANUAL" && manualValues ? (
+                                  {item.sourceType === "MANUAL" &&
+                                  manualValues ? (
                                     <>
-                                      <Form className="grid gap-3" method="post">
-                                        <input name="intent" type="hidden" value="update-manual-shopping-item" />
-                                        <input name="manualItemId" type="hidden" value={item.sourceKey} />
+                                      <Form
+                                        className="grid gap-3"
+                                        method="post"
+                                      >
+                                        <input
+                                          name="intent"
+                                          type="hidden"
+                                          value="update-manual-shopping-item"
+                                        />
+                                        <input
+                                          name="manualItemId"
+                                          type="hidden"
+                                          value={item.sourceKey}
+                                        />
 
                                         <label className="block text-sm font-medium text-slate-700">
                                           Varenavn
@@ -775,7 +922,9 @@ export default function FamilyMealPlanShoppingRoute({
                                             Mengde
                                             <input
                                               className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={manualValues.quantity}
+                                              defaultValue={
+                                                manualValues.quantity
+                                              }
                                               name="quantity"
                                               type="text"
                                             />
@@ -785,9 +934,13 @@ export default function FamilyMealPlanShoppingRoute({
                                             Handledato
                                             <input
                                               className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={manualValues.buyOnDate}
+                                              defaultValue={
+                                                manualValues.buyOnDate
+                                              }
                                               max={loaderData.mealPlan.endDate}
-                                              min={loaderData.mealPlan.startDate}
+                                              min={
+                                                loaderData.mealPlan.startDate
+                                              }
                                               name="buyOnDate"
                                               type="date"
                                             />
@@ -799,15 +952,24 @@ export default function FamilyMealPlanShoppingRoute({
                                             Kategori
                                             <select
                                               className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={manualValues.categoryId}
+                                              defaultValue={
+                                                manualValues.categoryId
+                                              }
                                               name="categoryId"
                                             >
-                                              <option value="">Velg kategori</option>
-                                              {loaderData.categories.map((category) => (
-                                                <option key={category.id} value={category.id}>
-                                                  {category.displayName}
-                                                </option>
-                                              ))}
+                                              <option value="">
+                                                Velg kategori
+                                              </option>
+                                              {loaderData.categories.map(
+                                                (category) => (
+                                                  <option
+                                                    key={category.id}
+                                                    value={category.id}
+                                                  >
+                                                    {category.displayName}
+                                                  </option>
+                                                ),
+                                              )}
                                             </select>
                                           </label>
 
@@ -815,15 +977,24 @@ export default function FamilyMealPlanShoppingRoute({
                                             Foretrukket butikk
                                             <select
                                               className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={manualValues.preferredStoreId}
+                                              defaultValue={
+                                                manualValues.preferredStoreId
+                                              }
                                               name="preferredStoreId"
                                             >
-                                              <option value="">Ingen valgt butikk</option>
-                                              {loaderData.stores.map((store) => (
-                                                <option key={store.id} value={store.id}>
-                                                  {store.name}
-                                                </option>
-                                              ))}
+                                              <option value="">
+                                                Ingen valgt butikk
+                                              </option>
+                                              {loaderData.stores.map(
+                                                (store) => (
+                                                  <option
+                                                    key={store.id}
+                                                    value={store.id}
+                                                  >
+                                                    {store.name}
+                                                  </option>
+                                                ),
+                                              )}
                                             </select>
                                           </label>
                                         </div>
@@ -837,30 +1008,52 @@ export default function FamilyMealPlanShoppingRoute({
                                           />
                                         </label>
 
-                                        {actionData?.intent === "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
+                                        {actionData?.intent ===
+                                          "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey ===
+                                          item.sourceKey &&
                                         actionData.manualFieldErrors?.name ? (
-                                          <p className="text-sm text-rose-600">{actionData.manualFieldErrors.name}</p>
-                                        ) : null}
-                                        {actionData?.intent === "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
-                                        actionData.manualFieldErrors?.categoryId ? (
                                           <p className="text-sm text-rose-600">
-                                            {actionData.manualFieldErrors.categoryId}
+                                            {actionData.manualFieldErrors.name}
                                           </p>
                                         ) : null}
-                                        {actionData?.intent === "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
-                                        actionData.manualFieldErrors?.preferredStoreId ? (
+                                        {actionData?.intent ===
+                                          "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey ===
+                                          item.sourceKey &&
+                                        actionData.manualFieldErrors
+                                          ?.categoryId ? (
                                           <p className="text-sm text-rose-600">
-                                            {actionData.manualFieldErrors.preferredStoreId}
+                                            {
+                                              actionData.manualFieldErrors
+                                                .categoryId
+                                            }
                                           </p>
                                         ) : null}
-                                        {actionData?.intent === "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey === item.sourceKey &&
-                                        actionData.manualFieldErrors?.buyOnDate ? (
+                                        {actionData?.intent ===
+                                          "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey ===
+                                          item.sourceKey &&
+                                        actionData.manualFieldErrors
+                                          ?.preferredStoreId ? (
                                           <p className="text-sm text-rose-600">
-                                            {actionData.manualFieldErrors.buyOnDate}
+                                            {
+                                              actionData.manualFieldErrors
+                                                .preferredStoreId
+                                            }
+                                          </p>
+                                        ) : null}
+                                        {actionData?.intent ===
+                                          "update-manual-shopping-item" &&
+                                        actionData.itemTarget?.sourceKey ===
+                                          item.sourceKey &&
+                                        actionData.manualFieldErrors
+                                          ?.buyOnDate ? (
+                                          <p className="text-sm text-rose-600">
+                                            {
+                                              actionData.manualFieldErrors
+                                                .buyOnDate
+                                            }
                                           </p>
                                         ) : null}
 
@@ -869,19 +1062,31 @@ export default function FamilyMealPlanShoppingRoute({
                                           disabled={isPendingManualSave}
                                           type="submit"
                                         >
-                                          {isPendingManualSave ? "Lagrer varelinje..." : "Lagre varelinje"}
+                                          {isPendingManualSave
+                                            ? "Lagrer varelinje..."
+                                            : "Lagre varelinje"}
                                         </button>
                                       </Form>
 
                                       <Form method="post">
-                                        <input name="intent" type="hidden" value="delete-manual-shopping-item" />
-                                        <input name="manualItemId" type="hidden" value={item.sourceKey} />
+                                        <input
+                                          name="intent"
+                                          type="hidden"
+                                          value="delete-manual-shopping-item"
+                                        />
+                                        <input
+                                          name="manualItemId"
+                                          type="hidden"
+                                          value={item.sourceKey}
+                                        />
                                         <button
                                           className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
                                           disabled={isPendingManualDelete}
                                           type="submit"
                                         >
-                                          {isPendingManualDelete ? "Sletter varelinje..." : "Slett varelinje"}
+                                          {isPendingManualDelete
+                                            ? "Sletter varelinje..."
+                                            : "Slett varelinje"}
                                         </button>
                                       </Form>
                                     </>
@@ -900,9 +1105,12 @@ export default function FamilyMealPlanShoppingRoute({
           </section>
         ) : (
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">Ingen varer ennå</h2>
+            <h2 className="text-lg font-semibold text-slate-950">
+              Ingen varer ennå
+            </h2>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-              Legg til middager i ukeplanen eller opprett en manuell varelinje for a starte handlelisten.
+              Legg til middager i ukeplanen eller opprett en manuell varelinje
+              for a starte handlelisten.
             </p>
           </section>
         )}
@@ -921,7 +1129,8 @@ export function ErrorBoundary({ error }: { error: unknown }) {
       description = "Du har ikke tilgang til denne familiehandlelisten.";
     } else if (error.status === 404) {
       title = "Handlelisten finnes ikke";
-      description = "Vi fant ikke ukeplanen du forsokte a hente handlelisten for.";
+      description =
+        "Vi fant ikke ukeplanen du forsokte a hente handlelisten for.";
     }
   }
 
@@ -960,7 +1169,9 @@ function requireRouteParam(value: string | undefined, message: string) {
 }
 
 function serializeProjectedShoppingItem(
-  item: Awaited<ReturnType<typeof getMealPlanShoppingData>>["projectedItems"][number],
+  item: Awaited<
+    ReturnType<typeof getMealPlanShoppingData>
+  >["projectedItems"][number],
 ) {
   if (item.sourceType === ShoppingItemSource.GENERATED) {
     return {
@@ -971,7 +1182,9 @@ function serializeProjectedShoppingItem(
         ...occurrence,
         date: formatDateOnly(occurrence.date),
       })),
-      postponedUntilDate: item.postponedUntilDate ? formatDateOnly(item.postponedUntilDate) : null,
+      postponedUntilDate: item.postponedUntilDate
+        ? formatDateOnly(item.postponedUntilDate)
+        : null,
     };
   }
 
@@ -981,7 +1194,9 @@ function serializeProjectedShoppingItem(
   };
 }
 
-function parseManualShoppingItemValues(formData: FormData): ManualShoppingItemValues {
+function parseManualShoppingItemValues(
+  formData: FormData,
+): ManualShoppingItemValues {
   return {
     buyOnDate: String(formData.get("buyOnDate") ?? ""),
     categoryId: String(formData.get("categoryId") ?? ""),
@@ -992,7 +1207,9 @@ function parseManualShoppingItemValues(formData: FormData): ManualShoppingItemVa
   };
 }
 
-function parseGeneratedShoppingItemOverrideValues(formData: FormData): GeneratedShoppingItemOverrideValues {
+function parseGeneratedShoppingItemOverrideValues(
+  formData: FormData,
+): GeneratedShoppingItemOverrideValues {
   return {
     note: String(formData.get("note") ?? ""),
     postponedUntilDate: String(formData.get("postponedUntilDate") ?? ""),
@@ -1001,7 +1218,10 @@ function parseGeneratedShoppingItemOverrideValues(formData: FormData): Generated
 }
 
 function parseShoppingItemSource(value: FormDataEntryValue | null) {
-  if (value === ShoppingItemSource.GENERATED || value === ShoppingItemSource.MANUAL) {
+  if (
+    value === ShoppingItemSource.GENERATED ||
+    value === ShoppingItemSource.MANUAL
+  ) {
     return value;
   }
 
@@ -1055,7 +1275,10 @@ function buildShoppingRedirect({
   notice: ShoppingNotice;
   request: Request;
 }) {
-  const url = new URL(`/families/${familyId}/meal-plans/${mealPlanId}/shopping`, request.url);
+  const url = new URL(
+    `/families/${familyId}/meal-plans/${mealPlanId}/shopping`,
+    request.url,
+  );
   url.searchParams.set("notice", notice);
 
   return Response.redirect(url, 302);
@@ -1065,7 +1288,8 @@ function getShoppingNoticeContent(notice: ShoppingNotice) {
   switch (notice) {
     case "manual-shopping-item-added":
       return {
-        description: "Den manuelle varelinjen ble lagt til i handlelisten og sortert sammen med de andre varene.",
+        description:
+          "Den manuelle varelinjen ble lagt til i handlelisten og sortert sammen med de andre varene.",
         title: "Varelinje lagt til",
       };
     case "manual-shopping-item-updated":
@@ -1075,12 +1299,14 @@ function getShoppingNoticeContent(notice: ShoppingNotice) {
       };
     case "manual-shopping-item-deleted":
       return {
-        description: "Den manuelle varelinjen og eventuell avkryssing ble fjernet fra handlelisten.",
+        description:
+          "Den manuelle varelinjen og eventuell avkryssing ble fjernet fra handlelisten.",
         title: "Varelinje slettet",
       };
     case "generated-shopping-item-updated":
       return {
-        description: "Butikkvalg, notat og handledato for den genererte varelinjen ble lagret.",
+        description:
+          "Butikkvalg, notat og handledato for den genererte varelinjen ble lagret.",
         title: "Tilpasninger lagret",
       };
     case "shopping-item-check-state-updated":

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1,5 +1,11 @@
 import { ShoppingItemSource } from "@prisma/client";
-import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
 
 import { requireUser } from "../lib/auth.server";
 import { getMealPlanStoreModeData } from "../lib/shopping.server";
@@ -40,7 +46,10 @@ interface FamilyMealPlanStoreModeRouteProps {
 export const meta: MetaFunction = () => {
   return [
     { title: "Butikkmodus | Mealplanner" },
-    { name: "description", content: "Kompakt butikkmodus for handlelisten i Mealplanner." },
+    {
+      name: "description",
+      content: "Kompakt butikkmodus for handlelisten i Mealplanner.",
+    },
   ];
 };
 
@@ -56,7 +65,10 @@ export async function loader({
 }) {
   const user = await requireUser(request);
   const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
-  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
   const result = await getMealPlanStoreModeData({
     familyId,
     mealPlanId,
@@ -103,7 +115,10 @@ export async function action({
 }) {
   const user = await requireUser(request);
   const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
-  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
 
@@ -205,13 +220,17 @@ export default function FamilyMealPlanStoreModeRoute({
   const navigation = useNavigation();
   const pendingIntent = navigation.formData?.get("intent");
   const pendingSourceKey = getPendingSourceKey(navigation.formData);
-  const noticeContent = loaderData.notice ? getStoreModeNoticeContent(loaderData.notice) : null;
+  const noticeContent = loaderData.notice
+    ? getStoreModeNoticeContent(loaderData.notice)
+    : null;
   const selectedStoreValue =
-    actionData?.intent === "update-selected-store" && actionData.selectedStoreValue !== undefined
+    actionData?.intent === "update-selected-store" &&
+    actionData.selectedStoreValue !== undefined
       ? actionData.selectedStoreValue
-      : loaderData.selectedStore?.id ?? "";
+      : (loaderData.selectedStore?.id ?? "");
   const activeShoppingDateValue =
-    actionData?.intent === "update-active-shopping-date" && actionData.activeShoppingDateValue
+    actionData?.intent === "update-active-shopping-date" &&
+    actionData.activeShoppingDateValue
       ? actionData.activeShoppingDateValue
       : loaderData.activeShoppingDate;
 
@@ -225,10 +244,13 @@ export default function FamilyMealPlanStoreModeRoute({
                 <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                   Butikkmodus
                 </span>
-                <h1 className="mt-4 text-3xl font-semibold tracking-tight">{loaderData.mealPlan.title}</h1>
+                <h1 className="mt-4 text-3xl font-semibold tracking-tight">
+                  {loaderData.mealPlan.title}
+                </h1>
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300">
-                  Storflatevisning for handleturen med seksjonsrekkefolge fra valgt butikk og bare varer
-                  som er relevante innen handledatoen.
+                  Storflatevisning for handleturen med seksjonsrekkefolge fra
+                  valgt butikk og bare varer som er relevante innen
+                  handledatoen.
                 </p>
               </div>
               <div className="flex flex-wrap gap-3">
@@ -236,7 +258,7 @@ export default function FamilyMealPlanStoreModeRoute({
                   className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
                   to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
                 >
-                  Apne handleliste
+                  Åpne handleliste
                 </Link>
                 <Link
                   className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
@@ -256,12 +278,15 @@ export default function FamilyMealPlanStoreModeRoute({
               </div>
               <div className="rounded-[24px] bg-white/10 p-4">
                 <p className="text-sm text-slate-300">Handledato</p>
-                <p className="mt-1 text-lg font-semibold">{formatDateLabel(loaderData.activeShoppingDate)}</p>
+                <p className="mt-1 text-lg font-semibold">
+                  {formatDateLabel(loaderData.activeShoppingDate)}
+                </p>
               </div>
               <div className="rounded-[24px] bg-emerald-500/20 p-4 ring-1 ring-emerald-400/30">
                 <p className="text-sm text-emerald-100">Fremdrift</p>
                 <p className="mt-1 text-lg font-semibold">
-                  {loaderData.progress.checkedCount}/{loaderData.progress.totalCount} varer krysset av
+                  {loaderData.progress.checkedCount}/
+                  {loaderData.progress.totalCount} varer krysset av
                 </p>
               </div>
             </div>
@@ -271,22 +296,32 @@ export default function FamilyMealPlanStoreModeRoute({
         {noticeContent ? (
           <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
           </section>
         ) : null}
 
         {actionData?.formError ? (
           <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
-            <h2 className="text-base font-semibold">Kunne ikke oppdatere butikkmodus</h2>
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere butikkmodus
+            </h2>
             <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
           </section>
         ) : null}
 
         <section className="grid gap-4 sm:grid-cols-2">
           <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">Velg butikk</h2>
+            <h2 className="text-lg font-semibold text-slate-950">
+              Velg butikk
+            </h2>
             <Form className="mt-4 space-y-3" method="post">
-              <input name="intent" type="hidden" value="update-selected-store" />
+              <input
+                name="intent"
+                type="hidden"
+                value="update-selected-store"
+              />
               <select
                 className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
                 defaultValue={selectedStoreValue}
@@ -300,14 +335,20 @@ export default function FamilyMealPlanStoreModeRoute({
               </select>
               {actionData?.intent === "update-selected-store" &&
               actionData.selectedStoreFieldErrors?.selectedStoreId ? (
-                <p className="text-sm text-rose-600">{actionData.selectedStoreFieldErrors.selectedStoreId}</p>
+                <p className="text-sm text-rose-600">
+                  {actionData.selectedStoreFieldErrors.selectedStoreId}
+                </p>
               ) : null}
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={navigation.state === "submitting" && pendingIntent === "update-selected-store"}
+                disabled={
+                  navigation.state === "submitting" &&
+                  pendingIntent === "update-selected-store"
+                }
                 type="submit"
               >
-                {navigation.state === "submitting" && pendingIntent === "update-selected-store"
+                {navigation.state === "submitting" &&
+                pendingIntent === "update-selected-store"
                   ? "Lagrer butikk..."
                   : "Lagre butikkvalg"}
               </button>
@@ -315,9 +356,15 @@ export default function FamilyMealPlanStoreModeRoute({
           </article>
 
           <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">Velg handledato</h2>
+            <h2 className="text-lg font-semibold text-slate-950">
+              Velg handledato
+            </h2>
             <Form className="mt-4 space-y-3" method="post">
-              <input name="intent" type="hidden" value="update-active-shopping-date" />
+              <input
+                name="intent"
+                type="hidden"
+                value="update-active-shopping-date"
+              />
               <select
                 className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
                 defaultValue={activeShoppingDateValue}
@@ -337,10 +384,14 @@ export default function FamilyMealPlanStoreModeRoute({
               ) : null}
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={navigation.state === "submitting" && pendingIntent === "update-active-shopping-date"}
+                disabled={
+                  navigation.state === "submitting" &&
+                  pendingIntent === "update-active-shopping-date"
+                }
                 type="submit"
               >
-                {navigation.state === "submitting" && pendingIntent === "update-active-shopping-date"
+                {navigation.state === "submitting" &&
+                pendingIntent === "update-active-shopping-date"
                   ? "Lagrer dato..."
                   : "Lagre handledato"}
               </button>
@@ -356,7 +407,9 @@ export default function FamilyMealPlanStoreModeRoute({
                 className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
               >
                 <div className="flex items-center justify-between gap-3">
-                  <h2 className="text-lg font-semibold text-slate-950">{section.displayName}</h2>
+                  <h2 className="text-lg font-semibold text-slate-950">
+                    {section.displayName}
+                  </h2>
                   <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
                     {section.items.length} varer
                   </span>
@@ -380,10 +433,26 @@ export default function FamilyMealPlanStoreModeRoute({
                       >
                         <div className="flex items-start gap-4">
                           <Form method="post">
-                            <input name="intent" type="hidden" value="toggle-shopping-item-checked" />
-                            <input name="sourceKey" type="hidden" value={item.sourceKey} />
-                            <input name="sourceType" type="hidden" value={item.sourceType} />
-                            <input name="checked" type="hidden" value={item.checked ? "false" : "true"} />
+                            <input
+                              name="intent"
+                              type="hidden"
+                              value="toggle-shopping-item-checked"
+                            />
+                            <input
+                              name="sourceKey"
+                              type="hidden"
+                              value={item.sourceKey}
+                            />
+                            <input
+                              name="sourceType"
+                              type="hidden"
+                              value={item.sourceType}
+                            />
+                            <input
+                              name="checked"
+                              type="hidden"
+                              value={item.checked ? "false" : "true"}
+                            />
                             <button
                               className={
                                 item.checked
@@ -399,7 +468,9 @@ export default function FamilyMealPlanStoreModeRoute({
 
                           <div className="min-w-0 flex-1">
                             <div className="flex flex-wrap items-center gap-2">
-                              <h3 className="text-base font-semibold text-slate-950">{item.name}</h3>
+                              <h3 className="text-base font-semibold text-slate-950">
+                                {item.name}
+                              </h3>
                               {item.quantityLabel ? (
                                 <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
                                   {item.quantityLabel}
@@ -410,7 +481,9 @@ export default function FamilyMealPlanStoreModeRoute({
                                   Manuell
                                 </span>
                               ) : null}
-                              {item.preferredStore && item.preferredStore.id !== loaderData.selectedStore?.id ? (
+                              {item.preferredStore &&
+                              item.preferredStore.id !==
+                                loaderData.selectedStore?.id ? (
                                 <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
                                   Foretrekker {item.preferredStore.name}
                                 </span>
@@ -420,7 +493,9 @@ export default function FamilyMealPlanStoreModeRoute({
                             <p className="mt-2 text-sm leading-6 text-slate-600">
                               {item.sourceType === "GENERATED"
                                 ? `Fra ${item.occurrenceCount} planlagte ${
-                                    item.occurrenceCount === 1 ? "middag" : "middager"
+                                    item.occurrenceCount === 1
+                                      ? "middag"
+                                      : "middager"
                                   } fram til ${formatDateLabel(item.lastDate)}.`
                                 : item.buyOnDate
                                   ? `Manuell vare planlagt for ${formatDateLabel(item.buyOnDate)}.`
@@ -428,11 +503,15 @@ export default function FamilyMealPlanStoreModeRoute({
                             </p>
 
                             {item.note ? (
-                              <p className="mt-2 text-sm leading-6 text-slate-700">Notat: {item.note}</p>
+                              <p className="mt-2 text-sm leading-6 text-slate-700">
+                                Notat: {item.note}
+                              </p>
                             ) : null}
-                            {item.sourceType === "GENERATED" && item.postponedUntilDate ? (
+                            {item.sourceType === "GENERATED" &&
+                            item.postponedUntilDate ? (
                               <p className="mt-2 text-sm leading-6 text-amber-800">
-                                Utsatt til {formatDateLabel(item.postponedUntilDate)}.
+                                Utsatt til{" "}
+                                {formatDateLabel(item.postponedUntilDate)}.
                               </p>
                             ) : null}
                           </div>
@@ -446,15 +525,20 @@ export default function FamilyMealPlanStoreModeRoute({
           </section>
         ) : (
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">Ingen varer ma handles na</h2>
+            <h2 className="text-lg font-semibold text-slate-950">
+              Ingen varer ma handles na
+            </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600">
-              Alt er enten ferdig handlet eller planlagt for senere i den aktive ukeplanen.
+              Alt er enten ferdig handlet eller planlagt for senere i den aktive
+              ukeplanen.
             </p>
           </section>
         )}
 
         <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-          <h2 className="text-lg font-semibold text-slate-950">Senere i perioden</h2>
+          <h2 className="text-lg font-semibold text-slate-950">
+            Senere i perioden
+          </h2>
           <div className="mt-4 flex flex-wrap gap-2">
             {loaderData.laterItems.length > 0 ? (
               loaderData.laterItems.map((item) => (
@@ -472,7 +556,9 @@ export default function FamilyMealPlanStoreModeRoute({
                 </span>
               ))
             ) : (
-              <p className="text-sm leading-6 text-slate-600">Ingen senere varer akkurat na.</p>
+              <p className="text-sm leading-6 text-slate-600">
+                Ingen senere varer akkurat na.
+              </p>
             )}
           </div>
         </section>
@@ -500,7 +586,10 @@ export function ErrorBoundary({ error }: { error: unknown }) {
       <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
         <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
         <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
-        <Link className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white" to="/app">
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+          to="/app"
+        >
           Til appen
         </Link>
       </div>
@@ -509,7 +598,9 @@ export function ErrorBoundary({ error }: { error: unknown }) {
 }
 
 function serializeProjectedShoppingItem(
-  item: Awaited<ReturnType<typeof getMealPlanStoreModeData>>["laterItems"][number],
+  item: Awaited<
+    ReturnType<typeof getMealPlanStoreModeData>
+  >["laterItems"][number],
 ) {
   if (item.sourceType === ShoppingItemSource.GENERATED) {
     return {
@@ -520,7 +611,9 @@ function serializeProjectedShoppingItem(
         ...occurrence,
         date: formatDateOnly(occurrence.date),
       })),
-      postponedUntilDate: item.postponedUntilDate ? formatDateOnly(item.postponedUntilDate) : null,
+      postponedUntilDate: item.postponedUntilDate
+        ? formatDateOnly(item.postponedUntilDate)
+        : null,
     };
   }
 
@@ -575,14 +668,20 @@ function buildStoreModeRedirect({
   notice: StoreModeNotice;
   request: Request;
 }) {
-  const url = new URL(`/families/${familyId}/meal-plans/${mealPlanId}/store-mode`, request.url);
+  const url = new URL(
+    `/families/${familyId}/meal-plans/${mealPlanId}/store-mode`,
+    request.url,
+  );
   url.searchParams.set("notice", notice);
 
   return Response.redirect(url, 302);
 }
 
 function parseShoppingItemSource(value: FormDataEntryValue | null) {
-  if (value === ShoppingItemSource.GENERATED || value === ShoppingItemSource.MANUAL) {
+  if (
+    value === ShoppingItemSource.GENERATED ||
+    value === ShoppingItemSource.MANUAL
+  ) {
     return value;
   }
 

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -110,6 +110,7 @@ describe("family meal plan route", () => {
       userId: "user-1",
     });
     expect(result).toEqual({
+      calendarExportDates: [],
       family: {
         id: "family-1",
         name: "Solberg",

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -1,4 +1,10 @@
-import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
 
 import { requireUser } from "../lib/auth.server";
 import {
@@ -22,6 +28,8 @@ type MealPlanIntent =
   | "reopen-meal-plan"
   | "save-meal-plan-entries"
   | "update-meal-plan";
+
+const CALENDAR_DOWNLOAD_TARGET = "meal-plan-calendar-download";
 
 interface MealPlanEntryFormState {
   note: string;
@@ -54,7 +62,10 @@ interface MealPlanRouteProps {
 export const meta: MetaFunction = () => {
   return [
     { title: "Rediger ukeplan | Mealplanner" },
-    { name: "description", content: "Oppdater navn og datointervall for en familieukeplan." },
+    {
+      name: "description",
+      content: "Oppdater navn og datointervall for en familieukeplan.",
+    },
   ];
 };
 
@@ -70,7 +81,10 @@ export async function loader({
 }) {
   const user = await requireUser(request);
   const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
-  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
   const result = await getMealPlanPlanningData({
     familyId,
     mealPlanId,
@@ -80,7 +94,9 @@ export async function loader({
   const entriesByDate = Object.fromEntries(
     result.visibleDates.map((date) => {
       const entry = result.mealPlan.entries.find(
-        (mealPlanEntry) => mealPlanEntry.mealType === "DINNER" && formatDateOnly(mealPlanEntry.date) === date,
+        (mealPlanEntry) =>
+          mealPlanEntry.mealType === "DINNER" &&
+          formatDateOnly(mealPlanEntry.date) === date,
       );
 
       return [
@@ -92,15 +108,25 @@ export async function loader({
       ];
     }),
   );
+  const calendarExportDates = result.mealPlan.entries.flatMap((entry) => {
+    if (entry.mealType !== "DINNER" || !entry.recipe) {
+      return [];
+    }
+
+    return [formatDateOnly(entry.date)];
+  });
 
   return {
+    calendarExportDates,
     family: result.family,
     mealPlan: {
       ...result.mealPlan,
       activeShoppingDate: result.mealPlan.activeShoppingDate
         ? formatDateOnly(result.mealPlan.activeShoppingDate)
         : null,
-      approvedAt: result.mealPlan.approvedAt ? result.mealPlan.approvedAt.toISOString() : null,
+      approvedAt: result.mealPlan.approvedAt
+        ? result.mealPlan.approvedAt.toISOString()
+        : null,
       endDate: formatDateOnly(result.mealPlan.endDate),
       entries: undefined,
       startDate: formatDateOnly(result.mealPlan.startDate),
@@ -125,7 +151,10 @@ export async function action({
 }) {
   const user = await requireUser(request);
   const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
-  const mealPlanId = requireRouteParam(params.mealPlanId, "Fant ikke ukeplanen.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
 
@@ -191,7 +220,10 @@ export async function action({
     return buildMealPlanRedirect({
       familyId,
       mealPlanId,
-      notice: result.status === "APPROVED" ? "meal-plan-approved" : "meal-plan-reopened",
+      notice:
+        result.status === "APPROVED"
+          ? "meal-plan-approved"
+          : "meal-plan-reopened",
       request,
     });
   }
@@ -234,19 +266,34 @@ export async function action({
   });
 }
 
-export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlanRouteProps) {
+export default function FamilyMealPlanRoute({
+  actionData,
+  loaderData,
+}: MealPlanRouteProps) {
   const navigation = useNavigation();
   const pendingIntent = navigation.formData?.get("intent");
-  const isApprovingMealPlan = navigation.state === "submitting" && pendingIntent === "approve-meal-plan";
-  const isReopeningMealPlan = navigation.state === "submitting" && pendingIntent === "reopen-meal-plan";
-  const isSavingEntries = navigation.state === "submitting" && pendingIntent === "save-meal-plan-entries";
-  const isUpdatingMetadata = navigation.state === "submitting" && pendingIntent === "update-meal-plan";
+  const isApprovingMealPlan =
+    navigation.state === "submitting" && pendingIntent === "approve-meal-plan";
+  const isReopeningMealPlan =
+    navigation.state === "submitting" && pendingIntent === "reopen-meal-plan";
+  const isSavingEntries =
+    navigation.state === "submitting" &&
+    pendingIntent === "save-meal-plan-entries";
+  const isUpdatingMetadata =
+    navigation.state === "submitting" && pendingIntent === "update-meal-plan";
   const canManageApproval = loaderData.userRole === "ADMIN";
-  const noticeContent = loaderData.notice ? getMealPlanNoticeContent(loaderData.notice) : null;
+  const noticeContent = loaderData.notice
+    ? getMealPlanNoticeContent(loaderData.notice)
+    : null;
   const titleValue = actionData?.values?.title ?? loaderData.mealPlan.title;
-  const startDateValue = actionData?.values?.startDate ?? loaderData.mealPlan.startDate;
-  const endDateValue = actionData?.values?.endDate ?? loaderData.mealPlan.endDate;
-  const approvalIntent = loaderData.mealPlan.status === "APPROVED" ? "reopen-meal-plan" : "approve-meal-plan";
+  const startDateValue =
+    actionData?.values?.startDate ?? loaderData.mealPlan.startDate;
+  const endDateValue =
+    actionData?.values?.endDate ?? loaderData.mealPlan.endDate;
+  const approvalIntent =
+    loaderData.mealPlan.status === "APPROVED"
+      ? "reopen-meal-plan"
+      : "approve-meal-plan";
   const approvalButtonLabel =
     approvalIntent === "approve-meal-plan"
       ? isApprovingMealPlan
@@ -264,9 +311,18 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
       .map((entry) => entry.recipeId)
       .filter(Boolean),
   );
+  const calendarExportDateSet = new Set(loaderData.calendarExportDates);
+  const hasMealPlanCalendarExport = calendarExportDateSet.size > 0;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <iframe
+        aria-hidden="true"
+        className="hidden"
+        name={CALENDAR_DOWNLOAD_TARGET}
+        tabIndex={-1}
+        title="Kalendernedlasting"
+      />
       <div className="mx-auto flex max-w-5xl flex-col gap-6">
         <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
           <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
@@ -274,10 +330,12 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
               <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                 Middagsplanlegging
               </span>
-              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.mealPlan.title}</h1>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.mealPlan.title}
+              </h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
-                Planlegg middager dag for dag i den aktive perioden. Oppskrifter og notater lagres pa
-                serveren for hele familien.
+                Planlegg middager dag for dag i den aktive perioden. Oppskrifter
+                og notater lagres pa serveren for hele familien.
               </p>
             </div>
 
@@ -286,14 +344,27 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
                 to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
               >
-                Apne handleliste
+                Åpne handleliste
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/store-mode`}
               >
-                Apne butikkmodus
+                Åpne butikkmodus
               </Link>
+              {hasMealPlanCalendarExport ? (
+                <a
+                  className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                  href={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/calendar.ics`}
+                  target={CALENDAR_DOWNLOAD_TARGET}
+                >
+                  Eksporter ukeplan (.ics)
+                </a>
+              ) : (
+                <span className="rounded-2xl bg-white/5 px-5 py-3 text-sm font-medium text-slate-400 ring-1 ring-white/10">
+                  Eksporter ukeplan (.ics)
+                </span>
+              )}
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to={`/families/${loaderData.family.id}/meal-plans`}
@@ -307,30 +378,45 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
         {noticeContent ? (
           <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
           </section>
         ) : null}
 
         <section className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Middager for aktiv periode</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Middager for aktiv periode
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Hver dag kan ha en middag, et notat eller begge deler. Tomme dager blir lagret som
-                up planlagt.
+                Hver dag kan ha en middag, et notat eller begge deler. Tomme
+                dager blir lagret som up planlagt.
               </p>
             </div>
 
             <Form className="mt-6 space-y-4" method="post">
-              <input name="intent" type="hidden" value="save-meal-plan-entries" />
+              <input
+                name="intent"
+                type="hidden"
+                value="save-meal-plan-entries"
+              />
 
               <div className="grid gap-4">
                 {loaderData.visibleDates.map((date) => {
                   const entry = entryValues[date] ?? { note: "", recipeId: "" };
-                  const selectedRecipe = loaderData.recipes.find((recipe) => recipe.id === entry.recipeId) ?? null;
+                  const canExportDay = calendarExportDateSet.has(date);
+                  const selectedRecipe =
+                    loaderData.recipes.find(
+                      (recipe) => recipe.id === entry.recipeId,
+                    ) ?? null;
 
                   return (
-                    <article key={date} className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                    <article
+                      key={date}
+                      className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                    >
                       <input name="entryDate" type="hidden" value={date} />
 
                       <div className="flex flex-col gap-4">
@@ -342,10 +428,22 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                             <h3 className="mt-2 text-lg font-semibold text-slate-950">
                               {formatWeekdayLabel(date)}
                             </h3>
-                            <p className="mt-1 text-sm font-medium text-slate-500">{formatDateLabel(date)}</p>
+                            <p className="mt-1 text-sm font-medium text-slate-500">
+                              {formatDateLabel(date)}
+                            </p>
                           </div>
 
-                          <div className="w-full sm:max-w-sm">
+                          <div className="flex w-full flex-col gap-3 sm:max-w-sm">
+                            {canExportDay ? (
+                              <a
+                                className="inline-flex items-center justify-center rounded-2xl bg-white px-4 py-2 text-sm font-medium text-slate-700 ring-1 ring-slate-200 transition hover:bg-slate-100"
+                                href={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/days/${date}/calendar.ics`}
+                                target={CALENDAR_DOWNLOAD_TARGET}
+                              >
+                                Eksporter dag (.ics)
+                              </a>
+                            ) : null}
+
                             <label className="block text-sm font-medium text-slate-700">
                               Oppskrift
                               <select
@@ -402,7 +500,8 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 })}
               </div>
 
-              {actionData?.intent === "save-meal-plan-entries" && actionData.entryFormError ? (
+              {actionData?.intent === "save-meal-plan-entries" &&
+              actionData.entryFormError ? (
                 <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
                   {actionData.entryFormError}
                 </p>
@@ -420,9 +519,12 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
 
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Oppskriftsbank</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Oppskriftsbank
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Seedede oppskrifter du kan bruke i den forste produksjonsflyten for middagsplanlegging.
+                Seedede oppskrifter du kan bruke i den forste produksjonsflyten
+                for middagsplanlegging.
               </p>
             </div>
 
@@ -438,8 +540,12 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div>
-                      <h3 className="text-base font-semibold text-slate-950">{recipe.title}</h3>
-                      <p className="mt-2 text-sm leading-6 text-slate-600">{recipe.description}</p>
+                      <h3 className="text-base font-semibold text-slate-950">
+                        {recipe.title}
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">
+                        {recipe.description}
+                      </p>
                     </div>
                     {selectedRecipeIds.has(recipe.id) ? (
                       <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
@@ -475,20 +581,25 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
             <div className="flex flex-col gap-2">
               <h2 className="text-lg font-semibold text-slate-950">Detaljer</h2>
               <p className="text-sm leading-6 text-slate-600">
-                Planen tilhorer familien {loaderData.family.name} og bruker et lagret datointervall pa maks
-                7 dager.
+                Planen tilhorer familien {loaderData.family.name} og bruker et
+                lagret datointervall pa maks 7 dager.
               </p>
             </div>
 
             <dl className="mt-6 grid gap-4">
               <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
-                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Status</dt>
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                  Status
+                </dt>
                 <dd className="mt-2 text-base font-semibold text-slate-950">
-                  {loaderData.mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+                  {loaderData.mealPlan.status === "APPROVED"
+                    ? "Godkjent"
+                    : "Utkast"}
                 </dd>
                 {loaderData.mealPlan.approvedAt ? (
                   <dd className="mt-2 text-sm leading-6 text-slate-600">
-                    Godkjent {formatApprovalTimestamp(loaderData.mealPlan.approvedAt)}
+                    Godkjent{" "}
+                    {formatApprovalTimestamp(loaderData.mealPlan.approvedAt)}
                   </dd>
                 ) : null}
               </div>
@@ -498,7 +609,10 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                   Aktiv periode
                 </dt>
                 <dd className="mt-2 text-base font-semibold text-slate-950">
-                  {formatMealPlanWindow(loaderData.mealPlan.startDate, loaderData.mealPlan.endDate)}
+                  {formatMealPlanWindow(
+                    loaderData.mealPlan.startDate,
+                    loaderData.mealPlan.endDate,
+                  )}
                 </dd>
               </div>
             </dl>
@@ -508,10 +622,12 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 <input name="intent" type="hidden" value={approvalIntent} />
 
                 <p className="text-sm leading-6 text-slate-600">
-                  Godkjenning markerer ukeplanen som klar for neste steg uten a lase redigering enda.
+                  Godkjenning markerer ukeplanen som klar for neste steg uten a
+                  lase redigering enda.
                 </p>
 
-                {(actionData?.intent === "approve-meal-plan" || actionData?.intent === "reopen-meal-plan") &&
+                {(actionData?.intent === "approve-meal-plan" ||
+                  actionData?.intent === "reopen-meal-plan") &&
                 actionData.statusFormError ? (
                   <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
                     {actionData.statusFormError}
@@ -531,9 +647,12 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
 
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Oppdater ukeplan</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Oppdater ukeplan
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Du kan fortsatt endre navn og datointervall her. Datointervallet kan vare maks 7 dager.
+                Du kan fortsatt endre navn og datointervall her. Datointervallet
+                kan vare maks 7 dager.
               </p>
             </div>
 
@@ -550,8 +669,11 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 />
               </label>
 
-              {actionData?.intent === "update-meal-plan" && actionData.fieldErrors?.title ? (
-                <p className="text-sm text-rose-600">{actionData.fieldErrors.title}</p>
+              {actionData?.intent === "update-meal-plan" &&
+              actionData.fieldErrors?.title ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.fieldErrors.title}
+                </p>
               ) : null}
 
               <div className="grid gap-4 sm:grid-cols-2">
@@ -576,11 +698,17 @@ export default function FamilyMealPlanRoute({ actionData, loaderData }: MealPlan
                 </label>
               </div>
 
-              {actionData?.intent === "update-meal-plan" && actionData.fieldErrors?.startDate ? (
-                <p className="text-sm text-rose-600">{actionData.fieldErrors.startDate}</p>
+              {actionData?.intent === "update-meal-plan" &&
+              actionData.fieldErrors?.startDate ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.fieldErrors.startDate}
+                </p>
               ) : null}
-              {actionData?.intent === "update-meal-plan" && actionData.fieldErrors?.endDate ? (
-                <p className="text-sm text-rose-600">{actionData.fieldErrors.endDate}</p>
+              {actionData?.intent === "update-meal-plan" &&
+              actionData.fieldErrors?.endDate ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.fieldErrors.endDate}
+                </p>
               ) : null}
               {actionData?.formError ? (
                 <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
@@ -613,7 +741,7 @@ export function ErrorBoundary({ error }: { error: unknown }) {
       description = "Du har ikke tilgang til denne familieukeplanen.";
     } else if (error.status === 404) {
       title = "Ukeplanen finnes ikke";
-      description = "Vi fant ikke ukeplanen du forsokte a apne.";
+      description = "Vi fant ikke ukeplanen du forsokte a Åpne.";
     }
   }
 
@@ -671,7 +799,10 @@ function buildMealPlanRedirect({
   notice: MealPlanNotice;
   request: Request;
 }) {
-  const url = new URL(`/families/${familyId}/meal-plans/${mealPlanId}`, request.url);
+  const url = new URL(
+    `/families/${familyId}/meal-plans/${mealPlanId}`,
+    request.url,
+  );
   url.searchParams.set("notice", notice);
 
   return Response.redirect(url, 302);
@@ -681,22 +812,26 @@ function getMealPlanNoticeContent(notice: MealPlanNotice) {
   switch (notice) {
     case "meal-plan-approved":
       return {
-        description: "Ukeplanen er markert som godkjent og klar for neste steg.",
+        description:
+          "Ukeplanen er markert som godkjent og klar for neste steg.",
         title: "Ukeplan godkjent",
       };
     case "meal-plan-created":
       return {
-        description: "Ukeplanen er klar for videre arbeid med innhold og handleliste.",
+        description:
+          "Ukeplanen er klar for videre arbeid med innhold og handleliste.",
         title: "Ukeplan opprettet",
       };
     case "meal-plan-entries-saved":
       return {
-        description: "Middagene og notatene ble lagret for den aktive perioden.",
+        description:
+          "Middagene og notatene ble lagret for den aktive perioden.",
         title: "Middager lagret",
       };
     case "meal-plan-reopened":
       return {
-        description: "Ukeplanen er gjenapnet som utkast og kan fortsatt redigeres.",
+        description:
+          "Ukeplanen er gjenapnet som utkast og kan fortsatt redigeres.",
         title: "Ukeplan gjenapnet",
       };
     case "meal-plan-updated":

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -9,7 +9,10 @@ import {
   listMealPlansForFamily,
 } from "../lib/meal-plan.server";
 
-type MealPlanNotice = "meal-plan-copied" | "meal-plan-created" | "meal-plan-deleted";
+type MealPlanNotice =
+  | "meal-plan-copied"
+  | "meal-plan-created"
+  | "meal-plan-deleted";
 
 interface MealPlanActionData {
   fieldErrors?: {
@@ -36,7 +39,10 @@ interface MealPlanListRouteProps {
 export const meta: MetaFunction = () => {
   return [
     { title: "Ukeplaner | Mealplanner" },
-    { name: "description", content: "Administrer familieukeplaner i Mealplanner." },
+    {
+      name: "description",
+      content: "Administrer familieukeplaner i Mealplanner.",
+    },
   ];
 };
 
@@ -60,7 +66,9 @@ export async function loader({
     family: result.family,
     mealPlans: result.mealPlans.map((mealPlan) => ({
       ...mealPlan,
-      activeShoppingDate: mealPlan.activeShoppingDate ? formatDateOnly(mealPlan.activeShoppingDate) : null,
+      activeShoppingDate: mealPlan.activeShoppingDate
+        ? formatDateOnly(mealPlan.activeShoppingDate)
+        : null,
       endDate: formatDateOnly(mealPlan.endDate),
       startDate: formatDateOnly(mealPlan.startDate),
     })),
@@ -119,7 +127,8 @@ export async function action({
 
     if (result.status === "NOT_FOUND") {
       return {
-        formError: "Fant ikke ukeplanen du ville gjenbruke. Velg en annen ukeplan og prov igjen.",
+        formError:
+          "Fant ikke ukeplanen du ville gjenbruke. Velg en annen ukeplan og prov igjen.",
         intent,
         values,
       } satisfies MealPlanActionData;
@@ -127,7 +136,9 @@ export async function action({
 
     return buildMealPlanRedirect({
       familyId,
-      notice: values.sourceMealPlanId ? "meal-plan-copied" : "meal-plan-created",
+      notice: values.sourceMealPlanId
+        ? "meal-plan-copied"
+        : "meal-plan-created",
       request,
     });
   }
@@ -167,14 +178,26 @@ export async function action({
   } satisfies MealPlanActionData;
 }
 
-export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPlanListRouteProps) {
+export default function FamilyMealPlansRoute({
+  actionData,
+  loaderData,
+}: MealPlanListRouteProps) {
   const navigation = useNavigation();
-  const noticeContent = loaderData.notice ? getMealPlanNoticeContent(loaderData.notice) : null;
+  const noticeContent = loaderData.notice
+    ? getMealPlanNoticeContent(loaderData.notice)
+    : null;
   const pendingIntent = navigation.formData?.get("intent");
-  const pendingMealPlanId = String(navigation.formData?.get("mealPlanId") ?? "");
-  const isCreatingMealPlan = navigation.state === "submitting" && pendingIntent === "create-meal-plan";
-  const isDeletingMealPlan = navigation.state === "submitting" && pendingIntent === "delete-meal-plan";
-  const sourceMealPlanValue = actionData?.intent === "create-meal-plan" ? actionData.values?.sourceMealPlanId ?? "" : "";
+  const pendingMealPlanId = String(
+    navigation.formData?.get("mealPlanId") ?? "",
+  );
+  const isCreatingMealPlan =
+    navigation.state === "submitting" && pendingIntent === "create-meal-plan";
+  const isDeletingMealPlan =
+    navigation.state === "submitting" && pendingIntent === "delete-meal-plan";
+  const sourceMealPlanValue =
+    actionData?.intent === "create-meal-plan"
+      ? (actionData.values?.sourceMealPlanId ?? "")
+      : "";
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -185,9 +208,12 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
               <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                 Ukeplaner
               </span>
-              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.family.name}</h1>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
-                Opprett og administrer familieukeplaner med lagrede start- og sluttdatoer.
+                Opprett og administrer familieukeplaner med lagrede start- og
+                sluttdatoer.
               </p>
             </div>
 
@@ -205,17 +231,22 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
         {noticeContent ? (
           <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
           </section>
         ) : null}
 
         <section className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Opprett ukeplan</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Opprett ukeplan
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Velg et navn og et datointervall pa maks 7 dager. Du kan starte fra en tom ukeplan eller
-                gjenbruke middager og notater fra en tidligere plan.
+                Velg et navn og et datointervall pa maks 7 dager. Du kan starte
+                fra en tom ukeplan eller gjenbruke middager og notater fra en
+                tidligere plan.
               </p>
             </div>
 
@@ -226,15 +257,22 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
                 Navn
                 <input
                   className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                  defaultValue={actionData?.intent === "create-meal-plan" ? actionData.values?.title ?? "" : ""}
+                  defaultValue={
+                    actionData?.intent === "create-meal-plan"
+                      ? (actionData.values?.title ?? "")
+                      : ""
+                  }
                   name="title"
                   placeholder="For eksempel Uke 20"
                   type="text"
                 />
               </label>
 
-              {actionData?.intent === "create-meal-plan" && actionData.fieldErrors?.title ? (
-                <p className="text-sm text-rose-600">{actionData.fieldErrors.title}</p>
+              {actionData?.intent === "create-meal-plan" &&
+              actionData.fieldErrors?.title ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.fieldErrors.title}
+                </p>
               ) : null}
 
               <label className="block text-sm font-medium text-slate-700">
@@ -247,15 +285,20 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
                   <option value="">Tom ukeplan</option>
                   {loaderData.mealPlans.map((mealPlan) => (
                     <option key={mealPlan.id} value={mealPlan.id}>
-                      {mealPlan.title} ({formatMealPlanWindow(mealPlan.startDate, mealPlan.endDate)})
+                      {mealPlan.title} (
+                      {formatMealPlanWindow(
+                        mealPlan.startDate,
+                        mealPlan.endDate,
+                      )}
+                      )
                     </option>
                   ))}
                 </select>
               </label>
 
               <p className="text-sm leading-6 text-slate-500">
-                Velg en tidligere ukeplan for a kopiere middager og notater til samme relative dager i den
-                nye perioden.
+                Velg en tidligere ukeplan for a kopiere middager og notater til
+                samme relative dager i den nye perioden.
               </p>
 
               <div className="grid gap-4 sm:grid-cols-2">
@@ -264,7 +307,9 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
                   <input
                     className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
                     defaultValue={
-                      actionData?.intent === "create-meal-plan" ? actionData.values?.startDate ?? "" : ""
+                      actionData?.intent === "create-meal-plan"
+                        ? (actionData.values?.startDate ?? "")
+                        : ""
                     }
                     name="startDate"
                     type="date"
@@ -275,18 +320,28 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
                   Sluttdato
                   <input
                     className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                    defaultValue={actionData?.intent === "create-meal-plan" ? actionData.values?.endDate ?? "" : ""}
+                    defaultValue={
+                      actionData?.intent === "create-meal-plan"
+                        ? (actionData.values?.endDate ?? "")
+                        : ""
+                    }
                     name="endDate"
                     type="date"
                   />
                 </label>
               </div>
 
-              {actionData?.intent === "create-meal-plan" && actionData.fieldErrors?.startDate ? (
-                <p className="text-sm text-rose-600">{actionData.fieldErrors.startDate}</p>
+              {actionData?.intent === "create-meal-plan" &&
+              actionData.fieldErrors?.startDate ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.fieldErrors.startDate}
+                </p>
               ) : null}
-              {actionData?.intent === "create-meal-plan" && actionData.fieldErrors?.endDate ? (
-                <p className="text-sm text-rose-600">{actionData.fieldErrors.endDate}</p>
+              {actionData?.intent === "create-meal-plan" &&
+              actionData.fieldErrors?.endDate ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.fieldErrors.endDate}
+                </p>
               ) : null}
               {actionData?.formError ? (
                 <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
@@ -306,32 +361,47 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
 
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Lagrede ukeplaner</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Lagrede ukeplaner
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Velg en ukeplan for a redigere navn og datoer, eller slett planer familien ikke trenger
-                lenger.
+                Velg en ukeplan for a redigere navn og datoer, eller slett
+                planer familien ikke trenger lenger.
               </p>
             </div>
 
             {loaderData.mealPlans.length > 0 ? (
               <div className="mt-6 grid gap-4">
                 {loaderData.mealPlans.map((mealPlan) => {
-                  const isPendingDelete = isDeletingMealPlan && pendingMealPlanId === mealPlan.id;
+                  const isPendingDelete =
+                    isDeletingMealPlan && pendingMealPlanId === mealPlan.id;
                   const deleteError =
-                    actionData?.targetMealPlanId === mealPlan.id ? actionData.formError : undefined;
+                    actionData?.targetMealPlanId === mealPlan.id
+                      ? actionData.formError
+                      : undefined;
 
                   return (
-                    <article key={mealPlan.id} className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                    <article
+                      key={mealPlan.id}
+                      className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                    >
                       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
                         <div>
                           <div className="flex flex-wrap items-center gap-3">
-                            <h3 className="text-base font-semibold text-slate-950">{mealPlan.title}</h3>
+                            <h3 className="text-base font-semibold text-slate-950">
+                              {mealPlan.title}
+                            </h3>
                             <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
-                              {mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+                              {mealPlan.status === "APPROVED"
+                                ? "Godkjent"
+                                : "Utkast"}
                             </span>
                           </div>
                           <p className="mt-2 text-sm leading-6 text-slate-600">
-                            {formatMealPlanWindow(mealPlan.startDate, mealPlan.endDate)}
+                            {formatMealPlanWindow(
+                              mealPlan.startDate,
+                              mealPlan.endDate,
+                            )}
                           </p>
                         </div>
 
@@ -340,12 +410,20 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
                             className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
                             to={`/families/${loaderData.family.id}/meal-plans/${mealPlan.id}`}
                           >
-                            Apne ukeplan
+                            Åpne ukeplan
                           </Link>
 
                           <Form method="post">
-                            <input name="intent" type="hidden" value="delete-meal-plan" />
-                            <input name="mealPlanId" type="hidden" value={mealPlan.id} />
+                            <input
+                              name="intent"
+                              type="hidden"
+                              value="delete-meal-plan"
+                            />
+                            <input
+                              name="mealPlanId"
+                              type="hidden"
+                              value={mealPlan.id}
+                            />
                             <button
                               className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
                               disabled={isDeletingMealPlan}
@@ -368,9 +446,12 @@ export default function FamilyMealPlansRoute({ actionData, loaderData }: MealPla
               </div>
             ) : (
               <div className="mt-6 rounded-[24px] border border-dashed border-slate-300 bg-slate-50 px-5 py-6">
-                <h3 className="text-base font-semibold text-slate-950">Ingen ukeplaner ennå</h3>
+                <h3 className="text-base font-semibold text-slate-950">
+                  Ingen ukeplaner ennå
+                </h3>
                 <p className="mt-2 text-sm leading-6 text-slate-600">
-                  Opprett familiens forste ukeplan for a komme i gang med serverlagret planlegging.
+                  Opprett familiens forste ukeplan for a komme i gang med
+                  serverlagret planlegging.
                 </p>
               </div>
             )}
@@ -395,7 +476,11 @@ function requireFamilyId(familyId: string | undefined) {
 function getMealPlanNotice(request: Request): MealPlanNotice | null {
   const notice = new URL(request.url).searchParams.get("notice");
 
-  if (notice === "meal-plan-copied" || notice === "meal-plan-created" || notice === "meal-plan-deleted") {
+  if (
+    notice === "meal-plan-copied" ||
+    notice === "meal-plan-created" ||
+    notice === "meal-plan-deleted"
+  ) {
     return notice;
   }
 
@@ -421,12 +506,14 @@ function getMealPlanNoticeContent(notice: MealPlanNotice) {
   switch (notice) {
     case "meal-plan-copied":
       return {
-        description: "Den nye ukeplanen ble opprettet med kopierte middager og notater i den valgte perioden.",
+        description:
+          "Den nye ukeplanen ble opprettet med kopierte middager og notater i den valgte perioden.",
         title: "Ukeplan gjenbrukt",
       };
     case "meal-plan-created":
       return {
-        description: "Ukeplanen ble lagret med start- og sluttdato for familien.",
+        description:
+          "Ukeplanen ble lagret med start- og sluttdato for familien.",
         title: "Ukeplan opprettet",
       };
     case "meal-plan-deleted":

--- a/app/routes/family-stores.tsx
+++ b/app/routes/family-stores.tsx
@@ -1,6 +1,12 @@
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { Form, Link, isRouteErrorResponse, useNavigation, type MetaFunction } from "react-router";
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
 
 import { requireUser } from "../lib/auth.server";
 import { FamilyStoreEditorCard } from "../components/family-store-editor-card";
@@ -13,15 +19,9 @@ import {
   type FamilyStoreValues,
 } from "../lib/store-write.server";
 
-type StoresNotice =
-  | "store-created"
-  | "store-deleted"
-  | "store-updated";
+type StoresNotice = "store-created" | "store-deleted" | "store-updated";
 
-type StoresIntent =
-  | "create-store"
-  | "delete-store"
-  | "update-store";
+type StoresIntent = "create-store" | "delete-store" | "update-store";
 
 interface StoresActionData {
   createFieldErrors?: {
@@ -45,7 +45,11 @@ interface FamilyStoresRouteProps {
 export const meta: MetaFunction = () => {
   return [
     { title: "Butikker | Mealplanner" },
-    { name: "description", content: "Administrer familiebutikker og seksjonsrekkefolge i Mealplanner." },
+    {
+      name: "description",
+      content:
+        "Administrer familiebutikker og seksjonsrekkefolge i Mealplanner.",
+    },
   ];
 };
 
@@ -190,13 +194,19 @@ export async function action({
   } satisfies StoresActionData;
 }
 
-export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStoresRouteProps) {
+export default function FamilyStoresRoute({
+  actionData,
+  loaderData,
+}: FamilyStoresRouteProps) {
   const navigation = useNavigation();
-  const noticeContent = loaderData.notice ? getStoresNoticeContent(loaderData.notice) : null;
+  const noticeContent = loaderData.notice
+    ? getStoresNoticeContent(loaderData.notice)
+    : null;
   const pendingIntent = navigation.formData?.get("intent");
-  const createValues = actionData?.intent === "create-store" && actionData.createValues
-    ? actionData.createValues
-    : { name: "" };
+  const createValues =
+    actionData?.intent === "create-store" && actionData.createValues
+      ? actionData.createValues
+      : { name: "" };
   const canManageStores = loaderData.userRole === "ADMIN";
 
   return (
@@ -208,10 +218,12 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
               <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                 Butikker
               </span>
-              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.family.name}</h1>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
-                Administrer familiebutikker og bestem seksjonsrekkefolgen slik at butikkmodus folger
-                handleturen deres.
+                Administrer familiebutikker og bestem seksjonsrekkefolgen slik
+                at butikkmodus folger handleturen deres.
               </p>
             </div>
 
@@ -220,7 +232,7 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
                 className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
                 to={`/families/${loaderData.family.id}/meal-plans`}
               >
-                Apne ukeplaner
+                Åpne ukeplaner
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
@@ -235,13 +247,17 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
         {noticeContent ? (
           <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
           </section>
         ) : null}
 
         {actionData?.formError ? (
           <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
-            <h2 className="text-base font-semibold">Kunne ikke oppdatere butikkene</h2>
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere butikkene
+            </h2>
             <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
           </section>
         ) : null}
@@ -249,9 +265,12 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
         {canManageStores ? (
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Opprett familiebutikk</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Opprett familiebutikk
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Nye butikker starter med alle kategorier og kan tilpasses videre under.
+                Nye butikker starter med alle kategorier og kan tilpasses videre
+                under.
               </p>
             </div>
 
@@ -267,15 +286,22 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
                   type="text"
                 />
               </label>
-              {actionData?.intent === "create-store" && actionData.createFieldErrors?.name ? (
-                <p className="text-sm text-rose-600">{actionData.createFieldErrors.name}</p>
+              {actionData?.intent === "create-store" &&
+              actionData.createFieldErrors?.name ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.createFieldErrors.name}
+                </p>
               ) : null}
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={navigation.state === "submitting" && pendingIntent === "create-store"}
+                disabled={
+                  navigation.state === "submitting" &&
+                  pendingIntent === "create-store"
+                }
                 type="submit"
               >
-                {navigation.state === "submitting" && pendingIntent === "create-store"
+                {navigation.state === "submitting" &&
+                pendingIntent === "create-store"
                   ? "Oppretter..."
                   : "Opprett butikk"}
               </button>
@@ -286,16 +312,24 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
         <section className="grid gap-6 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Seedede standardbutikker</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Seedede standardbutikker
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Disse butikkene er tilgjengelige for familien som faste utgangspunkt og kan ikke redigeres.
+                Disse butikkene er tilgjengelige for familien som faste
+                utgangspunkt og kan ikke redigeres.
               </p>
             </div>
 
             <div className="mt-6 grid gap-4">
               {loaderData.globalStores.map((store) => (
-                <article key={store.id} className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
-                  <h3 className="text-base font-semibold text-slate-950">{store.name}</h3>
+                <article
+                  key={store.id}
+                  className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                >
+                  <h3 className="text-base font-semibold text-slate-950">
+                    {store.name}
+                  </h3>
                   <ol className="mt-4 grid gap-2 text-sm leading-6 text-slate-700">
                     {store.sections.map((section, index) => (
                       <li key={section.id}>
@@ -310,9 +344,12 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
 
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Familiebutikker</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Familiebutikker
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Gi butikkene egne navn og tilpass seksjonsrekkefolgen for akkurat denne familien.
+                Gi butikkene egne navn og tilpass seksjonsrekkefolgen for
+                akkurat denne familien.
               </p>
             </div>
 
@@ -325,12 +362,14 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
                       key={store.id}
                       store={store}
                       updateFieldErrors={
-                        actionData?.intent === "update-store" && actionData.targetStoreId === store.id
+                        actionData?.intent === "update-store" &&
+                        actionData.targetStoreId === store.id
                           ? actionData.updateFieldErrors
                           : undefined
                       }
                       updateValues={
-                        actionData?.intent === "update-store" && actionData.targetStoreId === store.id
+                        actionData?.intent === "update-store" &&
+                        actionData.targetStoreId === store.id
                           ? actionData.updateValues
                           : undefined
                       }
@@ -340,7 +379,8 @@ export default function FamilyStoresRoute({ actionData, loaderData }: FamilyStor
               </DndProvider>
             ) : (
               <p className="mt-6 text-sm leading-6 text-slate-600">
-                Familien har ingen egne butikker ennå. Opprett en butikk for a fa en egen seksjonsrekkefolge.
+                Familien har ingen egne butikker ennå. Opprett en butikk for a
+                fa en egen seksjonsrekkefolge.
               </p>
             )}
           </article>
@@ -369,7 +409,10 @@ export function ErrorBoundary({ error }: { error: unknown }) {
       <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
         <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
         <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
-        <Link className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white" to="/app">
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+          to="/app"
+        >
           Til appen
         </Link>
       </div>
@@ -395,7 +438,8 @@ function getStoresNoticeContent(notice: StoresNotice) {
   switch (notice) {
     case "store-created":
       return {
-        description: "Butikken ble opprettet med alle kategorier klare for videre tilpasning.",
+        description:
+          "Butikken ble opprettet med alle kategorier klare for videre tilpasning.",
         title: "Butikken er opprettet",
       };
     case "store-updated":
@@ -405,7 +449,8 @@ function getStoresNoticeContent(notice: StoresNotice) {
       };
     case "store-deleted":
       return {
-        description: "Butikken ble slettet. Eventuelle preferanser peker na ikke lenger til denne butikken.",
+        description:
+          "Butikken ble slettet. Eventuelle preferanser peker na ikke lenger til denne butikken.",
         title: "Butikken er slettet",
       };
   }
@@ -427,13 +472,17 @@ function buildStoresRedirect({
 }
 
 function parseFamilyStoreValues(formData: FormData): FamilyStoreValues {
-  const categoryIds = formData.getAll("sectionCategoryId").map((value) => String(value));
+  const categoryIds = formData
+    .getAll("sectionCategoryId")
+    .map((value) => String(value));
 
   return {
     name: String(formData.get("name") ?? ""),
     sections: categoryIds.map((categoryId) => ({
       categoryId,
-      displayName: String(formData.get(`sectionDisplayName:${categoryId}`) ?? ""),
+      displayName: String(
+        formData.get(`sectionDisplayName:${categoryId}`) ?? "",
+      ),
     })),
   };
 }

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -53,7 +53,10 @@ function getFamilyNoticeContent(notice: FamilyNotice) {
 export const meta: Route.MetaFunction = () => {
   return [
     { title: "Familie | Mealplanner" },
-    { name: "description", content: "Familieoversikt og medlemsadministrasjon i Mealplanner." },
+    {
+      name: "description",
+      content: "Familieoversikt og medlemsadministrasjon i Mealplanner.",
+    },
   ];
 };
 
@@ -72,7 +75,8 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     familyId,
     userId: user.id,
   });
-  const members = membership.role === "ADMIN" ? await listFamilyMembers(familyId) : [];
+  const members =
+    membership.role === "ADMIN" ? await listFamilyMembers(familyId) : [];
 
   return {
     family: {
@@ -149,12 +153,20 @@ export async function action({ params, request }: Route.ActionArgs) {
   } satisfies FamilyActionData;
 }
 
-export default function FamilyRoute({ actionData, loaderData }: Route.ComponentProps) {
+export default function FamilyRoute({
+  actionData,
+  loaderData,
+}: Route.ComponentProps) {
   const navigation = useNavigation();
-  const noticeContent = loaderData.notice ? getFamilyNoticeContent(loaderData.notice) : null;
+  const noticeContent = loaderData.notice
+    ? getFamilyNoticeContent(loaderData.notice)
+    : null;
   const pendingIntent = navigation.formData?.get("intent");
-  const pendingTargetUserId = String(navigation.formData?.get("targetUserId") ?? "");
-  const isRemovingMember = navigation.state === "submitting" && pendingIntent === "remove-member";
+  const pendingTargetUserId = String(
+    navigation.formData?.get("targetUserId") ?? "",
+  );
+  const isRemovingMember =
+    navigation.state === "submitting" && pendingIntent === "remove-member";
   const isAdmin = loaderData.userRole === "ADMIN";
 
   return (
@@ -166,7 +178,9 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
               <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                 Familie
               </span>
-              <h1 className="mt-4 text-4xl font-semibold tracking-tight">{loaderData.family.name}</h1>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
                 {isAdmin
                   ? "Du kan administrere medlemmer og dele familiekoden med nye deltakere."
@@ -179,7 +193,7 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
                 className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
                 to={`/families/${loaderData.family.id}/meal-plans`}
               >
-                Apne ukeplaner
+                Åpne ukeplaner
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
@@ -200,14 +214,18 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
         {noticeContent ? (
           <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-emerald-900">{noticeContent.description}</p>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
           </section>
         ) : null}
 
         <section className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex items-center justify-between gap-3">
-              <h2 className="text-lg font-semibold text-slate-950">Din tilgang</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Din tilgang
+              </h2>
               <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
                 {isAdmin ? "Admin" : "Medlem"}
               </span>
@@ -220,7 +238,9 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
           </article>
 
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">Familiekode</h2>
+            <h2 className="text-lg font-semibold text-slate-950">
+              Familiekode
+            </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600">
               {loaderData.family.joinCode
                 ? "Del denne koden med personer som skal bli med i familien."
@@ -235,10 +255,12 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
         <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-slate-950">Ukeplaner</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Ukeplaner
+              </h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                Gå videre til familiens serverlagrede ukeplaner for å opprette, velge og oppdatere planer
-                med start- og sluttdato.
+                Gå videre til familiens serverlagrede ukeplaner for å opprette,
+                velge og oppdatere planer med start- og sluttdato.
               </p>
             </div>
 
@@ -254,66 +276,87 @@ export default function FamilyRoute({ actionData, loaderData }: Route.ComponentP
         {isAdmin ? (
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">Medlemmer</h2>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Medlemmer
+              </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Du kan fjerne vanlige medlemmer fra familien. Andre administratorer kan ikke fjernes her.
+                Du kan fjerne vanlige medlemmer fra familien. Andre
+                administratorer kan ikke fjernes her.
               </p>
             </div>
 
             <div className="mt-6 grid gap-4">
-              {loaderData.members.map((member: (typeof loaderData.members)[number]) => {
-                const canRemove = member.role === "MEMBER";
-                const isPendingRemoval = isRemovingMember && pendingTargetUserId === member.user.id;
-                const memberError =
-                  actionData?.targetUserId === member.user.id ? actionData.formError : undefined;
+              {loaderData.members.map(
+                (member: (typeof loaderData.members)[number]) => {
+                  const canRemove = member.role === "MEMBER";
+                  const isPendingRemoval =
+                    isRemovingMember && pendingTargetUserId === member.user.id;
+                  const memberError =
+                    actionData?.targetUserId === member.user.id
+                      ? actionData.formError
+                      : undefined;
 
-                return (
-                  <article
-                    key={member.id}
-                    className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
-                  >
-                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                      <div>
-                        <div className="flex flex-wrap items-center gap-3">
-                          <h3 className="text-base font-semibold text-slate-950">{member.user.displayName}</h3>
-                          <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
-                            {member.role === "ADMIN" ? "Admin" : "Medlem"}
-                          </span>
+                  return (
+                    <article
+                      key={member.id}
+                      className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                    >
+                      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div>
+                          <div className="flex flex-wrap items-center gap-3">
+                            <h3 className="text-base font-semibold text-slate-950">
+                              {member.user.displayName}
+                            </h3>
+                            <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
+                              {member.role === "ADMIN" ? "Admin" : "Medlem"}
+                            </span>
+                          </div>
+                          <p className="mt-2 text-sm leading-6 text-slate-600">
+                            {member.user.email}
+                          </p>
                         </div>
-                        <p className="mt-2 text-sm leading-6 text-slate-600">{member.user.email}</p>
+
+                        {canRemove ? (
+                          <Form method="post">
+                            <input
+                              name="intent"
+                              type="hidden"
+                              value="remove-member"
+                            />
+                            <input
+                              name="targetUserId"
+                              type="hidden"
+                              value={member.user.id}
+                            />
+                            <button
+                              className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+                              disabled={isRemovingMember}
+                              type="submit"
+                            >
+                              {isPendingRemoval ? "Fjerner..." : "Fjern medlem"}
+                            </button>
+                          </Form>
+                        ) : null}
                       </div>
 
-                      {canRemove ? (
-                        <Form method="post">
-                          <input name="intent" type="hidden" value="remove-member" />
-                          <input name="targetUserId" type="hidden" value={member.user.id} />
-                          <button
-                            className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
-                            disabled={isRemovingMember}
-                            type="submit"
-                          >
-                            {isPendingRemoval ? "Fjerner..." : "Fjern medlem"}
-                          </button>
-                        </Form>
+                      {memberError ? (
+                        <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                          {memberError}
+                        </p>
                       ) : null}
-                    </div>
-
-                    {memberError ? (
-                      <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-                        {memberError}
-                      </p>
-                    ) : null}
-                  </article>
-                );
-              })}
+                    </article>
+                  );
+                },
+              )}
             </div>
           </section>
         ) : (
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <h2 className="text-lg font-semibold text-slate-950">Neste steg</h2>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-              Familieadministrasjon ligger hos administratorene. Du kan fortsette videre til resten av den
-              beskyttede appen fra oversikten din.
+              Familieadministrasjon ligger hos administratorene. Du kan
+              fortsette videre til resten av den beskyttede appen fra oversikten
+              din.
             </p>
           </section>
         )}
@@ -332,7 +375,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
       description = "Du har ikke tilgang til a administrere denne familien.";
     } else if (error.status === 404) {
       title = "Familien finnes ikke";
-      description = "Vi fant ikke familien du forsokte a apne.";
+      description = "Vi fant ikke familien du forsokte a Åpne.";
     }
   }
 

--- a/app/routes/home.test.tsx
+++ b/app/routes/home.test.tsx
@@ -15,9 +15,8 @@ describe("Home", () => {
         name: /Prototype for familievennlig ukeplan og handleliste/i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Apne prototype/i })).toHaveAttribute(
-      "href",
-      "/prototype",
-    );
+    expect(
+      screen.getByRole("link", { name: /Åpne prototype/i }),
+    ).toHaveAttribute("href", "/prototype");
   });
 });

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -3,7 +3,10 @@ import { Link, type MetaFunction } from "react-router";
 export const meta: MetaFunction = () => {
   return [
     { title: "Mealplanner" },
-    { name: "description", content: "Prototype og videre arbeid for Mealplanner." },
+    {
+      name: "description",
+      content: "Prototype og videre arbeid for Mealplanner.",
+    },
   ];
 };
 
@@ -19,8 +22,8 @@ export default function Home() {
             Prototype for familievennlig ukeplan og handleliste
           </h1>
           <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
-            Prototypen ligger i sin egen mappe slik at vi kan utforske flyten uten a blande den
-            sammen med den framtidige produksjonsappen.
+            Prototypen ligger i sin egen mappe slik at vi kan utforske flyten
+            uten a blande den sammen med den framtidige produksjonsappen.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
@@ -39,7 +42,7 @@ export default function Home() {
               className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-200 transition hover:bg-white/15"
               to="/prototype"
             >
-              Apne prototype
+              Åpne prototype
             </Link>
           </div>
         </section>
@@ -48,20 +51,30 @@ export default function Home() {
           {[
             {
               title: "Ukeplan",
-              description: "Velg middager for hver dag og marker nar menyen er klar for godkjenning.",
+              description:
+                "Velg middager for hver dag og marker nar menyen er klar for godkjenning.",
             },
             {
               title: "Handleliste",
-              description: "Genereres automatisk fra ukens oppskrifter og kan kombineres med egne varer.",
+              description:
+                "Genereres automatisk fra ukens oppskrifter og kan kombineres med egne varer.",
             },
             {
               title: "Butikkmodus",
-              description: "Mobilvennlig visning med sortering per butikk og varer som kan utsettes.",
+              description:
+                "Mobilvennlig visning med sortering per butikk og varer som kan utsettes.",
             },
           ].map((item) => (
-            <article key={item.title} className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
-              <h2 className="text-lg font-semibold text-slate-950">{item.title}</h2>
-              <p className="mt-2 text-sm leading-6 text-slate-600">{item.description}</p>
+            <article
+              key={item.title}
+              className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
+            >
+              <h2 className="text-lg font-semibold text-slate-950">
+                {item.title}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                {item.description}
+              </p>
             </article>
           ))}
         </section>


### PR DESCRIPTION
## Summary
- add server-side `.ics` download routes for whole meal plans and single days
- generate timed `16:00-17:00` `Europe/Oslo` dinner events with focused ICS and route coverage
- keep the meal plan page visible during downloads by targeting a hidden iframe from the export buttons

## Test plan
- [x] `npm run test:run -- app/lib/calendar.server.test.ts app/routes/family-meal-plan-calendar.test.ts app/routes/family-meal-plan-day-calendar.test.ts app/routes/family-meal-plan.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`