### PR TITLE
Support stock ingredients (basisvarer) for shopping lists

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,33 +2,34 @@
 
 ## Current Objective
 
-Issue `#33` family recipe CRUD is implemented on branch `issue/33-crud-recipes`: admin-managed family recipes, read-only global list, meal-plan integration, and clearer ingredient handlekategori UI.
+Issue `#36` stock ingredients (basisvarer) is implemented: family registry, shopping projection skip, weekly opt-in via overrides, and UI on Handleliste / Butikkmodus / family settings.
 
 ## Completed
 
-- Added `app/lib/recipe.server.ts` and `app/lib/recipe-write.server.ts` for family recipe list/detail and admin-only create/update/delete.
-- Blocked delete when a recipe is referenced by `MealPlanEntry` (`IN_USE` with entry count).
-- Added `family-recipes` list page (family vs global sections) and `family-recipe` detail editor with `FamilyRecipeEditorCard`.
-- Wired routes, family dashboard link, and meal-plan Oppskriftsbank CTA.
-- Clarified UI copy: handlekategori is per ingredient, not per recipe.
+- Added `FamilyStockIngredient` model and `ShoppingItemOverride.includeDespiteStock` (migration `20260516173423_add_family_stock_ingredients`).
+- Added `app/lib/stock.server.ts`, `app/lib/stock-write.server.ts`, and `app/lib/ingredient-normalize.ts`.
+- Updated `app/lib/shopping.server.ts` to skip stock items in generated projection and expose `getStockIngredientsForMealPlan`.
+- Added `optInStockShoppingItems` in `app/lib/shopping-write.server.ts`.
+- Added route `families/:familyId/stock-ingredients` and family dashboard link.
+- Handleliste shows expandable basisvarer notice with per-item and bulk opt-in; Butikkmodus links to Handleliste when stock items are in play.
 
 ## Files To Read First
 
-- `app/lib/recipe-write.server.ts` - Validation, ingredient replace, delete guard.
-- `app/routes/family-recipes.tsx` - List/create UI with family vs global sections.
-- `app/routes/family-recipe.tsx` - Detail update/delete actions.
-- `app/components/family-recipe-editor-card.tsx` - Ingredient editor UI.
+- `app/lib/shopping.server.ts` — projection skip + stock summary.
+- `app/lib/shopping-write.server.ts` — `optInStockShoppingItems`.
+- `app/routes/family-stock-ingredients.tsx` — admin basisvarer management.
+- `app/routes/family-meal-plan-shopping.tsx` — opt-in UI on Handleliste.
 
 ## Validation
 
-- `npm run test:run -- app/lib/recipe-write.server.test.ts app/routes/family-recipes.test.ts app/routes/family-recipe.test.ts`
+- `npm run test:run -- app/lib/stock.server.test.ts app/lib/stock-write.server.test.ts app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-stock-ingredients.test.ts app/routes/family-meal-plan-shopping.test.ts app/routes/family-meal-plan-store-mode.test.ts`
 - `./node_modules/.bin/tsc --noEmit`
 
 ## Open Items
 
-- Manual smoke test: create recipe, use in meal plan, verify shopping list grouping, try delete while in use.
-- No migration required (uses existing schema).
+- Manual smoke: configure basisvarer, plan meals with staples, confirm Handleliste exclusion, opt in one item, verify store mode and persistence after reload.
+- Display-name matching requires exact normalized names (documented in UI copy).
 
 ## Next Step
 
-Merge PR and verify family admins can manage recipes end-to-end in staging/production.
+Manual QA in browser, then open PR for issue #36 if satisfied.

