### PR TITLE
Add family recipe CRUD so recipes are manageable outside seed data

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,37 +2,33 @@
 
 ## Current Objective
 
-Issue `#15` collaboration hardening is implemented: actor metadata on collaborative writes, optimistic concurrency with conflict errors, and structured logging for meal-plan and shopping mutations.
+Issue `#33` family recipe CRUD is implemented on branch `issue/33-crud-recipes`: admin-managed family recipes, read-only global list, meal-plan integration, and clearer ingredient handlekategori UI.
 
 ## Completed
 
-- Added `updatedByUserId` to `MealPlan`, `MealPlanEntry`, `ManualShoppingItem`, and `ShoppingItemOverride` with migration `prisma/migrations/20260515120000_collaboration_metadata`.
-- Added `app/lib/collaboration.server.ts` for version matching, entry snapshots, and Norwegian conflict copy.
-- Added `app/lib/write-observability.server.ts` for JSON collaboration write/failure logs.
-- Updated `app/lib/meal-plan.server.ts` with per-entry optimistic locking, plan-level locking for metadata/active date, and approval guards that block stale snapshots.
-- Updated `app/lib/shopping-write.server.ts` with optimistic locking on manual items, overrides, and active shopping date.
-- Wired hidden version fields and conflict banners in `family-meal-plan.tsx`, `family-meal-plan-shopping.tsx`, and `family-meal-plan-store-mode.tsx`.
-- Extended shopping projection with `collaborationVersion` / `overrideVersion` for form tokens.
-- Added tests for collaboration helpers, observability, domain conflicts, and route wiring.
+- Added `app/lib/recipe.server.ts` and `app/lib/recipe-write.server.ts` for family recipe list/detail and admin-only create/update/delete.
+- Blocked delete when a recipe is referenced by `MealPlanEntry` (`IN_USE` with entry count).
+- Added `family-recipes` list page (family vs global sections) and `family-recipe` detail editor with `FamilyRecipeEditorCard`.
+- Wired routes, family dashboard link, and meal-plan Oppskriftsbank CTA.
+- Clarified UI copy: handlekategori is per ingredient, not per recipe.
 
 ## Files To Read First
 
-- `app/lib/collaboration.server.ts` - Version matching, entry snapshots, conflict messages.
-- `app/lib/meal-plan.server.ts` - Entry save conflicts, plan update locking, approval snapshot guard.
-- `app/lib/shopping-write.server.ts` - Shopping/manual/override write conflicts and actor updates.
-- `app/routes/family-meal-plan.tsx` - Hidden `entryUpdatedAt`, `mealPlanUpdatedAt`, and `entriesSnapshot` fields.
+- `app/lib/recipe-write.server.ts` - Validation, ingredient replace, delete guard.
+- `app/routes/family-recipes.tsx` - List/create UI with family vs global sections.
+- `app/routes/family-recipe.tsx` - Detail update/delete actions.
+- `app/components/family-recipe-editor-card.tsx` - Ingredient editor UI.
 
 ## Validation
 
-- `npm run test:run -- app/lib/meal-plan.server.test.ts app/lib/shopping-write.server.test.ts app/lib/collaboration.server.test.ts app/lib/write-observability.server.test.ts app/routes/family-meal-plan.test.ts app/routes/family-meal-plan-shopping.test.ts app/routes/family-meal-plan-store-mode.test.ts`
+- `npm run test:run -- app/lib/recipe-write.server.test.ts app/routes/family-recipes.test.ts app/routes/family-recipe.test.ts`
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
-- Run `prisma migrate deploy` (or `prisma migrate dev`) against your database before manual testing.
-- No manual two-browser concurrency smoke test has been run yet.
-- `npm run typecheck` still needs Node `>20` if you want the full React Router typegen pipeline.
+- Manual smoke test: create recipe, use in meal plan, verify shopping list grouping, try delete while in use.
+- No migration required (uses existing schema).
 
 ## Next Step
 
-Run the migration, then smoke-test two family members editing the same meal plan day and shopping list to confirm conflict banners appear and a reload resolves them.
+Merge PR and verify family admins can manage recipes end-to-end in staging/production.