--- a/app/lib/ingredient-normalize.ts
+++ b/app/lib/ingredient-normalize.ts
@@ -1,0 +1,3 @@
+export function normalizeIngredientCanonicalName(displayName: string) {
+  return displayName.trim().toLowerCase();
+}

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -1,7 +1,14 @@
 import { ShoppingItemSource } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { dbMock, requireFamilyMembershipMock, transactionMock } = vi.hoisted(() => {
+const {
+  dbMock,
+  getFamilyStockMatchSetMock,
+  getStockIngredientsForMealPlanMock,
+  loadShoppingMealPlanMock,
+  requireFamilyMembershipMock,
+  transactionMock,
+} = vi.hoisted(() => {
   const transactionMock = {
     manualShoppingItem: {
       delete: vi.fn(),
@@ -42,6 +49,9 @@ const { dbMock, requireFamilyMembershipMock, transactionMock } = vi.hoisted(() =
         findFirst: vi.fn(),
       },
     },
+    getFamilyStockMatchSetMock: vi.fn(),
+    getStockIngredientsForMealPlanMock: vi.fn(),
+    loadShoppingMealPlanMock: vi.fn(),
     requireFamilyMembershipMock: vi.fn(),
     transactionMock,
   };
@@ -66,9 +76,23 @@ vi.mock("./write-observability.server", () => {
   };
 });
 
+vi.mock("./shopping.server", () => {
+  return {
+    getStockIngredientsForMealPlan: getStockIngredientsForMealPlanMock,
+    loadShoppingMealPlan: loadShoppingMealPlanMock,
+  };
+});
+
+vi.mock("./stock.server", () => {
+  return {
+    getFamilyStockMatchSet: getFamilyStockMatchSetMock,
+  };
+});
+
 import {
   createManualShoppingItem,
   deleteManualShoppingItem,
+  optInStockShoppingItems,
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
   updateGeneratedShoppingItemOverride,
@@ -251,6 +275,7 @@ describe("shopping-write.server", () => {
       checked: true,
       createdAt: new Date("2026-05-15T00:00:00.000Z"),
       id: "override-1",
+      includeDespiteStock: false,
       mealPlanId: "meal-plan-1",
       note: null,
       postponedUntilDate: null,
@@ -279,6 +304,7 @@ describe("shopping-write.server", () => {
     expect(dbMock.shoppingItemOverride.updateMany).toHaveBeenCalledWith({
       data: {
         checked: true,
+        includeDespiteStock: false,
         note: "Husk tilbud",
         postponedUntilDate: new Date("2026-05-17T00:00:00.000Z"),
         preferredStoreId: "store-2",
@@ -289,6 +315,48 @@ describe("shopping-write.server", () => {
         updatedAt: new Date("2026-05-15T00:00:00.000Z"),
       },
     });
+  });
+
+  it("opts stock ingredients into the generated shopping list", async () => {
+    loadShoppingMealPlanMock.mockResolvedValue({
+      id: "meal-plan-1",
+      shoppingOverrides: [],
+    });
+    getFamilyStockMatchSetMock.mockResolvedValue({
+      displayNameNormalized: new Set(),
+      ingredientIds: new Set(["ingredient-salt"]),
+    });
+    getStockIngredientsForMealPlanMock.mockReturnValue([
+      {
+        isOptedIn: false,
+        name: "Salt",
+        sourceKey: "entry-1:ingredient-1",
+      },
+    ]);
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue(null);
+    dbMock.shoppingItemOverride.upsert.mockResolvedValue({
+      id: "override-stock-1",
+    });
+
+    const result = await optInStockShoppingItems({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKeys: ["entry-1:ingredient-1"],
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("UPDATED");
+    expect(dbMock.shoppingItemOverride.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          includeDespiteStock: true,
+          sourceKey: "entry-1:ingredient-1",
+        }),
+        update: expect.objectContaining({
+          includeDespiteStock: true,
+        }),
+      }),
+    );
   });
 
   it("updates the meal plan active shopping date within range", async () => {

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -7,6 +7,11 @@ import {
 } from "./collaboration.server";
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
+import {
+  getStockIngredientsForMealPlan,
+  loadShoppingMealPlan,
+} from "./shopping.server";
+import { getFamilyStockMatchSet } from "./stock.server";
 import { logCollaborationFailure, logCollaborationWrite } from "./write-observability.server";
 
 export interface ManualShoppingItemValues {
@@ -421,6 +426,7 @@ export async function toggleShoppingItemChecked({
     select: {
       checked: true,
       id: true,
+      includeDespiteStock: true,
       note: true,
       postponedUntilDate: true,
       preferredStoreId: true,
@@ -578,6 +584,147 @@ export async function toggleShoppingItemChecked({
   }
 }
 
+export async function optInStockShoppingItems({
+  familyId,
+  mealPlanId,
+  sourceKeys,
+  userId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  sourceKeys: string[];
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const uniqueSourceKeys = [...new Set(sourceKeys.map((key) => key.trim()).filter(Boolean))];
+
+  if (uniqueSourceKeys.length === 0) {
+    return {
+      status: "VALIDATION_ERROR" as const,
+      formError: "Velg minst en basisvare som skal legges til i handlelisten.",
+    };
+  }
+
+  const mealPlan = await loadShoppingMealPlan({
+    familyId,
+    mealPlanId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const stockMatchSet = await getFamilyStockMatchSet(familyId);
+  const includeDespiteStockKeys = new Set(
+    mealPlan.shoppingOverrides
+      .filter(
+        (override) =>
+          override.sourceType === ShoppingItemSource.GENERATED &&
+          override.includeDespiteStock,
+      )
+      .map((override) => override.sourceKey),
+  );
+  const stockIngredients = getStockIngredientsForMealPlan({
+    includeDespiteStockKeys,
+    mealPlan,
+    stockMatchSet,
+  });
+  const allowedSourceKeys = new Set(
+    stockIngredients.map((ingredient) => ingredient.sourceKey),
+  );
+  const invalidSourceKeys = uniqueSourceKeys.filter(
+    (sourceKey) => !allowedSourceKeys.has(sourceKey),
+  );
+
+  if (invalidSourceKeys.length > 0) {
+    return {
+      status: "VALIDATION_ERROR" as const,
+      formError: "En eller flere basisvarer finnes ikke i ukeplanen.",
+    };
+  }
+
+  try {
+    for (const sourceKey of uniqueSourceKeys) {
+      const existingOverride = await db.shoppingItemOverride.findUnique({
+        select: {
+          checked: true,
+          id: true,
+          note: true,
+          postponedUntilDate: true,
+          preferredStoreId: true,
+        },
+        where: {
+          mealPlanId_sourceType_sourceKey: {
+            mealPlanId: mealPlan.id,
+            sourceKey,
+            sourceType: ShoppingItemSource.GENERATED,
+          },
+        },
+      });
+
+      await db.shoppingItemOverride.upsert({
+        create: {
+          checked: existingOverride?.checked ?? false,
+          includeDespiteStock: true,
+          mealPlanId: mealPlan.id,
+          note: existingOverride?.note ?? null,
+          postponedUntilDate: existingOverride?.postponedUntilDate ?? null,
+          preferredStoreId: existingOverride?.preferredStoreId ?? null,
+          sourceKey,
+          sourceType: ShoppingItemSource.GENERATED,
+          ...buildActorUpdate(userId),
+        },
+        update: {
+          includeDespiteStock: true,
+          ...buildActorUpdate(userId),
+        },
+        where: {
+          mealPlanId_sourceType_sourceKey: {
+            mealPlanId: mealPlan.id,
+            sourceKey,
+            sourceType: ShoppingItemSource.GENERATED,
+          },
+        },
+      });
+    }
+
+    logCollaborationWrite({
+      action: "opt-in-stock-shopping-items",
+      domain: "shopping",
+      entityId: mealPlan.id,
+      entityType: "meal-plan",
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "UPDATED",
+      userId,
+    });
+
+    return {
+      status: "UPDATED" as const,
+    };
+  } catch (error) {
+    logCollaborationFailure({
+      action: "opt-in-stock-shopping-items",
+      domain: "shopping",
+      entityId: mealPlan.id,
+      entityType: "meal-plan",
+      error,
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "VALIDATION_ERROR",
+      userId,
+    });
+
+    throw error;
+  }
+}
+
 export async function updateGeneratedShoppingItemOverride({
   expectedUpdatedAt,
   familyId,
@@ -623,6 +770,7 @@ export async function updateGeneratedShoppingItemOverride({
     select: {
       checked: true,
       id: true,
+      includeDespiteStock: true,
       note: true,
       postponedUntilDate: true,
       preferredStoreId: true,
@@ -650,11 +798,13 @@ export async function updateGeneratedShoppingItemOverride({
 
   const nextData: {
     checked: boolean;
+    includeDespiteStock: boolean;
     note: string | null;
     postponedUntilDate: Date | null;
     preferredStoreId: string | null;
   } = {
     checked: existingOverride?.checked ?? false,
+    includeDespiteStock: existingOverride?.includeDespiteStock ?? false,
     note: validation.values.note || null,
     postponedUntilDate: validation.postponedUntilDate ?? null,
     preferredStoreId: validation.preferredStoreId,
@@ -1164,6 +1314,7 @@ function parseDateOnly(value: string) {
 }
 
 function shouldDeleteOverrideAfterUnchecked(existingOverride: {
+  includeDespiteStock: boolean;
   note: string | null;
   postponedUntilDate: Date | null;
   preferredStoreId: string | null;
@@ -1173,14 +1324,26 @@ function shouldDeleteOverrideAfterUnchecked(existingOverride: {
     return true;
   }
 
-  return !existingOverride.note && !existingOverride.postponedUntilDate && !existingOverride.preferredStoreId;
+  return (
+    !existingOverride.includeDespiteStock &&
+    !existingOverride.note &&
+    !existingOverride.postponedUntilDate &&
+    !existingOverride.preferredStoreId
+  );
 }
 
 function isOverrideEmpty(values: {
   checked: boolean;
+  includeDespiteStock: boolean;
   note: string | null;
   postponedUntilDate: Date | null;
   preferredStoreId: string | null;
 }) {
-  return !values.checked && !values.note && !values.postponedUntilDate && !values.preferredStoreId;
+  return (
+    !values.checked &&
+    !values.includeDespiteStock &&
+    !values.note &&
+    !values.postponedUntilDate &&
+    !values.preferredStoreId
+  );
 }

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -43,11 +43,7 @@ vi.mock("./stock.server", async (importOriginal) => {
   };
 });
 
-import {
-  getMealPlanShoppingData,
-  getMealPlanStoreModeData,
-  getStockIngredientsForMealPlan,
-} from "./shopping.server";
+import { getMealPlanShoppingData, getMealPlanStoreModeData } from "./shopping.server";
 
 const mockMembership = {
   family: {

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -1,24 +1,26 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 
-const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
-  return {
-    dbMock: {
-      ingredientCategory: {
-        findMany: vi.fn(),
+const { dbMock, getFamilyStockMatchSetMock, requireFamilyMembershipMock } =
+  vi.hoisted(() => {
+    return {
+      dbMock: {
+        ingredientCategory: {
+          findMany: vi.fn(),
+        },
+        mealPlan: {
+          findFirst: vi.fn(),
+        },
+        store: {
+          findMany: vi.fn(),
+        },
+        userStorePreference: {
+          findUnique: vi.fn(),
+        },
       },
-      mealPlan: {
-        findFirst: vi.fn(),
-      },
-      store: {
-        findMany: vi.fn(),
-      },
-      userStorePreference: {
-        findUnique: vi.fn(),
-      },
-    },
-    requireFamilyMembershipMock: vi.fn(),
-  };
-});
+      getFamilyStockMatchSetMock: vi.fn(),
+      requireFamilyMembershipMock: vi.fn(),
+    };
+  });
 
 vi.mock("./db.server", () => {
   return {
@@ -32,7 +34,20 @@ vi.mock("./family.server", () => {
   };
 });
 
-import { getMealPlanShoppingData, getMealPlanStoreModeData } from "./shopping.server";
+vi.mock("./stock.server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./stock.server")>();
+
+  return {
+    ...actual,
+    getFamilyStockMatchSet: getFamilyStockMatchSetMock,
+  };
+});
+
+import {
+  getMealPlanShoppingData,
+  getMealPlanStoreModeData,
+  getStockIngredientsForMealPlan,
+} from "./shopping.server";
 
 const mockMembership = {
   family: {
@@ -50,6 +65,10 @@ describe("shopping.server", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     requireFamilyMembershipMock.mockResolvedValue(mockMembership);
+    getFamilyStockMatchSetMock.mockResolvedValue({
+      displayNameNormalized: new Set(),
+      ingredientIds: new Set(),
+    });
     dbMock.userStorePreference.findUnique.mockResolvedValue(null);
     dbMock.ingredientCategory.findMany.mockResolvedValue([
       {
@@ -208,6 +227,7 @@ describe("shopping.server", () => {
       shoppingOverrides: [
         {
           checked: true,
+          includeDespiteStock: false,
           note: "Kjop pa tilbud",
           postponedUntilDate: new Date("2026-05-16T00:00:00.000Z"),
           preferredStore: {
@@ -221,6 +241,7 @@ describe("shopping.server", () => {
         },
         {
           checked: true,
+          includeDespiteStock: false,
           note: null,
           postponedUntilDate: null,
           preferredStore: null,
@@ -705,6 +726,168 @@ describe("shopping.server", () => {
       checkedCount: 0,
       totalCount: 2,
     });
+  });
+
+  it("excludes stock ingredients from generated shopping items and exposes a stock summary", async () => {
+    getFamilyStockMatchSetMock.mockResolvedValue({
+      displayNameNormalized: new Set(),
+      ingredientIds: new Set(["canonical-lime"]),
+    });
+
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  displayName: "Frukt og gront",
+                  id: "category-produce",
+                },
+                categoryId: "category-produce",
+                displayName: "Lime",
+                id: "ingredient-1",
+                ingredientId: "canonical-lime",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+              {
+                amount: "1",
+                category: {
+                  displayName: "Brod",
+                  id: "category-bakery",
+                },
+                categoryId: "category-bakery",
+                displayName: "Tortillalefser",
+                id: "ingredient-2",
+                ingredientId: "canonical-tortilla",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 2,
+                unit: "pk",
+              },
+            ],
+            title: "Taco",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 20",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [],
+      },
+    ]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.itemCounts.generated).toBe(1);
+    expect(result.projectedItems.map((item) => item.name)).toEqual(["Tortillalefser"]);
+    expect(result.stockIngredientCount).toBe(1);
+    expect(result.stockIngredientsForPlan[0]).toMatchObject({
+      isOptedIn: false,
+      name: "Lime",
+      sourceKey: "entry-1:ingredient-1",
+    });
+  });
+
+  it("includes opted-in stock ingredients in generated shopping items", async () => {
+    getFamilyStockMatchSetMock.mockResolvedValue({
+      displayNameNormalized: new Set(),
+      ingredientIds: new Set(["canonical-lime"]),
+    });
+
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: null,
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  displayName: "Frukt og gront",
+                  id: "category-produce",
+                },
+                categoryId: "category-produce",
+                displayName: "Lime",
+                id: "ingredient-1",
+                ingredientId: "canonical-lime",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Taco",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [
+        {
+          checked: false,
+          includeDespiteStock: true,
+          note: null,
+          postponedUntilDate: null,
+          preferredStore: null,
+          preferredStoreId: null,
+          sourceKey: "entry-1:ingredient-1",
+          sourceType: "GENERATED",
+          updatedAt: new Date("2026-05-15T10:00:00.000Z"),
+        },
+      ],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 20",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [],
+      },
+    ]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.itemCounts.generated).toBe(1);
+    expect(result.projectedItems[0]?.name).toBe("Lime");
+    expect(result.stockIngredientCount).toBe(0);
   });
 
   it("throws a not-found response when the meal plan is outside the family scope", async () => {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -3,6 +3,11 @@ import { MealType, Prisma, ShoppingItemSource } from "@prisma/client";
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { getMealPlanDateRange } from "./meal-plan.server";
+import {
+  getFamilyStockMatchSet,
+  isStockIngredientMatch,
+  type FamilyStockMatchSet,
+} from "./stock.server";
 
 const storeSummarySelect = Prisma.validator<Prisma.StoreSelect>()({
   id: true,
@@ -57,6 +62,7 @@ const shoppingOverrideSelect =
   Prisma.validator<Prisma.ShoppingItemOverrideSelect>()({
     checked: true,
     id: true,
+    includeDespiteStock: true,
     note: true,
     postponedUntilDate: true,
     preferredStore: {
@@ -86,7 +92,7 @@ const manualShoppingItemSelect =
     updatedAt: true,
   });
 
-const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
+export const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
   activeShoppingDate: true,
   endDate: true,
   updatedAt: true,
@@ -158,6 +164,8 @@ interface GeneratedProjectionBucket {
     id: string;
     name: string;
   };
+  displayName: string;
+  ingredientId: string | null;
   name: string;
   occurrences: ProjectedShoppingOccurrence[];
   occurrenceKeys: string[];
@@ -168,6 +176,19 @@ interface GeneratedProjectionBucket {
     recipeTitle: string;
   };
   unit: string | null;
+}
+
+export interface ProjectedStockIngredientSummary {
+  category: {
+    id: string;
+    name: string;
+  };
+  isOptedIn: boolean;
+  name: string;
+  occurrenceCount: number;
+  occurrences: ProjectedShoppingOccurrence[];
+  quantityLabel: string | null;
+  sourceKey: string;
 }
 
 interface ProjectedShoppingItemBase {
@@ -235,6 +256,22 @@ export interface StoreModeProgress {
   totalCount: number;
 }
 
+export async function loadShoppingMealPlan({
+  familyId,
+  mealPlanId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+}) {
+  return db.mealPlan.findFirst({
+    select: shoppingMealPlanSelect,
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+}
+
 export async function getMealPlanShoppingData({
   familyId,
   mealPlanId,
@@ -249,12 +286,9 @@ export async function getMealPlanShoppingData({
     userId,
   });
 
-  const mealPlan = await db.mealPlan.findFirst({
-    select: shoppingMealPlanSelect,
-    where: {
-      familyId,
-      id: mealPlanId,
-    },
+  const mealPlan = await loadShoppingMealPlan({
+    familyId,
+    mealPlanId,
   });
 
   if (!mealPlan) {
@@ -264,7 +298,7 @@ export async function getMealPlanShoppingData({
     });
   }
 
-  const [stores, categories] = await Promise.all([
+  const [stores, categories, stockMatchSet] = await Promise.all([
     db.store.findMany({
       orderBy: [{ name: "asc" }],
       select: shoppingStoreSelect,
@@ -276,11 +310,22 @@ export async function getMealPlanShoppingData({
       orderBy: [{ displayName: "asc" }],
       select: shoppingCategorySelect,
     }),
+    getFamilyStockMatchSet(familyId),
   ]);
 
+  const includeDespiteStockKeys = buildIncludeDespiteStockKeys(
+    mealPlan.shoppingOverrides,
+  );
   const generatedItems = projectGeneratedShoppingItems({
+    includeDespiteStockKeys,
     mealPlan,
+    stockMatchSet,
     stores,
+  });
+  const stockIngredientsForPlan = getStockIngredientsForMealPlan({
+    includeDespiteStockKeys,
+    mealPlan,
+    stockMatchSet,
   });
   const manualItems = projectManualShoppingItems({
     mealPlan,
@@ -303,6 +348,8 @@ export async function getMealPlanShoppingData({
     },
     mealPlan,
     projectedItems,
+    stockIngredientCount: stockIngredientsForPlan.length,
+    stockIngredientsForPlan,
     storeGroups: buildProjectedStoreGroups(projectedItems),
     stores: stores.map((store) => ({
       id: store.id,
@@ -327,33 +374,35 @@ export async function getMealPlanStoreModeData({
     userId,
   });
 
-  const [mealPlan, stores, selectedStorePreference] = await Promise.all([
-    db.mealPlan.findFirst({
-      select: shoppingMealPlanSelect,
-      where: {
-        familyId,
-        id: mealPlanId,
-      },
-    }),
-    db.store.findMany({
-      orderBy: [{ name: "asc" }],
-      select: shoppingStoreSelect,
-      where: {
-        OR: [{ familyId: null }, { familyId }],
-      },
-    }),
-    db.userStorePreference.findUnique({
-      select: {
-        selectedStoreId: true,
-      },
-      where: {
-        userId_familyId: {
+  const [mealPlan, stores, selectedStorePreference, stockMatchSet] =
+    await Promise.all([
+      db.mealPlan.findFirst({
+        select: shoppingMealPlanSelect,
+        where: {
           familyId,
-          userId,
+          id: mealPlanId,
         },
-      },
-    }),
-  ]);
+      }),
+      db.store.findMany({
+        orderBy: [{ name: "asc" }],
+        select: shoppingStoreSelect,
+        where: {
+          OR: [{ familyId: null }, { familyId }],
+        },
+      }),
+      db.userStorePreference.findUnique({
+        select: {
+          selectedStoreId: true,
+        },
+        where: {
+          userId_familyId: {
+            familyId,
+            userId,
+          },
+        },
+      }),
+      getFamilyStockMatchSet(familyId),
+    ]);
 
   if (!mealPlan) {
     throw new Response("Fant ikke ukeplanen.", {
@@ -362,13 +411,23 @@ export async function getMealPlanStoreModeData({
     });
   }
 
+  const includeDespiteStockKeys = buildIncludeDespiteStockKeys(
+    mealPlan.shoppingOverrides,
+  );
   const generatedItems = projectGeneratedShoppingItems({
+    includeDespiteStockKeys,
     mealPlan,
+    stockMatchSet,
     stores,
   });
   const manualItems = projectManualShoppingItems({
     mealPlan,
     stores,
+  });
+  const stockIngredientsForPlan = getStockIngredientsForMealPlan({
+    includeDespiteStockKeys,
+    mealPlan,
+    stockMatchSet,
   });
   const projectedItems = [...generatedItems, ...manualItems];
   const activeShoppingDate = mealPlan.activeShoppingDate ?? mealPlan.startDate;
@@ -406,6 +465,8 @@ export async function getMealPlanStoreModeData({
     mealPlan,
     progress: buildStoreModeProgress(dueItems),
     selectedStore,
+    stockIngredientCount: stockIngredientsForPlan.length,
+    stockIngredientsForPlan,
     stores: stores.map((store) => ({
       id: store.id,
       name: store.name,
@@ -415,11 +476,50 @@ export async function getMealPlanStoreModeData({
   };
 }
 
-function projectGeneratedShoppingItems({
+export function getStockIngredientsForMealPlan({
+  includeDespiteStockKeys,
   mealPlan,
+  stockMatchSet,
+}: {
+  includeDespiteStockKeys: Set<string>;
+  mealPlan: ShoppingMealPlan;
+  stockMatchSet: FamilyStockMatchSet;
+}) {
+  const summaries: ProjectedStockIngredientSummary[] = [];
+
+  for (const bucket of buildGeneratedProjectionBuckets(mealPlan)) {
+    const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
+    const isStock = isStockIngredientMatch(bucket, stockMatchSet);
+
+    if (!isStock || includeDespiteStockKeys.has(sourceKey)) {
+      continue;
+    }
+
+    const occurrences = [...bucket.occurrences].sort(compareProjectedOccurrences);
+
+    summaries.push({
+      category: bucket.category,
+      isOptedIn: false,
+      name: bucket.name,
+      occurrenceCount: occurrences.length,
+      occurrences,
+      quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
+      sourceKey,
+    });
+  }
+
+  return summaries.sort((left, right) => left.name.localeCompare(right.name, "nb"));
+}
+
+function projectGeneratedShoppingItems({
+  includeDespiteStockKeys,
+  mealPlan,
+  stockMatchSet,
   stores,
 }: {
+  includeDespiteStockKeys: Set<string>;
   mealPlan: ShoppingMealPlan;
+  stockMatchSet: FamilyStockMatchSet;
   stores: ShoppingStore[];
 }) {
   const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
@@ -427,6 +527,50 @@ function projectGeneratedShoppingItems({
     mealPlan.shoppingOverrides,
     ShoppingItemSource.GENERATED,
   );
+
+  return buildGeneratedProjectionBuckets(mealPlan)
+    .filter((bucket) => {
+      const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
+      const isStock = isStockIngredientMatch(bucket, stockMatchSet);
+
+      return !isStock || includeDespiteStockKeys.has(sourceKey);
+    })
+    .map((bucket) => {
+    const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
+    const override = overrideBySourceKey.get(sourceKey);
+    const preferredStore = override?.preferredStore ?? bucket.preferredStore;
+    const section = resolveStoreSection({
+      category: bucket.category,
+      preferredStore,
+      storeSectionsByStoreId,
+    });
+    const occurrences = [...bucket.occurrences].sort(
+      compareProjectedOccurrences,
+    );
+
+    return {
+      amount: bucket.amount,
+      category: bucket.category,
+      checked: override?.checked ?? false,
+      firstDate: occurrences[0]!.date,
+      lastDate: occurrences[occurrences.length - 1]!.date,
+      name: bucket.name,
+      note: override?.note ?? null,
+      occurrenceCount: occurrences.length,
+      occurrences,
+      collaborationVersion: override?.updatedAt?.toISOString() ?? "",
+      postponedUntilDate: override?.postponedUntilDate ?? null,
+      preferredStore,
+      quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
+      section,
+      sourceKey,
+      sourceType: ShoppingItemSource.GENERATED,
+      unit: bucket.unit,
+    } satisfies ProjectedGeneratedShoppingItem;
+    });
+}
+
+function buildGeneratedProjectionBuckets(mealPlan: ShoppingMealPlan) {
   const buckets = new Map<string, GeneratedProjectionBucket>();
 
   for (const entry of mealPlan.entries) {
@@ -485,6 +629,8 @@ function projectGeneratedShoppingItems({
           id: ingredient.category.id,
           name: ingredient.category.displayName,
         },
+        displayName: ingredient.displayName,
+        ingredientId: ingredient.ingredientId,
         name: ingredient.displayName,
         occurrences: [occurrence],
         occurrenceKeys: [occurrenceKey],
@@ -499,39 +645,19 @@ function projectGeneratedShoppingItems({
     }
   }
 
-  return [...buckets.values()].map((bucket) => {
-    const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
-    const override = overrideBySourceKey.get(sourceKey);
-    const preferredStore = override?.preferredStore ?? bucket.preferredStore;
-    const section = resolveStoreSection({
-      category: bucket.category,
-      preferredStore,
-      storeSectionsByStoreId,
-    });
-    const occurrences = [...bucket.occurrences].sort(
-      compareProjectedOccurrences,
-    );
+  return [...buckets.values()];
+}
 
-    return {
-      amount: bucket.amount,
-      category: bucket.category,
-      checked: override?.checked ?? false,
-      firstDate: occurrences[0]!.date,
-      lastDate: occurrences[occurrences.length - 1]!.date,
-      name: bucket.name,
-      note: override?.note ?? null,
-      occurrenceCount: occurrences.length,
-      occurrences,
-      collaborationVersion: override?.updatedAt?.toISOString() ?? "",
-      postponedUntilDate: override?.postponedUntilDate ?? null,
-      preferredStore,
-      quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
-      section,
-      sourceKey,
-      sourceType: ShoppingItemSource.GENERATED,
-      unit: bucket.unit,
-    } satisfies ProjectedGeneratedShoppingItem;
-  });
+function buildIncludeDespiteStockKeys(overrides: ShoppingOverride[]) {
+  return new Set(
+    overrides
+      .filter(
+        (override) =>
+          override.sourceType === ShoppingItemSource.GENERATED &&
+          override.includeDespiteStock,
+      )
+      .map((override) => override.sourceKey),
+  );
 }
 
 function projectManualShoppingItems({

--- a/app/lib/stock-write.server.test.ts
+++ b/app/lib/stock-write.server.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyAdminMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      familyStockIngredient: {
+        create: vi.fn(),
+        deleteMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      ingredient: {
+        findUnique: vi.fn(),
+      },
+    },
+    requireFamilyAdminMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyAdmin: requireFamilyAdminMock,
+}));
+
+import {
+  addFamilyStockIngredient,
+  removeFamilyStockIngredient,
+} from "./stock-write.server";
+
+describe("stock-write.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyAdminMock.mockResolvedValue({
+      familyId: "family-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+  });
+
+  it("rejects empty stock ingredient input", async () => {
+    const result = await addFamilyStockIngredient({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        displayName: "   ",
+        ingredientId: "",
+        note: "",
+      },
+    });
+
+    expect(result.status).toBe("VALIDATION_ERROR");
+    expect(result.fieldErrors?.displayName).toBeTruthy();
+  });
+
+  it("creates a canonical stock ingredient", async () => {
+    dbMock.ingredient.findUnique.mockResolvedValue({ id: "ingredient-salt" });
+    dbMock.familyStockIngredient.findUnique.mockResolvedValue(null);
+    dbMock.familyStockIngredient.create.mockResolvedValue({ id: "stock-1" });
+
+    const result = await addFamilyStockIngredient({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        displayName: "",
+        ingredientId: "ingredient-salt",
+        note: "",
+      },
+    });
+
+    expect(result).toEqual({
+      status: "CREATED",
+      stockIngredientId: "stock-1",
+    });
+    expect(dbMock.familyStockIngredient.create).toHaveBeenCalledWith({
+      data: {
+        familyId: "family-1",
+        ingredientId: "ingredient-salt",
+        note: null,
+      },
+      select: {
+        id: true,
+      },
+    });
+  });
+
+  it("creates a display-name stock ingredient when canonical id is missing", async () => {
+    dbMock.familyStockIngredient.findUnique.mockResolvedValue(null);
+    dbMock.familyStockIngredient.create.mockResolvedValue({ id: "stock-2" });
+
+    const result = await addFamilyStockIngredient({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        displayName: "Olivenolje",
+        ingredientId: "",
+        note: "Extra virgin",
+      },
+    });
+
+    expect(result.status).toBe("CREATED");
+    expect(dbMock.familyStockIngredient.create).toHaveBeenCalledWith({
+      data: {
+        displayNameNormalized: "olivenolje",
+        familyId: "family-1",
+        note: "Extra virgin",
+      },
+      select: {
+        id: true,
+      },
+    });
+  });
+
+  it("removes a family stock ingredient", async () => {
+    dbMock.familyStockIngredient.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await removeFamilyStockIngredient({
+      familyId: "family-1",
+      stockIngredientId: "stock-1",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("DELETED");
+  });
+});

--- a/app/lib/stock-write.server.ts
+++ b/app/lib/stock-write.server.ts
@@ -1,0 +1,204 @@
+import { db } from "./db.server";
+import { requireFamilyAdmin } from "./family.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
+
+export interface AddFamilyStockIngredientValues {
+  displayName: string;
+  ingredientId: string;
+  note: string;
+}
+
+export interface AddFamilyStockIngredientFieldErrors {
+  displayName?: string;
+  ingredientId?: string;
+}
+
+export async function addFamilyStockIngredient({
+  familyId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  userId: string;
+  values: AddFamilyStockIngredientValues;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const ingredientId = values.ingredientId.trim();
+  const displayName = values.displayName.trim();
+  const note = values.note.trim() || null;
+
+  if (!ingredientId && !displayName) {
+    return {
+      fieldErrors: {
+        displayName: "Velg en ingrediens eller skriv inn et navn.",
+      },
+      status: "VALIDATION_ERROR" as const,
+      values: {
+        displayName,
+        ingredientId,
+        note: values.note,
+      },
+    };
+  }
+
+  if (ingredientId) {
+    const ingredient = await db.ingredient.findUnique({
+      select: {
+        id: true,
+      },
+      where: {
+        id: ingredientId,
+      },
+    });
+
+    if (!ingredient) {
+      return {
+        fieldErrors: {
+          ingredientId: "Fant ikke ingrediensen.",
+        },
+        status: "VALIDATION_ERROR" as const,
+        values: {
+          displayName,
+          ingredientId,
+          note: values.note,
+        },
+      };
+    }
+
+    const existing = await db.familyStockIngredient.findUnique({
+      select: {
+        id: true,
+      },
+      where: {
+        familyId_ingredientId: {
+          familyId,
+          ingredientId,
+        },
+      },
+    });
+
+    if (existing) {
+      return {
+        fieldErrors: {
+          ingredientId: "Ingrediensen er allerede lagt til som basisvare.",
+        },
+        status: "VALIDATION_ERROR" as const,
+        values: {
+          displayName,
+          ingredientId,
+          note: values.note,
+        },
+      };
+    }
+
+    const stockIngredient = await db.familyStockIngredient.create({
+      data: {
+        familyId,
+        ingredientId,
+        note,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return {
+      status: "CREATED" as const,
+      stockIngredientId: stockIngredient.id,
+    };
+  }
+
+  const displayNameNormalized = normalizeIngredientCanonicalName(displayName);
+
+  if (!displayNameNormalized) {
+    return {
+      fieldErrors: {
+        displayName: "Skriv inn et gyldig ingrediensnavn.",
+      },
+      status: "VALIDATION_ERROR" as const,
+      values: {
+        displayName,
+        ingredientId,
+        note: values.note,
+      },
+    };
+  }
+
+  const existing = await db.familyStockIngredient.findUnique({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId_displayNameNormalized: {
+        displayNameNormalized,
+        familyId,
+      },
+    },
+  });
+
+  if (existing) {
+    return {
+      fieldErrors: {
+        displayName: "Ingrediensen er allerede lagt til som basisvare.",
+      },
+      status: "VALIDATION_ERROR" as const,
+      values: {
+        displayName,
+        ingredientId,
+        note: values.note,
+      },
+    };
+  }
+
+  const stockIngredient = await db.familyStockIngredient.create({
+    data: {
+      displayNameNormalized,
+      familyId,
+      note,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return {
+    status: "CREATED" as const,
+    stockIngredientId: stockIngredient.id,
+  };
+}
+
+export async function removeFamilyStockIngredient({
+  familyId,
+  stockIngredientId,
+  userId,
+}: {
+  familyId: string;
+  stockIngredientId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const deleted = await db.familyStockIngredient.deleteMany({
+    where: {
+      familyId,
+      id: stockIngredientId,
+    },
+  });
+
+  if (deleted.count === 0) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  return {
+    status: "DELETED" as const,
+  };
+}

--- a/app/lib/stock.server.test.ts
+++ b/app/lib/stock.server.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      familyStockIngredient: {
+        findMany: vi.fn(),
+      },
+      ingredient: {
+        findMany: vi.fn(),
+      },
+    },
+    requireFamilyMembershipMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+import {
+  getFamilyStockMatchSet,
+  isStockIngredientMatch,
+  listFamilyStockIngredients,
+} from "./stock.server";
+
+describe("stock.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+  });
+
+  it("builds a match set from ingredient ids and normalized display names", async () => {
+    dbMock.familyStockIngredient.findMany.mockResolvedValue([
+      {
+        displayNameNormalized: null,
+        ingredientId: "ingredient-salt",
+      },
+      {
+        displayNameNormalized: "olivenolje",
+        ingredientId: null,
+      },
+    ]);
+
+    const matchSet = await getFamilyStockMatchSet("family-1");
+
+    expect(matchSet.ingredientIds).toEqual(new Set(["ingredient-salt"]));
+    expect(matchSet.displayNameNormalized).toEqual(new Set(["olivenolje"]));
+  });
+
+  it("matches recipe ingredients by ingredient id or normalized display name", () => {
+    const matchSet = {
+      displayNameNormalized: new Set(["salt"]),
+      ingredientIds: new Set(["ingredient-salt"]),
+    };
+
+    expect(
+      isStockIngredientMatch(
+        { displayName: "Salt", ingredientId: "ingredient-salt" },
+        matchSet,
+      ),
+    ).toBe(true);
+    expect(
+      isStockIngredientMatch(
+        { displayName: "Salt", ingredientId: null },
+        matchSet,
+      ),
+    ).toBe(true);
+    expect(
+      isStockIngredientMatch(
+        { displayName: "Paprika", ingredientId: null },
+        matchSet,
+      ),
+    ).toBe(false);
+  });
+
+  it("lists formatted family stock ingredients for members", async () => {
+    dbMock.familyStockIngredient.findMany.mockResolvedValue([
+      {
+        displayNameNormalized: null,
+        id: "stock-1",
+        ingredient: {
+          canonicalName: "salt",
+          id: "ingredient-salt",
+        },
+        ingredientId: "ingredient-salt",
+        note: null,
+      },
+    ]);
+
+    const result = await listFamilyStockIngredients({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(result.stockIngredients).toEqual([
+      {
+        displayLabel: "salt",
+        displayNameNormalized: null,
+        id: "stock-1",
+        ingredientId: "ingredient-salt",
+        note: null,
+      },
+    ]);
+    expect(result.userRole).toBe("ADMIN");
+  });
+});

--- a/app/lib/stock.server.ts
+++ b/app/lib/stock.server.ts
@@ -1,0 +1,149 @@
+import { Prisma } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
+
+const familyStockIngredientSelect =
+  Prisma.validator<Prisma.FamilyStockIngredientSelect>()({
+    displayNameNormalized: true,
+    id: true,
+    ingredient: {
+      select: {
+        canonicalName: true,
+        id: true,
+      },
+    },
+    ingredientId: true,
+    note: true,
+  });
+
+export type FamilyStockIngredientRow = Prisma.FamilyStockIngredientGetPayload<{
+  select: typeof familyStockIngredientSelect;
+}>;
+
+export interface FamilyStockMatchSet {
+  ingredientIds: Set<string>;
+  displayNameNormalized: Set<string>;
+}
+
+export interface StockMatchableIngredient {
+  displayName: string;
+  ingredientId: string | null;
+}
+
+export async function listFamilyStockIngredients({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const stockIngredients = await db.familyStockIngredient.findMany({
+    orderBy: [
+      { ingredient: { canonicalName: "asc" } },
+      { displayNameNormalized: "asc" },
+    ],
+    select: familyStockIngredientSelect,
+    where: {
+      familyId,
+    },
+  });
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    stockIngredients: stockIngredients.map(formatFamilyStockIngredient),
+    userRole: membership.role,
+  };
+}
+
+export async function getFamilyStockMatchSet(
+  familyId: string,
+): Promise<FamilyStockMatchSet> {
+  const rows = await db.familyStockIngredient.findMany({
+    select: {
+      displayNameNormalized: true,
+      ingredientId: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  const ingredientIds = new Set<string>();
+  const displayNameNormalized = new Set<string>();
+
+  for (const row of rows) {
+    if (row.ingredientId) {
+      ingredientIds.add(row.ingredientId);
+    }
+
+    if (row.displayNameNormalized) {
+      displayNameNormalized.add(row.displayNameNormalized);
+    }
+  }
+
+  return {
+    displayNameNormalized,
+    ingredientIds,
+  };
+}
+
+export function isStockIngredientMatch(
+  ingredient: StockMatchableIngredient,
+  matchSet: FamilyStockMatchSet,
+) {
+  if (
+    ingredient.ingredientId &&
+    matchSet.ingredientIds.has(ingredient.ingredientId)
+  ) {
+    return true;
+  }
+
+  const normalizedDisplayName = normalizeIngredientCanonicalName(
+    ingredient.displayName,
+  );
+
+  return matchSet.displayNameNormalized.has(normalizedDisplayName);
+}
+
+export async function searchCanonicalIngredients(query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  return db.ingredient.findMany({
+    orderBy: [{ canonicalName: "asc" }],
+    select: {
+      canonicalName: true,
+      id: true,
+    },
+    take: 20,
+    where: {
+      canonicalName: {
+        contains: normalizedQuery,
+        mode: "insensitive",
+      },
+    },
+  });
+}
+
+function formatFamilyStockIngredient(row: FamilyStockIngredientRow) {
+  return {
+    displayLabel: row.ingredient?.canonicalName ?? row.displayNameNormalized ?? "",
+    displayNameNormalized: row.displayNameNormalized,
+    id: row.id,
+    ingredientId: row.ingredientId,
+    note: row.note,
+  };
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -14,6 +14,7 @@ export default [
   route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
   route("families/:familyId/meal-plans/:mealPlanId/store-mode", "routes/family-meal-plan-store-mode.tsx"),
   route("families/:familyId/stores", "routes/family-stores.tsx"),
+  route("families/:familyId/stock-ingredients", "routes/family-stock-ingredients.tsx"),
   route("families/:familyId/recipes", "routes/family-recipes.tsx"),
   route("families/:familyId/recipes/:recipeId", "routes/family-recipe.tsx"),
   route("login", "routes/login.tsx"),

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -19,6 +19,7 @@ vi.mock("../lib/shopping-write.server", () => {
   return {
     createManualShoppingItem: vi.fn(),
     deleteManualShoppingItem: vi.fn(),
+    optInStockShoppingItems: vi.fn(),
     toggleShoppingItemChecked: vi.fn(),
     updateGeneratedShoppingItemOverride: vi.fn(),
     updateManualShoppingItem: vi.fn(),
@@ -29,6 +30,7 @@ import { requireUser } from "../lib/auth.server";
 import { getMealPlanShoppingData } from "../lib/shopping.server";
 import {
   createManualShoppingItem,
+  optInStockShoppingItems,
   toggleShoppingItemChecked,
   updateGeneratedShoppingItemOverride,
 } from "../lib/shopping-write.server";
@@ -224,6 +226,8 @@ describe("family meal plan shopping route", () => {
           },
         },
       ],
+      stockIngredientCount: 0,
+      stockIngredientsForPlan: [],
       stores: [
         {
           id: "store-1",
@@ -355,6 +359,8 @@ describe("family meal plan shopping route", () => {
           },
         },
       ],
+      stockIngredientCount: 0,
+      stockIngredientsForPlan: [],
       stores: [
         {
           id: "store-1",
@@ -364,6 +370,107 @@ describe("family meal plan shopping route", () => {
       userRole: "ADMIN",
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
     });
+  });
+
+  it("serializes stock ingredients for the active meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanShoppingData).mockResolvedValue({
+      categories: [],
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      itemCounts: {
+        generated: 1,
+        manual: 0,
+        total: 1,
+      },
+      mealPlan: {
+        activeShoppingDate: null,
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        entries: [],
+        id: "meal-plan-1",
+        manualShoppingItems: [],
+        shoppingOverrides: [],
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Uke 20",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+      projectedItems: [],
+      stockIngredientCount: 1,
+      stockIngredientsForPlan: [
+        {
+          category: {
+            id: "category-pantry",
+            name: "Torrvarer",
+          },
+          isOptedIn: false,
+          name: "Salt",
+          occurrenceCount: 1,
+          occurrences: [
+            {
+              date: new Date("2026-05-15T00:00:00.000Z"),
+              mealPlanEntryId: "entry-1",
+              recipeId: "recipe-1",
+              recipeIngredientId: "ingredient-1",
+              recipeTitle: "Taco",
+            },
+          ],
+          quantityLabel: "1 ts",
+          sourceKey: "entry-1:ingredient-1",
+        },
+      ],
+      storeGroups: [],
+      stores: [],
+      userRole: "ADMIN",
+      visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(result.stockIngredientCount).toBe(1);
+    expect(result.stockIngredientsForPlan[0]?.name).toBe("Salt");
+    expect(result.stockIngredientsForPlan[0]?.occurrences[0]?.date).toBe(
+      "2026-05-15",
+    );
+  });
+
+  it("opts stock ingredients into the shopping list", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(optInStockShoppingItems).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "opt-in-stock-shopping-item");
+    formData.set("sourceKey", "entry-1:ingredient-1");
+
+    const response = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping",
+        formData,
+      ),
+    });
+
+    expect(optInStockShoppingItems).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKeys: ["entry-1:ingredient-1"],
+      userId: "user-1",
+    });
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
   });
 
   it("returns manual item validation errors from the server module", async () => {

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -12,6 +12,7 @@ import { getMealPlanShoppingData } from "../lib/shopping.server";
 import {
   createManualShoppingItem,
   deleteManualShoppingItem,
+  optInStockShoppingItems,
   toggleShoppingItemChecked,
   updateGeneratedShoppingItemOverride,
   updateManualShoppingItem,
@@ -26,11 +27,14 @@ type ShoppingNotice =
   | "manual-shopping-item-added"
   | "manual-shopping-item-deleted"
   | "manual-shopping-item-updated"
-  | "shopping-item-check-state-updated";
+  | "shopping-item-check-state-updated"
+  | "stock-shopping-items-opted-in";
 
 type ShoppingIntent =
   | "add-manual-shopping-item"
   | "delete-manual-shopping-item"
+  | "opt-in-stock-shopping-item"
+  | "opt-in-stock-shopping-items"
   | "toggle-shopping-item-checked"
   | "update-generated-shopping-item"
   | "update-manual-shopping-item";
@@ -118,6 +122,14 @@ export async function loader({
         items: section.items.map(serializeProjectedShoppingItem),
       })),
       store: group.store,
+    })),
+    stockIngredientCount: result.stockIngredientCount,
+    stockIngredientsForPlan: result.stockIngredientsForPlan.map((ingredient) => ({
+      ...ingredient,
+      occurrences: ingredient.occurrences.map((occurrence) => ({
+        ...occurrence,
+        date: formatDateOnly(occurrence.date),
+      })),
     })),
     stores: result.stores,
     userRole: result.userRole,
@@ -284,6 +296,41 @@ export async function action({
     });
   }
 
+  if (
+    intent === "opt-in-stock-shopping-item" ||
+    intent === "opt-in-stock-shopping-items"
+  ) {
+    const sourceKeys =
+      intent === "opt-in-stock-shopping-items"
+        ? formData.getAll("sourceKey").map((value) => String(value))
+        : [String(formData.get("sourceKey") ?? "")];
+
+    const result = await optInStockShoppingItems({
+      familyId,
+      mealPlanId,
+      sourceKeys,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "stock-shopping-items-opted-in",
+      request,
+    });
+  }
+
   if (intent === "update-generated-shopping-item") {
     const sourceKey = String(formData.get("sourceKey") ?? "").trim();
 
@@ -411,6 +458,98 @@ export default function FamilyMealPlanShoppingRoute({
               Kunne ikke oppdatere handlelisten
             </h2>
             <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        {loaderData.stockIngredientCount > 0 ? (
+          <section className="rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm">
+            <details>
+              <summary className="cursor-pointer text-base font-semibold">
+                {loaderData.stockIngredientCount} basisvarer brukt denne uken
+              </summary>
+              <div className="mt-4 space-y-4">
+                <p className="text-sm leading-6 text-amber-900">
+                  Disse varene er vanligvis på lager og vises ikke i
+                  handlelisten med mindre du legger dem til for denne uken.
+                </p>
+                <Form className="flex flex-wrap gap-3" method="post">
+                  <input
+                    name="intent"
+                    type="hidden"
+                    value="opt-in-stock-shopping-items"
+                  />
+                  {loaderData.stockIngredientsForPlan.map((ingredient) => (
+                    <input
+                      key={ingredient.sourceKey}
+                      name="sourceKey"
+                      type="hidden"
+                      value={ingredient.sourceKey}
+                    />
+                  ))}
+                  <button
+                    className="rounded-2xl bg-amber-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-950 disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={
+                      navigation.state === "submitting" &&
+                      pendingIntent === "opt-in-stock-shopping-items"
+                    }
+                    type="submit"
+                  >
+                    Legg til alle i handlelisten
+                  </button>
+                </Form>
+                <ul className="grid gap-3">
+                  {loaderData.stockIngredientsForPlan.map((ingredient) => (
+                    <li
+                      key={ingredient.sourceKey}
+                      className="rounded-[20px] border border-amber-200 bg-white px-4 py-4"
+                    >
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-slate-950">
+                            {ingredient.name}
+                            {ingredient.quantityLabel
+                              ? ` · ${ingredient.quantityLabel}`
+                              : ""}
+                          </p>
+                          <p className="mt-1 text-xs leading-5 text-slate-600">
+                            {ingredient.occurrenceCount === 1
+                              ? `Brukt i ${ingredient.occurrences[0]?.recipeTitle}`
+                              : `Brukt i ${ingredient.occurrenceCount} oppskrifter`}
+                            {ingredient.occurrences[0]?.date
+                              ? ` · ${formatDateLabel(ingredient.occurrences[0].date)}`
+                              : ""}
+                          </p>
+                        </div>
+                        <Form method="post">
+                          <input
+                            name="intent"
+                            type="hidden"
+                            value="opt-in-stock-shopping-item"
+                          />
+                          <input
+                            name="sourceKey"
+                            type="hidden"
+                            value={ingredient.sourceKey}
+                          />
+                          <button
+                            className="rounded-xl bg-slate-950 px-4 py-2 text-xs font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={
+                              navigation.state === "submitting" &&
+                              pendingIntent === "opt-in-stock-shopping-item" &&
+                              navigation.formData?.get("sourceKey") ===
+                                ingredient.sourceKey
+                            }
+                            type="submit"
+                          >
+                            Legg til i handlelisten
+                          </button>
+                        </Form>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </details>
           </section>
         ) : null}
 
@@ -1325,7 +1464,8 @@ function getShoppingNotice(request: Request): ShoppingNotice | null {
     notice === "manual-shopping-item-added" ||
     notice === "manual-shopping-item-deleted" ||
     notice === "manual-shopping-item-updated" ||
-    notice === "shopping-item-check-state-updated"
+    notice === "shopping-item-check-state-updated" ||
+    notice === "stock-shopping-items-opted-in"
   ) {
     return notice;
   }
@@ -1382,6 +1522,12 @@ function getShoppingNoticeContent(notice: ShoppingNotice) {
       return {
         description: "Avkryssingen for varelinjen ble oppdatert.",
         title: "Handleliste oppdatert",
+      };
+    case "stock-shopping-items-opted-in":
+      return {
+        description:
+          "Basisvarene ble lagt til i handlelisten for denne ukeplanen.",
+        title: "Basisvarer lagt til",
       };
   }
 }

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -132,6 +132,8 @@ describe("family meal plan store mode route", () => {
         id: "store-1",
         name: "Meny",
       },
+      stockIngredientCount: 0,
+      stockIngredientsForPlan: [],
       stores: [
         {
           id: "store-1",

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -100,6 +100,7 @@ export async function loader({
     notice: getStoreModeNotice(request),
     progress: result.progress,
     selectedStore: result.selectedStore,
+    stockIngredientCount: result.stockIngredientCount,
     stores: result.stores,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
@@ -333,6 +334,24 @@ export default function FamilyMealPlanStoreModeRoute({
             <p className="mt-2 text-sm leading-6">
               {actionData?.formError ?? toggleFormError}
             </p>
+          </section>
+        ) : null}
+
+        {loaderData.stockIngredientCount > 0 ? (
+          <section className="rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm">
+            <p className="text-sm font-semibold">
+              {loaderData.stockIngredientCount} basisvarer brukt denne uken
+            </p>
+            <p className="mt-2 text-sm leading-6 text-amber-900">
+              Basisvarer ligger utenfor butikkmodus med mindre de er lagt til i
+              handlelisten.
+            </p>
+            <Link
+              className="mt-4 inline-flex rounded-2xl bg-amber-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-950"
+              to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
+            >
+              Åpne handlelisten
+            </Link>
           </section>
         ) : null}
 

--- a/app/routes/family-stock-ingredients.test.ts
+++ b/app/routes/family-stock-ingredients.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/stock.server", () => {
+  return {
+    listFamilyStockIngredients: vi.fn(),
+    searchCanonicalIngredients: vi.fn(),
+  };
+});
+
+vi.mock("../lib/stock-write.server", () => {
+  return {
+    addFamilyStockIngredient: vi.fn(),
+    removeFamilyStockIngredient: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { listFamilyStockIngredients, searchCanonicalIngredients } from "../lib/stock.server";
+import {
+  addFamilyStockIngredient,
+  removeFamilyStockIngredient,
+} from "../lib/stock-write.server";
+import { action, loader } from "./family-stock-ingredients";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/stock-ingredients",
+  formData?: FormData,
+) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family stock ingredients route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads family stock ingredients", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listFamilyStockIngredients).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      stockIngredients: [
+        {
+          displayLabel: "salt",
+          displayNameNormalized: null,
+          id: "stock-1",
+          ingredientId: "ingredient-salt",
+          note: null,
+        },
+      ],
+      userRole: "ADMIN",
+    });
+    vi.mocked(searchCanonicalIngredients).mockResolvedValue([]);
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(result.stockIngredients).toHaveLength(1);
+    expect(result.userRole).toBe("ADMIN");
+  });
+
+  it("adds a stock ingredient for admins", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(addFamilyStockIngredient).mockResolvedValue({
+      status: "CREATED",
+      stockIngredientId: "stock-1",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "add-stock-ingredient");
+    formData.set("ingredientId", "ingredient-salt");
+    formData.set("displayName", "");
+    formData.set("note", "");
+
+    const response = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/stock-ingredients",
+        formData,
+      ),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+    expect(addFamilyStockIngredient).toHaveBeenCalled();
+  });
+
+  it("removes a stock ingredient", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(removeFamilyStockIngredient).mockResolvedValue({
+      status: "DELETED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "remove-stock-ingredient");
+    formData.set("stockIngredientId", "stock-1");
+
+    const response = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/stock-ingredients",
+        formData,
+      ),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect(removeFamilyStockIngredient).toHaveBeenCalledWith({
+      familyId: "family-1",
+      stockIngredientId: "stock-1",
+      userId: "user-1",
+    });
+  });
+});

--- a/app/routes/family-stock-ingredients.tsx
+++ b/app/routes/family-stock-ingredients.tsx
@@ -1,0 +1,468 @@
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import {
+  listFamilyStockIngredients,
+  searchCanonicalIngredients,
+} from "../lib/stock.server";
+import {
+  addFamilyStockIngredient,
+  removeFamilyStockIngredient,
+  type AddFamilyStockIngredientFieldErrors,
+  type AddFamilyStockIngredientValues,
+} from "../lib/stock-write.server";
+
+type StockNotice = "stock-ingredient-added" | "stock-ingredient-removed";
+
+type StockIntent = "add-stock-ingredient" | "remove-stock-ingredient";
+
+interface StockActionData {
+  addFieldErrors?: AddFamilyStockIngredientFieldErrors;
+  addValues?: AddFamilyStockIngredientValues;
+  formError?: string;
+  intent?: StockIntent;
+  targetStockIngredientId?: string;
+}
+
+interface FamilyStockIngredientsRouteProps {
+  actionData?: StockActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Basisvarer | Mealplanner" },
+    {
+      name: "description",
+      content:
+        "Administrer basisvarer som vanligvis er på lager og holdes utenfor handlelisten.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const searchQuery = new URL(request.url).searchParams.get("q")?.trim() ?? "";
+  const result = await listFamilyStockIngredients({
+    familyId,
+    userId: user.id,
+  });
+  const searchResults =
+    searchQuery.length > 0
+      ? await searchCanonicalIngredients(searchQuery)
+      : [];
+
+  return {
+    family: result.family,
+    notice: getStockNotice(request),
+    searchQuery,
+    searchResults,
+    stockIngredients: result.stockIngredients,
+    userRole: result.userRole,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "add-stock-ingredient") {
+    const result = await addFamilyStockIngredient({
+      familyId,
+      userId: user.id,
+      values: {
+        displayName: String(formData.get("displayName") ?? ""),
+        ingredientId: String(formData.get("ingredientId") ?? ""),
+        note: String(formData.get("note") ?? ""),
+      },
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        addFieldErrors: result.fieldErrors,
+        addValues: result.values,
+        intent,
+      } satisfies StockActionData;
+    }
+
+    return buildStockRedirect({
+      familyId,
+      notice: "stock-ingredient-added",
+      request,
+    });
+  }
+
+  if (intent === "remove-stock-ingredient") {
+    const stockIngredientId = String(formData.get("stockIngredientId") ?? "");
+
+    if (!stockIngredientId) {
+      return {
+        formError: "Fant ikke basisvaren som skulle fjernes.",
+        intent,
+      } satisfies StockActionData;
+    }
+
+    const result = await removeFamilyStockIngredient({
+      familyId,
+      stockIngredientId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke basisvaren som skulle fjernes.",
+        intent,
+        targetStockIngredientId: stockIngredientId,
+      } satisfies StockActionData;
+    }
+
+    return buildStockRedirect({
+      familyId,
+      notice: "stock-ingredient-removed",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies StockActionData;
+}
+
+export default function FamilyStockIngredientsRoute({
+  actionData,
+  loaderData,
+}: FamilyStockIngredientsRouteProps) {
+  const navigation = useNavigation();
+  const noticeContent = loaderData.notice
+    ? getStockNoticeContent(loaderData.notice)
+    : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const addValues =
+    actionData?.intent === "add-stock-ingredient" && actionData.addValues
+      ? actionData.addValues
+      : {
+          displayName: "",
+          ingredientId: "",
+          note: "",
+        };
+  const canManageStock = loaderData.userRole === "ADMIN";
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Basisvarer
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Vanligvis på lager. Basisvarer vises fortsatt i oppskrifter, men
+                holdes utenfor den automatiske handlelisten med mindre dere
+                velger å ta dem med for uken.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Åpne ukeplaner
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}`}
+              >
+                Tilbake til familie
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere basisvarene
+            </h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        {canManageStock ? (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">
+                Legg til basisvare
+              </h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Søk etter en kanonisk ingrediens, eller skriv inn et navn som
+                skal matches mot oppskriftslinjer uten kobling.
+              </p>
+            </div>
+
+            <Form className="mt-6 space-y-4" method="get">
+              <label className="block text-sm font-medium text-slate-700">
+                Søk i ingrediensregister
+                <input
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={loaderData.searchQuery}
+                  name="q"
+                  placeholder="For eksempel salt"
+                  type="search"
+                />
+              </label>
+              <button
+                className="inline-flex rounded-2xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                type="submit"
+              >
+                Søk
+              </button>
+            </Form>
+
+            {loaderData.searchResults.length > 0 ? (
+              <ul className="mt-4 grid gap-2">
+                {loaderData.searchResults.map((ingredient) => (
+                  <li key={ingredient.id}>
+                    <Form className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3" method="post">
+                      <input name="intent" type="hidden" value="add-stock-ingredient" />
+                      <input name="ingredientId" type="hidden" value={ingredient.id} />
+                      <input name="displayName" type="hidden" value="" />
+                      <input name="note" type="hidden" value="" />
+                      <span className="text-sm font-medium text-slate-900">
+                        {ingredient.canonicalName}
+                      </span>
+                      <button
+                        className="rounded-xl bg-slate-950 px-3 py-2 text-xs font-medium text-white transition hover:bg-slate-800"
+                        type="submit"
+                      >
+                        Legg til
+                      </button>
+                    </Form>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            <Form className="mt-6 space-y-4 border-t border-slate-200 pt-6" method="post">
+              <input name="intent" type="hidden" value="add-stock-ingredient" />
+              <input name="ingredientId" type="hidden" value="" />
+              <label className="block text-sm font-medium text-slate-700">
+                Eller fritekstnavn
+                <input
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={addValues.displayName}
+                  name="displayName"
+                  placeholder="For eksempel Olivenolje"
+                  type="text"
+                />
+              </label>
+              {actionData?.addFieldErrors?.displayName ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.addFieldErrors.displayName}
+                </p>
+              ) : null}
+              {actionData?.addFieldErrors?.ingredientId ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.addFieldErrors.ingredientId}
+                </p>
+              ) : null}
+              <label className="block text-sm font-medium text-slate-700">
+                Notat (valgfritt)
+                <input
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={addValues.note}
+                  name="note"
+                  type="text"
+                />
+              </label>
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={
+                  navigation.state === "submitting" &&
+                  pendingIntent === "add-stock-ingredient"
+                }
+                type="submit"
+              >
+                {navigation.state === "submitting" &&
+                pendingIntent === "add-stock-ingredient"
+                  ? "Legger til..."
+                  : "Legg til basisvare"}
+              </button>
+            </Form>
+          </section>
+        ) : (
+          <section className="rounded-[28px] border border-slate-200 bg-white px-6 py-5 text-sm leading-6 text-slate-600 shadow-sm">
+            Bare administratorer kan endre basisvarene. Du kan fortsatt se
+            listen og legge dem til i handlelisten fra ukeplanen.
+          </section>
+        )}
+
+        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <div className="flex flex-col gap-2">
+            <h2 className="text-lg font-semibold text-slate-950">
+              Familiens basisvarer
+            </h2>
+            <p className="text-sm leading-6 text-slate-600">
+              {loaderData.stockIngredients.length === 0
+                ? "Ingen basisvarer er konfigurert ennå."
+                : `${loaderData.stockIngredients.length} basisvarer er registrert.`}
+            </p>
+          </div>
+
+          {loaderData.stockIngredients.length > 0 ? (
+            <ul className="mt-6 grid gap-3">
+              {loaderData.stockIngredients.map((ingredient) => (
+                <li
+                  key={ingredient.id}
+                  className="flex flex-col gap-3 rounded-[24px] border border-slate-200 bg-slate-50 p-5 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div>
+                    <p className="text-base font-semibold text-slate-950">
+                      {ingredient.displayLabel}
+                    </p>
+                    {ingredient.note ? (
+                      <p className="mt-1 text-sm leading-6 text-slate-600">
+                        {ingredient.note}
+                      </p>
+                    ) : null}
+                  </div>
+                  {canManageStock ? (
+                    <Form method="post">
+                      <input
+                        name="intent"
+                        type="hidden"
+                        value="remove-stock-ingredient"
+                      />
+                      <input
+                        name="stockIngredientId"
+                        type="hidden"
+                        value={ingredient.id}
+                      />
+                      <button
+                        className="rounded-xl border border-rose-200 px-4 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={
+                          navigation.state === "submitting" &&
+                          pendingIntent === "remove-stock-ingredient" &&
+                          navigation.formData?.get("stockIngredientId") ===
+                            ingredient.id
+                        }
+                        type="submit"
+                      >
+                        Fjern
+                      </button>
+                    </Form>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  if (isRouteErrorResponse(error)) {
+    return (
+      <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+        <div className="mx-auto max-w-3xl rounded-[28px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+          <h1 className="text-2xl font-semibold text-slate-950">
+            {error.status} {error.statusText}
+          </h1>
+          <p className="mt-4 text-sm leading-6 text-slate-600">{error.data}</p>
+        </div>
+      </main>
+    );
+  }
+
+  throw error;
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}
+
+function getStockNotice(request: Request): StockNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (notice === "stock-ingredient-added" || notice === "stock-ingredient-removed") {
+    return notice;
+  }
+
+  return null;
+}
+
+function getStockNoticeContent(notice: StockNotice) {
+  switch (notice) {
+    case "stock-ingredient-added":
+      return {
+        description: "Basisvaren ble lagt til i familiens liste.",
+        title: "Basisvare lagt til",
+      };
+    case "stock-ingredient-removed":
+      return {
+        description: "Basisvaren ble fjernet fra familiens liste.",
+        title: "Basisvare fjernet",
+      };
+  }
+}
+
+function buildStockRedirect({
+  familyId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  notice: StockNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/stock-ingredients`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -209,6 +209,12 @@ export default function FamilyRoute({
               </Link>
               <Link
                 className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/stock-ingredients`}
+              >
+                Basisvarer
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                 to="/app"
               >
                 Tilbake til oversikten

--- a/prisma/migrations/20260516173423_add_family_stock_ingredients/migration.sql
+++ b/prisma/migrations/20260516173423_add_family_stock_ingredients/migration.sql
@@ -1,0 +1,30 @@
+-- AlterTable
+ALTER TABLE "ShoppingItemOverride" ADD COLUMN     "includeDespiteStock" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "FamilyStockIngredient" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "ingredientId" TEXT,
+    "displayNameNormalized" TEXT,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FamilyStockIngredient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FamilyStockIngredient_familyId_idx" ON "FamilyStockIngredient"("familyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FamilyStockIngredient_familyId_ingredientId_key" ON "FamilyStockIngredient"("familyId", "ingredientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FamilyStockIngredient_familyId_displayNameNormalized_key" ON "FamilyStockIngredient"("familyId", "displayNameNormalized");
+
+-- AddForeignKey
+ALTER TABLE "FamilyStockIngredient" ADD CONSTRAINT "FamilyStockIngredient_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FamilyStockIngredient" ADD CONSTRAINT "FamilyStockIngredient_ingredientId_fkey" FOREIGN KEY ("ingredientId") REFERENCES "Ingredient"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,8 +67,9 @@ model Family {
   memberships     FamilyMembership[]
   recipes         Recipe[]
   mealPlans       MealPlan[]
-  stores          Store[]
-  storePreferences UserStorePreference[]
+  stores              Store[]
+  storePreferences    UserStorePreference[]
+  stockIngredients    FamilyStockIngredient[]
 
   @@index([createdByUserId])
   @@index([name])
@@ -109,10 +110,27 @@ model Ingredient {
   defaultCategoryId String?
   createdAt         DateTime            @default(now())
   updatedAt         DateTime            @updatedAt
-  defaultCategory   IngredientCategory? @relation(fields: [defaultCategoryId], references: [id], onDelete: SetNull)
-  recipeIngredients RecipeIngredient[]
+  defaultCategory      IngredientCategory?     @relation(fields: [defaultCategoryId], references: [id], onDelete: SetNull)
+  recipeIngredients    RecipeIngredient[]
+  familyStockIngredients FamilyStockIngredient[]
 
   @@index([defaultCategoryId])
+}
+
+model FamilyStockIngredient {
+  id                    String   @id @default(cuid())
+  familyId              String
+  ingredientId          String?
+  displayNameNormalized String?
+  note                  String?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+  family                Family     @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  ingredient            Ingredient? @relation(fields: [ingredientId], references: [id], onDelete: SetNull)
+
+  @@unique([familyId, ingredientId])
+  @@unique([familyId, displayNameNormalized])
+  @@index([familyId])
 }
 
 model Recipe {
@@ -241,11 +259,12 @@ model ShoppingItemOverride {
   mealPlanId         String
   sourceType         ShoppingItemSource
   sourceKey          String
-  checked            Boolean            @default(false)
-  postponedUntilDate DateTime?          @db.Date
-  preferredStoreId   String?
-  note               String?
-  updatedByUserId    String?
+  checked               Boolean            @default(false)
+  includeDespiteStock   Boolean            @default(false)
+  postponedUntilDate    DateTime?          @db.Date
+  preferredStoreId      String?
+  note                  String?
+  updatedByUserId       String?
   createdAt          DateTime           @default(now())
   updatedAt          DateTime           @updatedAt
   mealPlan           MealPlan           @relation(fields: [mealPlanId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary

- Add `FamilyStockIngredient` so families can mark pantry staples (basisvarer) that stay out of auto-generated shopping lists.
- Skip stock-matched recipe lines in shopping projection unless opted in for the current meal plan via `ShoppingItemOverride.includeDespiteStock`.
- Add admin **Basisvarer** page (`/families/:familyId/stock-ingredients`) and an expandable notice on Handleliste with per-item and bulk opt-in.
- Butikkmodus shows a compact link to Handleliste when stock items are in use.

Closes #36

## Test plan

- [x] `npm run test:run -- app/lib/stock.server.test.ts app/lib/stock-write.server.test.ts app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts app/routes/family-stock-ingredients.test.ts app/routes/family-meal-plan-shopping.test.ts app/routes/family-meal-plan-store-mode.test.ts`
- [x] `tsc --noEmit`
- [ ] Manual: configure basisvarer as admin, plan meals using staples, confirm Handleliste excludes them, opt in one item, verify it appears and persists after reload