--- a/app/components/family-recipe-editor-card.tsx
+++ b/app/components/family-recipe-editor-card.tsx
@@ -1,0 +1,672 @@
+import { useEffect, useMemo, useState } from "react";
+import { Form, useNavigation } from "react-router";
+
+import type {
+  FamilyRecipeFieldErrors,
+  FamilyRecipeIngredientValues,
+  FamilyRecipeValues,
+} from "../lib/recipe-write.server";
+
+interface RecipeCategory {
+  displayName: string;
+  id: string;
+}
+
+interface RecipeStore {
+  id: string;
+  name: string;
+}
+
+interface DraftIngredientRow extends FamilyRecipeIngredientValues {
+  key: string;
+}
+
+interface FamilyRecipeEditorCardProps {
+  canManageRecipes: boolean;
+  categories: RecipeCategory[];
+  familyStores: RecipeStore[];
+  mealPlanEntryCount: number;
+  recipe: {
+    defaultServings: number | null;
+    description: string | null;
+    id: string;
+    ingredients: Array<{
+      amount: string | null;
+      categoryId: string;
+      displayName: string;
+      preferredStoreId: string | null;
+      unit: string | null;
+    }>;
+    prepMinutes: number | null;
+    tags: string[];
+    title: string;
+  };
+  updateFieldErrors?: FamilyRecipeFieldErrors;
+  updateValues?: FamilyRecipeValues;
+}
+
+export function FamilyRecipeEditorCard({
+  canManageRecipes,
+  categories,
+  familyStores,
+  mealPlanEntryCount,
+  recipe,
+  updateFieldErrors,
+  updateValues,
+}: FamilyRecipeEditorCardProps) {
+  const navigation = useNavigation();
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingRecipeId = String(navigation.formData?.get("recipeId") ?? "");
+  const isUpdatingRecipe =
+    navigation.state === "submitting" &&
+    pendingIntent === "update-recipe" &&
+    pendingRecipeId === recipe.id;
+  const isDeletingRecipe =
+    navigation.state === "submitting" &&
+    pendingIntent === "delete-recipe" &&
+    pendingRecipeId === recipe.id;
+  const persistedValues = useMemo<FamilyRecipeValues>(
+    () => toRecipeValues(recipe),
+    [recipe],
+  );
+  const [ignoreSubmittedValues, setIgnoreSubmittedValues] = useState(false);
+  const sourceValues =
+    updateValues && !ignoreSubmittedValues ? updateValues : persistedValues;
+  const [isEditing, setIsEditing] = useState(Boolean(updateValues));
+  const [draftValues, setDraftValues] = useState(sourceValues);
+
+  useEffect(() => {
+    if (updateValues) {
+      setIgnoreSubmittedValues(false);
+    }
+  }, [updateValues]);
+
+  useEffect(() => {
+    setDraftValues(sourceValues);
+  }, [sourceValues]);
+
+  const draftIngredients = useMemo(
+    () => toDraftIngredients(draftValues.ingredients),
+    [draftValues.ingredients],
+  );
+
+  function handleCancelEditing() {
+    setIgnoreSubmittedValues(true);
+    setDraftValues(persistedValues);
+    setIsEditing(false);
+  }
+
+  function updateIngredient(
+    key: string,
+    patch: Partial<FamilyRecipeIngredientValues>,
+  ) {
+    const index = draftIngredients.findIndex((row) => row.key === key);
+
+    if (index === -1) {
+      return;
+    }
+
+    setDraftValues((current) => {
+      const nextIngredients = [...current.ingredients];
+      nextIngredients[index] = {
+        ...nextIngredients[index],
+        ...patch,
+      };
+
+      return {
+        ...current,
+        ingredients: nextIngredients,
+      };
+    });
+  }
+
+  function addIngredient() {
+    const defaultCategoryId = categories[0]?.id ?? "";
+
+    setDraftValues((current) => ({
+      ...current,
+      ingredients: [
+        ...current.ingredients,
+        {
+          amount: "",
+          categoryId: defaultCategoryId,
+          displayName: "",
+          preferredStoreId: "",
+          unit: "",
+        },
+      ],
+    }));
+  }
+
+  function removeIngredient(key: string) {
+    const index = draftIngredients.findIndex((row) => row.key === key);
+
+    if (index === -1) {
+      return;
+    }
+
+    setDraftValues((current) => ({
+      ...current,
+      ingredients: current.ingredients.filter((_, rowIndex) => rowIndex !== index),
+    }));
+  }
+
+  function moveIngredient(key: string, direction: "up" | "down") {
+    const index = draftIngredients.findIndex((row) => row.key === key);
+
+    if (index === -1) {
+      return;
+    }
+
+    const targetIndex = direction === "up" ? index - 1 : index + 1;
+
+    if (targetIndex < 0 || targetIndex >= draftIngredients.length) {
+      return;
+    }
+
+    setDraftValues((current) => {
+      const nextIngredients = [...current.ingredients];
+      const [moved] = nextIngredients.splice(index, 1);
+      nextIngredients.splice(targetIndex, 0, moved);
+
+      return {
+        ...current,
+        ingredients: nextIngredients,
+      };
+    });
+  }
+
+  return (
+    <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <span className="inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
+            Familieoppskrift
+          </span>
+          <h2 className="mt-3 text-2xl font-semibold text-slate-950">{recipe.title}</h2>
+          {mealPlanEntryCount > 0 ? (
+            <p className="mt-2 text-sm text-slate-600">
+              Brukt i {mealPlanEntryCount}{" "}
+              {mealPlanEntryCount === 1 ? "ukeplan" : "ukeplaner"}
+            </p>
+          ) : null}
+        </div>
+        {canManageRecipes && !isEditing ? (
+          <button
+            className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+            onClick={() => setIsEditing(true)}
+            type="button"
+          >
+            Rediger oppskrift
+          </button>
+        ) : null}
+      </div>
+
+      {canManageRecipes && isEditing ? (
+        <Form className="mt-6 space-y-6" method="post">
+          <input name="intent" type="hidden" value="update-recipe" />
+          <input name="recipeId" type="hidden" value={recipe.id} />
+          <RecipeFields
+            categories={categories}
+            draftIngredients={draftIngredients}
+            draftValues={draftValues}
+            familyStores={familyStores}
+            fieldErrors={updateFieldErrors}
+            onAddIngredient={addIngredient}
+            onMoveIngredient={moveIngredient}
+            onRemoveIngredient={removeIngredient}
+            onUpdateIngredient={updateIngredient}
+            setDraftValues={setDraftValues}
+          />
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              className="inline-flex flex-1 items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+              disabled={isUpdatingRecipe}
+              type="submit"
+            >
+              {isUpdatingRecipe ? "Lagrer..." : "Lagre oppskrift"}
+            </button>
+            <button
+              className="inline-flex flex-1 items-center justify-center rounded-2xl bg-white px-5 py-3 text-sm font-medium text-slate-700 ring-1 ring-slate-300 transition hover:bg-slate-50"
+              onClick={handleCancelEditing}
+              type="button"
+            >
+              Avbryt
+            </button>
+          </div>
+        </Form>
+      ) : (
+        <RecipeReadOnlySummary
+          categories={categories}
+          draftIngredients={draftIngredients}
+          draftValues={draftValues}
+          familyStores={familyStores}
+        />
+      )}
+
+      {canManageRecipes && !isEditing ? (
+        <div className="mt-4 space-y-3">
+          {mealPlanEntryCount > 0 ? (
+            <p className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-900">
+              Oppskriften brukes i {mealPlanEntryCount}{" "}
+              {mealPlanEntryCount === 1 ? "ukeplan" : "ukeplaner"} og kan ikke
+              slettes for du fjerner den fra planene.
+            </p>
+          ) : null}
+          <Form method="post">
+            <input name="intent" type="hidden" value="delete-recipe" />
+            <input name="recipeId" type="hidden" value={recipe.id} />
+            <button
+              className="inline-flex w-full items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+              disabled={isDeletingRecipe || mealPlanEntryCount > 0}
+              type="submit"
+            >
+              {isDeletingRecipe ? "Sletter..." : "Slett oppskrift"}
+            </button>
+          </Form>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function RecipeFields({
+  categories,
+  draftIngredients,
+  draftValues,
+  familyStores,
+  fieldErrors,
+  onAddIngredient,
+  onMoveIngredient,
+  onRemoveIngredient,
+  onUpdateIngredient,
+  setDraftValues,
+}: {
+  categories: RecipeCategory[];
+  draftIngredients: DraftIngredientRow[];
+  draftValues: FamilyRecipeValues;
+  familyStores: RecipeStore[];
+  fieldErrors?: FamilyRecipeFieldErrors;
+  onAddIngredient: () => void;
+  onMoveIngredient: (key: string, direction: "up" | "down") => void;
+  onRemoveIngredient: (key: string) => void;
+  onUpdateIngredient: (
+    key: string,
+    patch: Partial<FamilyRecipeIngredientValues>,
+  ) => void;
+  setDraftValues: React.Dispatch<React.SetStateAction<FamilyRecipeValues>>;
+}) {
+  return (
+    <>
+      <label className="block text-sm font-medium text-slate-700">
+        Tittel
+        <input
+          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+          name="title"
+          onChange={(event) =>
+            setDraftValues((current) => ({
+              ...current,
+              title: event.target.value,
+            }))
+          }
+          type="text"
+          value={draftValues.title}
+        />
+      </label>
+      {fieldErrors?.title ? (
+        <p className="text-sm text-rose-600">{fieldErrors.title}</p>
+      ) : null}
+
+      <label className="block text-sm font-medium text-slate-700">
+        Beskrivelse
+        <textarea
+          className="mt-2 min-h-24 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+          name="description"
+          onChange={(event) =>
+            setDraftValues((current) => ({
+              ...current,
+              description: event.target.value,
+            }))
+          }
+          value={draftValues.description}
+        />
+      </label>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block text-sm font-medium text-slate-700">
+          Porsjoner
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            inputMode="numeric"
+            name="defaultServings"
+            onChange={(event) =>
+              setDraftValues((current) => ({
+                ...current,
+                defaultServings: event.target.value,
+              }))
+            }
+            placeholder="4"
+            type="text"
+            value={draftValues.defaultServings}
+          />
+          {fieldErrors?.defaultServings ? (
+            <p className="mt-2 text-sm text-rose-600">
+              {fieldErrors.defaultServings}
+            </p>
+          ) : null}
+        </label>
+
+        <label className="block text-sm font-medium text-slate-700">
+          Tilberedning (min)
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            inputMode="numeric"
+            name="prepMinutes"
+            onChange={(event) =>
+              setDraftValues((current) => ({
+                ...current,
+                prepMinutes: event.target.value,
+              }))
+            }
+            placeholder="30"
+            type="text"
+            value={draftValues.prepMinutes}
+          />
+          {fieldErrors?.prepMinutes ? (
+            <p className="mt-2 text-sm text-rose-600">{fieldErrors.prepMinutes}</p>
+          ) : null}
+        </label>
+      </div>
+
+      <label className="block text-sm font-medium text-slate-700">
+        Stikkord (kommaseparert)
+        <input
+          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+          name="tags"
+          onChange={(event) =>
+            setDraftValues((current) => ({
+              ...current,
+              tags: event.target.value,
+            }))
+          }
+          placeholder="middag, rask"
+          type="text"
+          value={draftValues.tags}
+        />
+      </label>
+
+      <div className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-slate-950">Ingredienser</h3>
+            <p className="mt-1 text-sm leading-6 text-slate-600">
+              Hver rad er én ingrediens med egen handlekategori (brukes i
+              handlelisten, ikke som oppskriftstype).
+            </p>
+          </div>
+          <button
+            className="shrink-0 rounded-2xl bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-800 ring-1 ring-emerald-200 transition hover:bg-emerald-100"
+            onClick={onAddIngredient}
+            type="button"
+          >
+            Legg til rad
+          </button>
+        </div>
+        {fieldErrors?.ingredients ? (
+          <p className="text-sm text-rose-600">{fieldErrors.ingredients}</p>
+        ) : null}
+
+        {draftIngredients.map((row, index) => (
+          <IngredientRowEditor
+            categories={categories}
+            familyStores={familyStores}
+            index={index}
+            key={row.key}
+            onMove={onMoveIngredient}
+            onRemove={onRemoveIngredient}
+            onUpdate={onUpdateIngredient}
+            row={row}
+            validationError={
+              fieldErrors?.ingredientDisplayNames?.[index] ??
+              fieldErrors?.ingredientCategories?.[index]
+            }
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+function IngredientRowEditor({
+  categories,
+  familyStores,
+  index,
+  onMove,
+  onRemove,
+  onUpdate,
+  row,
+  validationError,
+}: {
+  categories: RecipeCategory[];
+  familyStores: RecipeStore[];
+  index: number;
+  onMove: (key: string, direction: "up" | "down") => void;
+  onRemove: (key: string) => void;
+  onUpdate: (key: string, patch: Partial<FamilyRecipeIngredientValues>) => void;
+  row: DraftIngredientRow;
+  validationError?: string;
+}) {
+  return (
+    <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-4">
+      <input name="ingredientIndex" type="hidden" value={String(index)} />
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200">
+          Ingrediens {index + 1}
+        </span>
+        <button
+          className="rounded-xl bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+          onClick={() => onMove(row.key, "up")}
+          type="button"
+        >
+          Opp
+        </button>
+        <button
+          className="rounded-xl bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+          onClick={() => onMove(row.key, "down")}
+          type="button"
+        >
+          Ned
+        </button>
+        <button
+          className="rounded-xl bg-rose-50 px-3 py-1 text-xs font-medium text-rose-700 ring-1 ring-rose-200"
+          onClick={() => onRemove(row.key)}
+          type="button"
+        >
+          Fjern
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <label className="block text-sm font-medium text-slate-700 sm:col-span-2">
+          Navn
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+            name={`ingredientDisplayName:${index}`}
+            onChange={(event) =>
+              onUpdate(row.key, { displayName: event.target.value })
+            }
+            type="text"
+            value={row.displayName}
+          />
+        </label>
+        <label className="block text-sm font-medium text-slate-700">
+          Mengde
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+            name={`ingredientAmount:${index}`}
+            onChange={(event) => onUpdate(row.key, { amount: event.target.value })}
+            type="text"
+            value={row.amount}
+          />
+        </label>
+        <label className="block text-sm font-medium text-slate-700">
+          Enhet
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+            name={`ingredientUnit:${index}`}
+            onChange={(event) => onUpdate(row.key, { unit: event.target.value })}
+            type="text"
+            value={row.unit}
+          />
+        </label>
+        <label className="block text-sm font-medium text-slate-700">
+          Handlekategori
+          <span className="mt-1 block text-xs font-normal text-slate-500">
+            Hvor varen havner i handlelisten
+          </span>
+          <select
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+            name={`ingredientCategoryId:${index}`}
+            onChange={(event) =>
+              onUpdate(row.key, { categoryId: event.target.value })
+            }
+            value={row.categoryId}
+          >
+            <option value="">Velg handlekategori</option>
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.displayName}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-sm font-medium text-slate-700">
+          Foretrukket butikk
+          <select
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+            name={`ingredientPreferredStoreId:${index}`}
+            onChange={(event) =>
+              onUpdate(row.key, { preferredStoreId: event.target.value })
+            }
+            value={row.preferredStoreId}
+          >
+            <option value="">Ingen</option>
+            {familyStores.map((store) => (
+              <option key={store.id} value={store.id}>
+                {store.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {validationError ? (
+        <p className="mt-2 text-sm text-rose-600">{validationError}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function RecipeReadOnlySummary({
+  categories,
+  draftIngredients,
+  draftValues,
+  familyStores,
+}: {
+  categories: RecipeCategory[];
+  draftIngredients: DraftIngredientRow[];
+  draftValues: FamilyRecipeValues;
+  familyStores: RecipeStore[];
+}) {
+  const categoryById = new Map(categories.map((category) => [category.id, category]));
+  const storeById = new Map(familyStores.map((store) => [store.id, store]));
+
+  return (
+    <div className="mt-6 space-y-6">
+      {draftValues.description ? (
+        <p className="text-sm leading-7 text-slate-600">{draftValues.description}</p>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        {draftValues.defaultServings ? (
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
+            {draftValues.defaultServings} porsjoner
+          </span>
+        ) : null}
+        {draftValues.prepMinutes ? (
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
+            {draftValues.prepMinutes} min
+          </span>
+        ) : null}
+        {draftValues.tags
+          .split(",")
+          .map((tag) => tag.trim())
+          .filter(Boolean)
+          .map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+            >
+              {tag}
+            </span>
+          ))}
+      </div>
+      <ol className="space-y-3">
+        {draftIngredients.map((row, index) => (
+          <li
+            className="rounded-[20px] border border-slate-200 bg-slate-50 px-4 py-3"
+            key={row.key}
+          >
+            <p className="font-medium text-slate-950">
+              {index + 1}. {row.displayName}
+            </p>
+            <p className="mt-1 text-sm text-slate-600">
+              {[row.amount, row.unit].filter(Boolean).join(" ") || "Uten mengde"}
+              {" · Handlekategori: "}
+              {categoryById.get(row.categoryId)?.displayName ??
+                "Ukjent handlekategori"}
+              {row.preferredStoreId
+                ? ` · ${storeById.get(row.preferredStoreId)?.name ?? "Butikk"}`
+                : ""}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function toRecipeValues(recipe: FamilyRecipeEditorCardProps["recipe"]): FamilyRecipeValues {
+  return {
+    defaultServings: recipe.defaultServings?.toString() ?? "",
+    description: recipe.description ?? "",
+    ingredients:
+      recipe.ingredients.length > 0
+        ? recipe.ingredients.map((ingredient) => ({
+            amount: ingredient.amount ?? "",
+            categoryId: ingredient.categoryId,
+            displayName: ingredient.displayName,
+            preferredStoreId: ingredient.preferredStoreId ?? "",
+            unit: ingredient.unit ?? "",
+          }))
+        : [
+            {
+              amount: "",
+              categoryId: "",
+              displayName: "",
+              preferredStoreId: "",
+              unit: "",
+            },
+          ],
+    prepMinutes: recipe.prepMinutes?.toString() ?? "",
+    tags: recipe.tags.join(", "),
+    title: recipe.title,
+  };
+}
+
+function toDraftIngredients(
+  ingredients: FamilyRecipeIngredientValues[],
+): DraftIngredientRow[] {
+  return ingredients.map((ingredient, index) => ({
+    ...ingredient,
+    key: `row-${index}`,
+  }));
+}

--- a/app/lib/recipe-write.server.test.ts
+++ b/app/lib/recipe-write.server.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyAdminMock, transactionMock } = vi.hoisted(() => {
+  const transactionMock = {
+    recipe: {
+      update: vi.fn(),
+    },
+    recipeIngredient: {
+      createMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  };
+
+  return {
+    dbMock: {
+      $transaction: vi.fn(),
+      recipe: {
+        create: vi.fn(),
+        delete: vi.fn(),
+        findFirst: vi.fn(),
+      },
+      store: {
+        findMany: vi.fn(),
+      },
+    },
+    requireFamilyAdminMock: vi.fn(),
+    transactionMock,
+  };
+});
+
+vi.mock("./db.server", () => {
+  return {
+    db: dbMock,
+  };
+});
+
+vi.mock("./family.server", () => {
+  return {
+    requireFamilyAdmin: requireFamilyAdminMock,
+  };
+});
+
+vi.mock("./store.server", () => {
+  return {
+    listIngredientCategories: vi.fn(),
+  };
+});
+
+import { listIngredientCategories } from "./store.server";
+import {
+  createFamilyRecipe,
+  deleteFamilyRecipe,
+  updateFamilyRecipe,
+} from "./recipe-write.server";
+
+const baseValues = {
+  defaultServings: "4",
+  description: "En god middag",
+  ingredients: [
+    {
+      amount: "500",
+      categoryId: "category-meat",
+      displayName: "Kyllingfilet",
+      preferredStoreId: "",
+      unit: "g",
+    },
+  ],
+  prepMinutes: "30",
+  tags: "middag, rask",
+  title: "Kyllingwok",
+};
+
+describe("recipe-write.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyAdminMock.mockResolvedValue({
+      familyId: "family-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+    vi.mocked(listIngredientCategories).mockResolvedValue([
+      {
+        displayName: "Kjott og fisk",
+        id: "category-meat",
+      },
+    ]);
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        id: "store-1",
+      },
+    ]);
+    dbMock.$transaction.mockImplementation(async (callback: (tx: typeof transactionMock) => unknown) =>
+      callback(transactionMock),
+    );
+  });
+
+  it("returns validation errors before creating a family recipe", async () => {
+    const result = await createFamilyRecipe({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        ...baseValues,
+        ingredients: [],
+        title: "   ",
+      },
+    });
+
+    expect(result).toEqual({
+      fieldErrors: {
+        ingredients: "Legg til minst en ingrediens.",
+        title: "Skriv inn en tittel.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        ...baseValues,
+        ingredients: [],
+        title: "",
+      },
+    });
+    expect(dbMock.recipe.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a family recipe with ordered ingredients", async () => {
+    dbMock.recipe.create.mockResolvedValue({
+      id: "recipe-1",
+      title: "Kyllingwok",
+    });
+
+    const result = await createFamilyRecipe({
+      familyId: "family-1",
+      userId: "user-1",
+      values: baseValues,
+    });
+
+    expect(result).toEqual({
+      recipe: {
+        id: "recipe-1",
+        title: "Kyllingwok",
+      },
+      status: "CREATED",
+    });
+    expect(dbMock.recipe.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        familyId: "family-1",
+        scope: "FAMILY",
+        title: "Kyllingwok",
+        ingredients: {
+          create: [
+            expect.objectContaining({
+              displayName: "Kyllingfilet",
+              sortOrder: 1,
+            }),
+          ],
+        },
+      }),
+      select: {
+        id: true,
+        title: true,
+      },
+    });
+  });
+
+  it("replaces ingredients transactionally on update", async () => {
+    dbMock.recipe.findFirst.mockResolvedValue({
+      id: "recipe-1",
+    });
+
+    const result = await updateFamilyRecipe({
+      familyId: "family-1",
+      recipeId: "recipe-1",
+      userId: "user-1",
+      values: baseValues,
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(transactionMock.recipeIngredient.deleteMany).toHaveBeenCalledWith({
+      where: {
+        recipeId: "recipe-1",
+      },
+    });
+    expect(transactionMock.recipeIngredient.createMany).toHaveBeenCalled();
+  });
+
+  it("blocks delete when recipe is used in meal plans", async () => {
+    dbMock.recipe.findFirst.mockResolvedValue({
+      _count: {
+        mealPlanEntries: 2,
+      },
+      id: "recipe-1",
+      title: "Kyllingwok",
+    });
+
+    const result = await deleteFamilyRecipe({
+      familyId: "family-1",
+      recipeId: "recipe-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      entryCount: 2,
+      status: "IN_USE",
+      title: "Kyllingwok",
+    });
+    expect(dbMock.recipe.delete).not.toHaveBeenCalled();
+  });
+
+  it("deletes unused family recipes", async () => {
+    dbMock.recipe.findFirst.mockResolvedValue({
+      _count: {
+        mealPlanEntries: 0,
+      },
+      id: "recipe-1",
+      title: "Kyllingwok",
+    });
+
+    const result = await deleteFamilyRecipe({
+      familyId: "family-1",
+      recipeId: "recipe-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "DELETED" });
+    expect(dbMock.recipe.delete).toHaveBeenCalledWith({
+      where: {
+        id: "recipe-1",
+      },
+    });
+  });
+
+  it("returns not found for missing family recipes", async () => {
+    dbMock.recipe.findFirst.mockResolvedValue(null);
+
+    const result = await updateFamilyRecipe({
+      familyId: "family-1",
+      recipeId: "global-recipe",
+      userId: "user-1",
+      values: baseValues,
+    });
+
+    expect(result).toEqual({ status: "NOT_FOUND" });
+  });
+
+  it("rejects preferred stores outside the family", async () => {
+    const result = await createFamilyRecipe({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        ...baseValues,
+        ingredients: [
+          {
+            ...baseValues.ingredients[0],
+            preferredStoreId: "other-store",
+          },
+        ],
+      },
+    });
+
+    expect(result.status).toBe("VALIDATION_ERROR");
+    expect(result).toMatchObject({
+      fieldErrors: {
+        ingredientCategories: {
+          0: "Foretrukket butikk ma tilhore familien.",
+        },
+      },
+    });
+  });
+});

--- a/app/lib/recipe-write.server.ts
+++ b/app/lib/recipe-write.server.ts
@@ -1,0 +1,415 @@
+import { Prisma, RecipeScope } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyAdmin } from "./family.server";
+import { listIngredientCategories } from "./store.server";
+
+export interface FamilyRecipeIngredientValues {
+  amount: string;
+  categoryId: string;
+  displayName: string;
+  preferredStoreId: string;
+  unit: string;
+}
+
+export interface FamilyRecipeValues {
+  defaultServings: string;
+  description: string;
+  ingredients: FamilyRecipeIngredientValues[];
+  prepMinutes: string;
+  tags: string;
+  title: string;
+}
+
+export function parseFamilyRecipeValues(formData: FormData): FamilyRecipeValues {
+  const indices = formData
+    .getAll("ingredientIndex")
+    .map((value) => String(value))
+    .filter((value) => value.length > 0);
+  const uniqueIndices = [...new Set(indices)].sort(
+    (left, right) => Number(left) - Number(right),
+  );
+
+  return {
+    defaultServings: String(formData.get("defaultServings") ?? ""),
+    description: String(formData.get("description") ?? ""),
+    ingredients: uniqueIndices.map((index) => ({
+      amount: String(formData.get(`ingredientAmount:${index}`) ?? ""),
+      categoryId: String(formData.get(`ingredientCategoryId:${index}`) ?? ""),
+      displayName: String(formData.get(`ingredientDisplayName:${index}`) ?? ""),
+      preferredStoreId: String(
+        formData.get(`ingredientPreferredStoreId:${index}`) ?? "",
+      ),
+      unit: String(formData.get(`ingredientUnit:${index}`) ?? ""),
+    })),
+    prepMinutes: String(formData.get("prepMinutes") ?? ""),
+    tags: String(formData.get("tags") ?? ""),
+    title: String(formData.get("title") ?? ""),
+  };
+}
+
+export interface FamilyRecipeFieldErrors {
+  defaultServings?: string;
+  ingredients?: string;
+  ingredientAmounts?: Record<number, string>;
+  ingredientCategories?: Record<number, string>;
+  ingredientDisplayNames?: Record<number, string>;
+  prepMinutes?: string;
+  title?: string;
+}
+
+function parseOptionalPositiveInt(value: string, fieldLabel: string) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return {
+      ok: true as const,
+      value: null,
+    };
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return {
+      error: `${fieldLabel} ma vare et positivt heltall.`,
+      ok: false as const,
+    };
+  }
+
+  return {
+    ok: true as const,
+    value: parsed,
+  };
+}
+
+function parseTags(tags: string) {
+  return tags
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+export async function createFamilyRecipe({
+  familyId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  userId: string;
+  values: FamilyRecipeValues;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const validation = await validateFamilyRecipeValues({
+    familyId,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  const recipe = await db.recipe.create({
+    data: {
+      createdByUserId: userId,
+      defaultServings: validation.parsed.defaultServings,
+      description: validation.parsed.description,
+      familyId,
+      ingredients: {
+        create: validation.parsed.ingredients.map((ingredient, index) => ({
+          amount: ingredient.amount,
+          categoryId: ingredient.categoryId,
+          displayName: ingredient.displayName,
+          preferredStoreId: ingredient.preferredStoreId,
+          sortOrder: index + 1,
+          unit: ingredient.unit,
+        })),
+      },
+      prepMinutes: validation.parsed.prepMinutes,
+      scope: RecipeScope.FAMILY,
+      tags: validation.parsed.tags,
+      title: validation.parsed.title,
+    },
+    select: {
+      id: true,
+      title: true,
+    },
+  });
+
+  return {
+    recipe,
+    status: "CREATED" as const,
+  };
+}
+
+export async function updateFamilyRecipe({
+  familyId,
+  recipeId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  recipeId: string;
+  userId: string;
+  values: FamilyRecipeValues;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const existingRecipe = await db.recipe.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId,
+      id: recipeId,
+      scope: RecipeScope.FAMILY,
+    },
+  });
+
+  if (!existingRecipe) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const validation = await validateFamilyRecipeValues({
+    familyId,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  await db.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.recipe.update({
+      data: {
+        defaultServings: validation.parsed.defaultServings,
+        description: validation.parsed.description,
+        prepMinutes: validation.parsed.prepMinutes,
+        tags: validation.parsed.tags,
+        title: validation.parsed.title,
+      },
+      where: {
+        id: existingRecipe.id,
+      },
+    });
+
+    await tx.recipeIngredient.deleteMany({
+      where: {
+        recipeId: existingRecipe.id,
+      },
+    });
+
+    await tx.recipeIngredient.createMany({
+      data: validation.parsed.ingredients.map((ingredient, index) => ({
+        amount: ingredient.amount,
+        categoryId: ingredient.categoryId,
+        displayName: ingredient.displayName,
+        preferredStoreId: ingredient.preferredStoreId,
+        recipeId: existingRecipe.id,
+        sortOrder: index + 1,
+        unit: ingredient.unit,
+      })),
+    });
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+export async function deleteFamilyRecipe({
+  familyId,
+  recipeId,
+  userId,
+}: {
+  familyId: string;
+  recipeId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const recipe = await db.recipe.findFirst({
+    select: {
+      id: true,
+      title: true,
+      _count: {
+        select: {
+          mealPlanEntries: true,
+        },
+      },
+    },
+    where: {
+      familyId,
+      id: recipeId,
+      scope: RecipeScope.FAMILY,
+    },
+  });
+
+  if (!recipe) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (recipe._count.mealPlanEntries > 0) {
+    return {
+      entryCount: recipe._count.mealPlanEntries,
+      status: "IN_USE" as const,
+      title: recipe.title,
+    };
+  }
+
+  await db.recipe.delete({
+    where: {
+      id: recipe.id,
+    },
+  });
+
+  return {
+    status: "DELETED" as const,
+  };
+}
+
+async function validateFamilyRecipeValues({
+  familyId,
+  values,
+}: {
+  familyId: string;
+  values: FamilyRecipeValues;
+}) {
+  const normalizedValues: FamilyRecipeValues = {
+    defaultServings: values.defaultServings.trim(),
+    description: values.description.trim(),
+    ingredients: values.ingredients.map((ingredient) => ({
+      amount: ingredient.amount.trim(),
+      categoryId: ingredient.categoryId.trim(),
+      displayName: ingredient.displayName.trim(),
+      preferredStoreId: ingredient.preferredStoreId.trim(),
+      unit: ingredient.unit.trim(),
+    })),
+    prepMinutes: values.prepMinutes.trim(),
+    tags: values.tags.trim(),
+    title: values.title.trim(),
+  };
+  const fieldErrors: FamilyRecipeFieldErrors = {};
+  const ingredientDisplayNames: Record<number, string> = {};
+  const ingredientCategories: Record<number, string> = {};
+
+  if (!normalizedValues.title) {
+    fieldErrors.title = "Skriv inn en tittel.";
+  }
+
+  const servingsResult = parseOptionalPositiveInt(
+    normalizedValues.defaultServings,
+    "Antall porsjoner",
+  );
+
+  if (!servingsResult.ok) {
+    fieldErrors.defaultServings = servingsResult.error;
+  }
+
+  const prepResult = parseOptionalPositiveInt(
+    normalizedValues.prepMinutes,
+    "Tilberedningstid",
+  );
+
+  if (!prepResult.ok) {
+    fieldErrors.prepMinutes = prepResult.error;
+  }
+
+  if (normalizedValues.ingredients.length === 0) {
+    fieldErrors.ingredients = "Legg til minst en ingrediens.";
+  }
+
+  const categories = await listIngredientCategories();
+  const validCategoryIds = new Set(categories.map((category) => category.id));
+  const familyStores = await db.store.findMany({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+  const validFamilyStoreIds = new Set(familyStores.map((store) => store.id));
+
+  normalizedValues.ingredients.forEach((ingredient, index) => {
+    if (!ingredient.displayName) {
+      ingredientDisplayNames[index] = "Skriv inn et ingrediensnavn.";
+    }
+
+    if (!ingredient.categoryId || !validCategoryIds.has(ingredient.categoryId)) {
+      ingredientCategories[index] = "Velg en gyldig kategori.";
+    }
+
+    if (
+      ingredient.preferredStoreId &&
+      !validFamilyStoreIds.has(ingredient.preferredStoreId)
+    ) {
+      ingredientCategories[index] =
+        "Foretrukket butikk ma tilhore familien.";
+    }
+  });
+
+  if (Object.keys(ingredientDisplayNames).length > 0) {
+    fieldErrors.ingredientDisplayNames = ingredientDisplayNames;
+  }
+
+  if (Object.keys(ingredientCategories).length > 0) {
+    fieldErrors.ingredientCategories = ingredientCategories;
+  }
+
+  if (
+    fieldErrors.title ||
+    fieldErrors.defaultServings ||
+    fieldErrors.prepMinutes ||
+    fieldErrors.ingredients ||
+    fieldErrors.ingredientDisplayNames ||
+    fieldErrors.ingredientCategories
+  ) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  return {
+    ok: true as const,
+    parsed: {
+      defaultServings: servingsResult.ok ? servingsResult.value : null,
+      description: normalizedValues.description || null,
+      ingredients: normalizedValues.ingredients.map((ingredient) => ({
+        amount: ingredient.amount || null,
+        categoryId: ingredient.categoryId,
+        displayName: ingredient.displayName,
+        preferredStoreId: ingredient.preferredStoreId || null,
+        unit: ingredient.unit || null,
+      })),
+      prepMinutes: prepResult.ok ? prepResult.value : null,
+      tags: parseTags(normalizedValues.tags),
+      title: normalizedValues.title,
+    },
+    values: normalizedValues,
+  };
+}

--- a/app/lib/recipe.server.ts
+++ b/app/lib/recipe.server.ts
@@ -1,0 +1,191 @@
+import { Prisma, RecipeScope } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { listIngredientCategories } from "./store.server";
+
+export const recipeIngredientSelect =
+  Prisma.validator<Prisma.RecipeIngredientSelect>()({
+    amount: true,
+    category: {
+      select: {
+        displayName: true,
+        id: true,
+      },
+    },
+    categoryId: true,
+    displayName: true,
+    id: true,
+    ingredientId: true,
+    preferredStore: {
+      select: {
+        id: true,
+        name: true,
+      },
+    },
+    preferredStoreId: true,
+    sortOrder: true,
+    unit: true,
+  });
+
+export const managedRecipeSelect = Prisma.validator<Prisma.RecipeSelect>()({
+  createdAt: true,
+  defaultServings: true,
+  description: true,
+  familyId: true,
+  id: true,
+  ingredients: {
+    orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+    select: recipeIngredientSelect,
+  },
+  prepMinutes: true,
+  scope: true,
+  tags: true,
+  title: true,
+  updatedAt: true,
+});
+
+export const recipeListSummarySelect = Prisma.validator<Prisma.RecipeSelect>()({
+  defaultServings: true,
+  description: true,
+  familyId: true,
+  id: true,
+  prepMinutes: true,
+  scope: true,
+  tags: true,
+  title: true,
+  updatedAt: true,
+  _count: {
+    select: {
+      ingredients: true,
+      mealPlanEntries: true,
+    },
+  },
+});
+
+export type ManagedRecipe = Prisma.RecipeGetPayload<{
+  select: typeof managedRecipeSelect;
+}>;
+
+export type RecipeListSummary = Prisma.RecipeGetPayload<{
+  select: typeof recipeListSummarySelect;
+}>;
+
+export async function listFamilyStoresForRecipes(familyId: string) {
+  return db.store.findMany({
+    orderBy: [{ name: "asc" }],
+    select: {
+      id: true,
+      name: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+}
+
+export async function getRecipeManagementData({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+  const [categories, familyStores, familyRecipes, globalRecipes] = await Promise.all([
+    listIngredientCategories(),
+    listFamilyStoresForRecipes(familyId),
+    db.recipe.findMany({
+      orderBy: [{ title: "asc" }],
+      select: recipeListSummarySelect,
+      where: {
+        familyId,
+        scope: RecipeScope.FAMILY,
+      },
+    }),
+    db.recipe.findMany({
+      orderBy: [{ title: "asc" }],
+      select: recipeListSummarySelect,
+      where: {
+        scope: RecipeScope.GLOBAL,
+      },
+    }),
+  ]);
+
+  return {
+    categories,
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    familyRecipes,
+    familyStores,
+    globalRecipes,
+    userRole: membership.role,
+  };
+}
+
+export async function getFamilyRecipeDetail({
+  familyId,
+  recipeId,
+  userId,
+}: {
+  familyId: string;
+  recipeId: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const recipe = await db.recipe.findFirst({
+    select: {
+      ...managedRecipeSelect,
+      _count: {
+        select: {
+          mealPlanEntries: true,
+        },
+      },
+    },
+    where: {
+      familyId,
+      id: recipeId,
+      scope: RecipeScope.FAMILY,
+    },
+  });
+
+  if (!recipe) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const [categories, familyStores] = await Promise.all([
+    listIngredientCategories(),
+    listFamilyStoresForRecipes(familyId),
+  ]);
+
+  return {
+    categories,
+    familyStores,
+    mealPlanEntryCount: recipe._count.mealPlanEntries,
+    recipe: {
+      createdAt: recipe.createdAt,
+      defaultServings: recipe.defaultServings,
+      description: recipe.description,
+      familyId: recipe.familyId,
+      id: recipe.id,
+      ingredients: recipe.ingredients,
+      prepMinutes: recipe.prepMinutes,
+      scope: recipe.scope,
+      tags: recipe.tags,
+      title: recipe.title,
+      updatedAt: recipe.updatedAt,
+    },
+    status: "FOUND" as const,
+  };
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -14,6 +14,8 @@ export default [
   route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
   route("families/:familyId/meal-plans/:mealPlanId/store-mode", "routes/family-meal-plan-store-mode.tsx"),
   route("families/:familyId/stores", "routes/family-stores.tsx"),
+  route("families/:familyId/recipes", "routes/family-recipes.tsx"),
+  route("families/:familyId/recipes/:recipeId", "routes/family-recipe.tsx"),
   route("login", "routes/login.tsx"),
   route("logout", "routes/logout.tsx"),
   route("prototype", "routes/prototype.tsx"),

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -574,9 +574,15 @@ export default function FamilyMealPlanRoute({
                 Oppskriftsbank
               </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Seedede oppskrifter du kan bruke i den forste produksjonsflyten
-                for middagsplanlegging.
+                Standard- og familieoppskrifter du kan velge til middagene i
+                planen.
               </p>
+              <Link
+                className="mt-2 inline-flex w-fit items-center justify-center rounded-2xl bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-800 ring-1 ring-emerald-200 transition hover:bg-emerald-100"
+                to={`/families/${loaderData.family.id}/recipes`}
+              >
+                Administrer oppskrifter
+              </Link>
             </div>
 
             <div className="mt-6 grid gap-3">

--- a/app/routes/family-recipe.test.ts
+++ b/app/routes/family-recipe.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/recipe.server", () => {
+  return {
+    getFamilyRecipeDetail: vi.fn(),
+    getRecipeManagementData: vi.fn(),
+  };
+});
+
+vi.mock("../lib/recipe-write.server", () => {
+  return {
+    deleteFamilyRecipe: vi.fn(),
+    parseFamilyRecipeValues: vi.fn(),
+    updateFamilyRecipe: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getFamilyRecipeDetail, getRecipeManagementData } from "../lib/recipe.server";
+import {
+  deleteFamilyRecipe,
+  parseFamilyRecipeValues,
+  updateFamilyRecipe,
+} from "../lib/recipe-write.server";
+import { action } from "./family-recipe";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/recipes/recipe-1",
+  formData?: FormData,
+) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family recipe route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getRecipeManagementData).mockResolvedValue({
+      categories: [],
+      family: { id: "family-1", name: "Solberg" },
+      familyRecipes: [],
+      familyStores: [],
+      globalRecipes: [],
+      userRole: "ADMIN",
+    });
+    vi.mocked(getFamilyRecipeDetail).mockResolvedValue({
+      categories: [],
+      familyStores: [],
+      mealPlanEntryCount: 1,
+      recipe: {
+        createdAt: new Date(),
+        defaultServings: 4,
+        description: "Test",
+        familyId: "family-1",
+        id: "recipe-1",
+        ingredients: [],
+        prepMinutes: 20,
+        scope: "FAMILY",
+        tags: [],
+        title: "Test",
+        updatedAt: new Date(),
+      },
+      status: "FOUND",
+    });
+  });
+
+  it("returns a visible error when delete is blocked by meal plan usage", async () => {
+    vi.mocked(deleteFamilyRecipe).mockResolvedValue({
+      entryCount: 2,
+      status: "IN_USE",
+      title: "Test",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "delete-recipe");
+    formData.set("recipeId", "recipe-1");
+
+    const result = await action({
+      params: { familyId: "family-1", recipeId: "recipe-1" },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(result).toEqual({
+      formError:
+        "«Test» brukes i 2 ukeplaner og kan ikke slettes for du fjerner den fra planene.",
+      intent: "delete-recipe",
+    });
+  });
+
+  it("redirects to the recipe list after delete", async () => {
+    vi.mocked(deleteFamilyRecipe).mockResolvedValue({
+      status: "DELETED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "delete-recipe");
+    formData.set("recipeId", "recipe-1");
+
+    const response = await action({
+      params: { familyId: "family-1", recipeId: "recipe-1" },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/recipes?notice=recipe-deleted",
+    );
+  });
+
+  it("returns validation errors from update", async () => {
+    vi.mocked(parseFamilyRecipeValues).mockReturnValue({
+      defaultServings: "",
+      description: "",
+      ingredients: [],
+      prepMinutes: "",
+      tags: "",
+      title: "",
+    });
+    vi.mocked(updateFamilyRecipe).mockResolvedValue({
+      fieldErrors: {
+        title: "Skriv inn en tittel.",
+      },
+      status: "VALIDATION_ERROR",
+      values: {
+        defaultServings: "",
+        description: "",
+        ingredients: [],
+        prepMinutes: "",
+        tags: "",
+        title: "",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-recipe");
+    formData.set("recipeId", "recipe-1");
+
+    const result = await action({
+      params: { familyId: "family-1", recipeId: "recipe-1" },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(result).toEqual({
+      intent: "update-recipe",
+      updateFieldErrors: {
+        title: "Skriv inn en tittel.",
+      },
+      updateValues: {
+        defaultServings: "",
+        description: "",
+        ingredients: [],
+        prepMinutes: "",
+        tags: "",
+        title: "",
+      },
+    });
+  });
+});

--- a/app/routes/family-recipe.tsx
+++ b/app/routes/family-recipe.tsx
@@ -1,0 +1,365 @@
+import { Link, isRouteErrorResponse } from "react-router";
+
+import { FamilyRecipeEditorCard } from "../components/family-recipe-editor-card";
+import { requireUser } from "../lib/auth.server";
+import { getFamilyRecipeDetail, getRecipeManagementData } from "../lib/recipe.server";
+import {
+  deleteFamilyRecipe,
+  parseFamilyRecipeValues,
+  updateFamilyRecipe,
+  type FamilyRecipeFieldErrors,
+  type FamilyRecipeValues,
+} from "../lib/recipe-write.server";
+
+type RecipeDetailNotice = "recipe-created" | "recipe-deleted" | "recipe-updated";
+
+type RecipeDetailIntent = "delete-recipe" | "update-recipe";
+
+interface RecipeDetailActionData {
+  formError?: string;
+  intent?: RecipeDetailIntent;
+  updateFieldErrors?: FamilyRecipeFieldErrors;
+  updateValues?: FamilyRecipeValues;
+}
+
+interface FamilyRecipeRouteProps {
+  actionData?: RecipeDetailActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta = () => {
+  return [
+    { title: "Oppskrift | Mealplanner" },
+    {
+      name: "description",
+      content: "Rediger en familieoppskrift i Mealplanner.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    recipeId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const recipeId = requireRecipeId(params.recipeId);
+  const [managementData, detail] = await Promise.all([
+    getRecipeManagementData({
+      familyId,
+      userId: user.id,
+    }),
+    getFamilyRecipeDetail({
+      familyId,
+      recipeId,
+      userId: user.id,
+    }),
+  ]);
+
+  if (detail.status === "NOT_FOUND") {
+    throw new Response("Fant ikke oppskriften.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return {
+    categories: detail.categories,
+    family: managementData.family,
+    familyStores: detail.familyStores,
+    mealPlanEntryCount: detail.mealPlanEntryCount,
+    notice: getRecipeDetailNotice(request),
+    recipe: detail.recipe,
+    userRole: managementData.userRole,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+    recipeId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const recipeId = requireRecipeId(params.recipeId);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "update-recipe") {
+    const submittedRecipeId = String(formData.get("recipeId") ?? "").trim();
+    const values = parseFamilyRecipeValues(formData);
+
+    if (!submittedRecipeId || submittedRecipeId !== recipeId) {
+      return {
+        formError: "Fant ikke oppskriften som skulle oppdateres.",
+        intent,
+      } satisfies RecipeDetailActionData;
+    }
+
+    const result = await updateFamilyRecipe({
+      familyId,
+      recipeId,
+      userId: user.id,
+      values,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke oppskriften som skulle oppdateres.",
+        intent,
+      } satisfies RecipeDetailActionData;
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        intent,
+        updateFieldErrors: result.fieldErrors,
+        updateValues: result.values,
+      } satisfies RecipeDetailActionData;
+    }
+
+    return buildRecipeDetailRedirect({
+      familyId,
+      notice: "recipe-updated",
+      recipeId,
+      request,
+    });
+  }
+
+  if (intent === "delete-recipe") {
+    const submittedRecipeId = String(formData.get("recipeId") ?? "").trim();
+
+    if (!submittedRecipeId || submittedRecipeId !== recipeId) {
+      return {
+        formError: "Fant ikke oppskriften som skulle slettes.",
+        intent,
+      } satisfies RecipeDetailActionData;
+    }
+
+    const result = await deleteFamilyRecipe({
+      familyId,
+      recipeId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke oppskriften som skulle slettes.",
+        intent,
+      } satisfies RecipeDetailActionData;
+    }
+
+    if (result.status === "IN_USE") {
+      return {
+        formError: `«${result.title}» brukes i ${result.entryCount} ${
+          result.entryCount === 1 ? "ukeplan" : "ukeplaner"
+        } og kan ikke slettes for du fjerner den fra planene.`,
+        intent,
+      } satisfies RecipeDetailActionData;
+    }
+
+    const url = new URL(`/families/${familyId}/recipes`, request.url);
+    url.searchParams.set("notice", "recipe-deleted");
+
+    return Response.redirect(url, 302);
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies RecipeDetailActionData;
+}
+
+export default function FamilyRecipeRoute({
+  actionData,
+  loaderData,
+}: FamilyRecipeRouteProps) {
+  const noticeContent = loaderData.notice
+    ? getRecipeDetailNoticeContent(loaderData.notice)
+    : null;
+  const canManageRecipes = loaderData.userRole === "ADMIN";
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Familieoppskrift
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.recipe.title}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Rediger oppskriften for {loaderData.family.name}. Endringer
+                vises i ukeplaner og handlelister som bruker denne oppskriften.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/recipes`}
+              >
+                Alle oppskrifter
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Ukeplaner
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">Handlingen feilet</h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        <FamilyRecipeEditorCard
+          canManageRecipes={canManageRecipes}
+          categories={loaderData.categories}
+          familyStores={loaderData.familyStores}
+          mealPlanEntryCount={loaderData.mealPlanEntryCount}
+          recipe={loaderData.recipe}
+          updateFieldErrors={
+            actionData?.intent === "update-recipe"
+              ? actionData.updateFieldErrors
+              : undefined
+          }
+          updateValues={
+            actionData?.intent === "update-recipe" ? actionData.updateValues : undefined
+          }
+        />
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi kunne ikke laste oppskriften akkurat na.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke oppskriften" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-16 text-slate-900">
+      <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+          to="/app"
+        >
+          Til appen
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function getRecipeDetailNotice(request: Request): RecipeDetailNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (
+    notice === "recipe-created" ||
+    notice === "recipe-deleted" ||
+    notice === "recipe-updated"
+  ) {
+    return notice;
+  }
+
+  return null;
+}
+
+function getRecipeDetailNoticeContent(notice: RecipeDetailNotice) {
+  switch (notice) {
+    case "recipe-created":
+      return {
+        description:
+          "Oppskriften ble opprettet. Legg til flere ingredienser og detaljer her.",
+        title: "Oppskriften er opprettet",
+      };
+    case "recipe-updated":
+      return {
+        description: "Oppskriften og ingrediensene ble lagret.",
+        title: "Endringene er lagret",
+      };
+    case "recipe-deleted":
+      return {
+        description: "Oppskriften ble fjernet fra familien.",
+        title: "Oppskriften er slettet",
+      };
+  }
+}
+
+function buildRecipeDetailRedirect({
+  familyId,
+  notice,
+  recipeId,
+  request,
+}: {
+  familyId: string;
+  notice: RecipeDetailNotice;
+  recipeId: string;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/recipes/${recipeId}`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}
+
+function requireRecipeId(recipeId: string | undefined) {
+  if (!recipeId) {
+    throw new Response("Fant ikke oppskriften.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return recipeId;
+}

--- a/app/routes/family-recipes.test.ts
+++ b/app/routes/family-recipes.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/recipe.server", () => {
+  return {
+    getRecipeManagementData: vi.fn(),
+  };
+});
+
+vi.mock("../lib/recipe-write.server", () => {
+  return {
+    createFamilyRecipe: vi.fn(),
+    parseFamilyRecipeValues: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getRecipeManagementData } from "../lib/recipe.server";
+import { createFamilyRecipe, parseFamilyRecipeValues } from "../lib/recipe-write.server";
+import { action, loader } from "./family-recipes";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(url = "http://localhost/families/family-1/recipes", formData?: FormData) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family recipes route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads family and global recipe lists", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getRecipeManagementData).mockResolvedValue({
+      categories: [{ displayName: "Meieri", id: "category-dairy" }],
+      family: { id: "family-1", name: "Solberg" },
+      familyRecipes: [
+        {
+          _count: { ingredients: 2, mealPlanEntries: 0 },
+          defaultServings: 4,
+          description: "Familie",
+          familyId: "family-1",
+          id: "recipe-family",
+          prepMinutes: 20,
+          scope: "FAMILY",
+          tags: ["middag"],
+          title: "Familiepai",
+          updatedAt: new Date(),
+        },
+      ],
+      familyStores: [],
+      globalRecipes: [
+        {
+          _count: { ingredients: 3, mealPlanEntries: 1 },
+          defaultServings: 4,
+          description: "Global",
+          familyId: null,
+          id: "recipe-global",
+          prepMinutes: 30,
+          scope: "GLOBAL",
+          tags: [],
+          title: "Tomatsuppe",
+          updatedAt: new Date(),
+        },
+      ],
+      userRole: "ADMIN",
+    });
+
+    const result = await loader({
+      params: { familyId: "family-1" },
+      request: buildRequest(),
+    });
+
+    expect(getRecipeManagementData).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result.familyRecipes).toHaveLength(1);
+    expect(result.globalRecipes).toHaveLength(1);
+  });
+
+  it("redirects to the recipe detail page after create", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseFamilyRecipeValues).mockReturnValue({
+      defaultServings: "",
+      description: "",
+      ingredients: [
+        {
+          amount: "",
+          categoryId: "category-dairy",
+          displayName: "Melk",
+          preferredStoreId: "",
+          unit: "",
+        },
+      ],
+      prepMinutes: "",
+      tags: "",
+      title: "Familiepai",
+    });
+    vi.mocked(createFamilyRecipe).mockResolvedValue({
+      recipe: {
+        id: "recipe-new",
+        title: "Familiepai",
+      },
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-recipe");
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: buildRequest("http://localhost/families/family-1/recipes", formData),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/recipes/recipe-new?notice=recipe-created",
+    );
+  });
+});

--- a/app/routes/family-recipes.tsx
+++ b/app/routes/family-recipes.tsx
@@ -1,0 +1,522 @@
+import { Form, Link, isRouteErrorResponse, useNavigation } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { getRecipeManagementData } from "../lib/recipe.server";
+import {
+  createFamilyRecipe,
+  parseFamilyRecipeValues,
+  type FamilyRecipeFieldErrors,
+  type FamilyRecipeValues,
+} from "../lib/recipe-write.server";
+
+type RecipesNotice = "recipe-created" | "recipe-deleted";
+
+type RecipesIntent = "create-recipe";
+
+interface RecipesActionData {
+  createFieldErrors?: FamilyRecipeFieldErrors;
+  createValues?: FamilyRecipeValues;
+  formError?: string;
+  intent?: RecipesIntent;
+}
+
+interface FamilyRecipesRouteProps {
+  actionData?: RecipesActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta = () => {
+  return [
+    { title: "Oppskrifter | Mealplanner" },
+    {
+      name: "description",
+      content: "Administrer familieoppskrifter og se standardoppskrifter.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const result = await getRecipeManagementData({
+    familyId,
+    userId: user.id,
+  });
+
+  return {
+    categories: result.categories,
+    family: result.family,
+    familyRecipes: result.familyRecipes,
+    globalRecipes: result.globalRecipes,
+    notice: getRecipesNotice(request),
+    userRole: result.userRole,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "create-recipe") {
+    const values = parseFamilyRecipeValues(formData);
+    const result = await createFamilyRecipe({
+      familyId,
+      userId: user.id,
+      values,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        createFieldErrors: result.fieldErrors,
+        createValues: result.values,
+        intent,
+      } satisfies RecipesActionData;
+    }
+
+    const url = new URL(
+      `/families/${familyId}/recipes/${result.recipe.id}`,
+      request.url,
+    );
+    url.searchParams.set("notice", "recipe-created");
+
+    return Response.redirect(url, 302);
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies RecipesActionData;
+}
+
+export default function FamilyRecipesRoute({
+  actionData,
+  loaderData,
+}: FamilyRecipesRouteProps) {
+  const navigation = useNavigation();
+  const noticeContent = loaderData.notice
+    ? getRecipesNoticeContent(loaderData.notice)
+    : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const canManageRecipes = loaderData.userRole === "ADMIN";
+  const createValues =
+    actionData?.intent === "create-recipe" && actionData.createValues
+      ? actionData.createValues
+      : {
+          defaultServings: "",
+          description: "",
+          ingredients: [
+            {
+              amount: "",
+              categoryId: loaderData.categories[0]?.id ?? "",
+              displayName: "",
+              preferredStoreId: "",
+              unit: "",
+            },
+          ],
+          prepMinutes: "",
+          tags: "",
+          title: "",
+        };
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Oppskrifter
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Familieoppskrifter kan redigeres her. Standardoppskrifter er
+                felles for alle familier og kan bare leses i appen.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Åpne ukeplaner
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}`}
+              >
+                Tilbake til familie
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere oppskriftene
+            </h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        {canManageRecipes ? (
+          <section className="rounded-[28px] border-2 border-emerald-200 bg-white p-6 shadow-sm ring-1 ring-emerald-100">
+            <div className="flex flex-col gap-2">
+              <span className="inline-flex w-fit rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
+                Familie — ny oppskrift
+              </span>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Opprett familieoppskrift
+              </h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Legg inn oppskriftstittel og minst én ingrediens. Flere
+                ingredienser og detaljer kan legges til etter opprettelsen.
+              </p>
+            </div>
+
+            <Form className="mt-6 space-y-4" method="post">
+              <input name="intent" type="hidden" value="create-recipe" />
+              <input name="ingredientIndex" type="hidden" value="0" />
+              <label className="block text-sm font-medium text-slate-700">
+                Oppskriftstittel
+                <input
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+                  defaultValue={createValues.title}
+                  name="title"
+                  placeholder="For eksempel Kyllingwok"
+                  type="text"
+                />
+              </label>
+              {actionData?.createFieldErrors?.title ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.createFieldErrors.title}
+                </p>
+              ) : null}
+              <fieldset className="space-y-4 rounded-[24px] border border-slate-200 bg-slate-50 p-4">
+                <legend className="px-1 text-sm font-semibold text-slate-950">
+                  Første ingrediens
+                </legend>
+                <p className="text-sm leading-6 text-slate-600">
+                  Handlekategori gjelder denne ingrediensraden — ikke hele
+                  oppskriften. Den brukes når handlelisten grupperes (for
+                  eksempel «Kjøtt og fisk»).
+                </p>
+                <label className="block text-sm font-medium text-slate-700">
+                  Ingrediensnavn
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+                    defaultValue={createValues.ingredients[0]?.displayName ?? ""}
+                    name="ingredientDisplayName:0"
+                    placeholder="For eksempel Kyllingfilet"
+                    type="text"
+                  />
+                </label>
+                {actionData?.createFieldErrors?.ingredientDisplayNames?.[0] ? (
+                  <p className="text-sm text-rose-600">
+                    {actionData.createFieldErrors.ingredientDisplayNames[0]}
+                  </p>
+                ) : null}
+                <label className="block text-sm font-medium text-slate-700">
+                  Handlekategori for ingrediensen
+                  <select
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+                    defaultValue={createValues.ingredients[0]?.categoryId ?? ""}
+                    name="ingredientCategoryId:0"
+                  >
+                    <option value="">Velg handlekategori</option>
+                    {loaderData.categories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {actionData?.createFieldErrors?.ingredientCategories?.[0] ? (
+                  <p className="text-sm text-rose-600">
+                    {actionData.createFieldErrors.ingredientCategories[0]}
+                  </p>
+                ) : null}
+              </fieldset>
+              {actionData?.createFieldErrors?.ingredients ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.createFieldErrors.ingredients}
+                </p>
+              ) : null}
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={
+                  navigation.state === "submitting" &&
+                  pendingIntent === "create-recipe"
+                }
+                type="submit"
+              >
+                {navigation.state === "submitting" &&
+                pendingIntent === "create-recipe"
+                  ? "Oppretter..."
+                  : "Opprett oppskrift"}
+              </button>
+            </Form>
+          </section>
+        ) : null}
+
+        <section className="rounded-[28px] border-2 border-emerald-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-2">
+            <span className="inline-flex w-fit rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
+              Familie
+            </span>
+            <h2 className="text-xl font-semibold text-slate-950">
+              Familieoppskrifter
+            </h2>
+            <p className="text-sm leading-6 text-slate-600">
+              Oppskrifter som tilhorer {loaderData.family.name}.{" "}
+              {canManageRecipes
+                ? "Som administrator kan du opprette, redigere og slette disse."
+                : "Du kan apne og lese oppskriftene, men ikke endre dem."}
+            </p>
+          </div>
+
+          {loaderData.familyRecipes.length === 0 ? (
+            <p className="mt-6 rounded-[24px] border border-dashed border-emerald-200 bg-emerald-50/50 px-5 py-8 text-center text-sm leading-6 text-slate-600">
+              {canManageRecipes
+                ? "Ingen familieoppskrifter enna. Opprett den forste oppskriften over."
+                : "Familien har ingen egne oppskrifter enna."}
+            </p>
+          ) : (
+            <div className="mt-6 grid gap-3">
+              {loaderData.familyRecipes.map((recipe) => (
+                <RecipeListCard
+                  key={recipe.id}
+                  recipe={recipe}
+                  scopeLabel="Familie"
+                  scopeTone="family"
+                  to={`/families/${loaderData.family.id}/recipes/${recipe.id}`}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-[28px] border border-slate-200 bg-slate-50 p-6 shadow-sm">
+          <div className="flex flex-col gap-2">
+            <span className="inline-flex w-fit rounded-full bg-slate-200 px-3 py-1 text-xs font-medium text-slate-700">
+              Standard (global)
+            </span>
+            <h2 className="text-xl font-semibold text-slate-950">
+              Standardoppskrifter
+            </h2>
+            <p className="text-sm leading-6 text-slate-600">
+              Felles oppskrifter fra seed-data. De kan brukes i ukeplaner, men
+              kan ikke redigeres eller slettes her.
+            </p>
+          </div>
+
+          <div className="mt-6 grid gap-3">
+            {loaderData.globalRecipes.map((recipe) => (
+              <RecipeListCard
+                key={recipe.id}
+                readOnly
+                recipe={recipe}
+                scopeLabel="Standard"
+                scopeTone="global"
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function RecipeListCard({
+  readOnly = false,
+  recipe,
+  scopeLabel,
+  scopeTone,
+  to,
+}: {
+  readOnly?: boolean;
+  recipe: {
+    _count: {
+      ingredients: number;
+      mealPlanEntries: number;
+    };
+    defaultServings: number | null;
+    description: string | null;
+    id: string;
+    prepMinutes: number | null;
+    tags: string[];
+    title: string;
+  };
+  scopeLabel: string;
+  scopeTone: "family" | "global";
+  to?: string;
+}) {
+  const scopeClasses =
+    scopeTone === "family"
+      ? "bg-emerald-100 text-emerald-800"
+      : "bg-slate-200 text-slate-700";
+  const content = (
+    <article
+      className={
+        readOnly
+          ? "rounded-[24px] border border-slate-200 bg-white p-5"
+          : "rounded-[24px] border border-emerald-200 bg-emerald-50/40 p-5 transition hover:border-emerald-300 hover:bg-emerald-50"
+      }
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`rounded-full px-3 py-1 text-xs font-medium ${scopeClasses}`}
+            >
+              {scopeLabel}
+            </span>
+            {readOnly ? (
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                Kun lesing
+              </span>
+            ) : null}
+          </div>
+          <h3 className="mt-3 text-base font-semibold text-slate-950">
+            {recipe.title}
+          </h3>
+          {recipe.description ? (
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              {recipe.description}
+            </p>
+          ) : null}
+        </div>
+        {!readOnly && to ? (
+          <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200">
+            Apne
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-slate-700">
+        <span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-200">
+          {recipe._count.ingredients} ingredienser
+        </span>
+        <span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-200">
+          {recipe.prepMinutes ?? "?"} min
+        </span>
+        <span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-200">
+          {recipe.defaultServings ?? "?"} personer
+        </span>
+        {recipe.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-200"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </article>
+  );
+
+  if (to) {
+    return (
+      <Link className="block" to={to}>
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi kunne ikke laste oppskriftene akkurat na.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke siden" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-16 text-slate-900">
+      <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+          to="/app"
+        >
+          Til appen
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function getRecipesNotice(request: Request): RecipesNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (notice === "recipe-created" || notice === "recipe-deleted") {
+    return notice;
+  }
+
+  return null;
+}
+
+function getRecipesNoticeContent(notice: RecipesNotice) {
+  switch (notice) {
+    case "recipe-created":
+      return {
+        description:
+          "Oppskriften ble opprettet. Du kan legge til flere ingredienser og detaljer nedenfor.",
+        title: "Oppskriften er opprettet",
+      };
+    case "recipe-deleted":
+      return {
+        description: "Familieoppskriften ble fjernet.",
+        title: "Oppskriften er slettet",
+      };
+  }
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -203,6 +203,12 @@ export default function FamilyRoute({
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/recipes`}
+              >
+                Administrer oppskrifter
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to="/app"
               >
                 Tilbake til oversikten


### PR DESCRIPTION
## Summary
- Add family-scoped recipe CRUD (create, list, update, delete) with nested ingredient rows and admin-only writes.
- Show family recipes and read-only global recipes on one page, with a detail editor for family recipes.
- Block delete when a recipe is used in meal plans; wire navigation from family dashboard and meal-plan Oppskriftsbank.
- Clarify UI copy so handlekategori is per ingredient (shopping list grouping), not per recipe.

Closes #33

## Test plan
- [ ] Family admin creates a recipe with at least one ingredient and opens the detail page
- [ ] New recipe appears in the meal-plan dinner picker without seed changes
- [ ] Editing ingredients updates shopping list projection for plans using the recipe
- [ ] Delete is blocked while the recipe is assigned to a meal plan entry
- [ ] Delete succeeds after removing the recipe from all meal plan entries
- [ ] Family members can browse recipes; non-admins cannot create/edit/delete
- [x] `npm run test:run -- app/lib/recipe-write.server.test.ts app/routes/family-recipes.test.ts app/routes/family-recipe.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`