### PR TITLE
Auto-fill meal plans and shopping list exclude/restore

### DIFF
--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -50,12 +50,14 @@ vi.mock("./write-observability.server", () => {
 
 import {
   approveMealPlan,
+  autoFillMealPlanEntries,
   copyMealPlan,
   createMealPlan,
   deleteMealPlan,
   formatDateOnly,
   getMealPlanForFamily,
   getMealPlanPlanningData,
+  getRecentlyUsedRecipeIds,
   listMealPlansForFamily,
   reopenMealPlan,
   saveMealPlanEntries,
@@ -936,6 +938,281 @@ describe("meal-plan.server", () => {
         title: "Uke 20",
       },
       status: "DELETED",
+    });
+  });
+
+  it("collects recipe ids from the two most recent other meal plans", async () => {
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        entries: [{ recipeId: "recipe-a" }, { recipeId: "recipe-b" }],
+      },
+      {
+        entries: [{ recipeId: "recipe-c" }],
+      },
+    ]);
+
+    const result = await getRecentlyUsedRecipeIds({
+      currentMealPlanId: "meal-plan-3",
+      familyId: "family-1",
+    });
+
+    expect(result).toEqual(new Set(["recipe-a", "recipe-b", "recipe-c"]));
+    expect(dbMock.mealPlan.findMany).toHaveBeenCalledWith({
+      orderBy: {
+        endDate: "desc",
+      },
+      select: {
+        entries: {
+          select: {
+            recipeId: true,
+          },
+          where: {
+            mealType: "DINNER",
+            recipeId: {
+              not: null,
+            },
+          },
+        },
+      },
+      take: 2,
+      where: {
+        familyId: "family-1",
+        id: {
+          not: "meal-plan-3",
+        },
+      },
+    });
+  });
+
+  it("rejects auto-fill for approved meal plans", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      approvedAt: new Date("2026-05-16T09:30:00.000Z"),
+      approvedByUserId: "user-1",
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [],
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "APPROVED",
+      title: "Langhelg",
+      updatedAt: new Date("2026-05-16T09:30:00.000Z"),
+    });
+
+    const result = await autoFillMealPlanEntries({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      formError: "Godkjente ukeplaner kan ikke fylles automatisk.",
+      status: "NOT_DRAFT",
+    });
+    expect(dbMock.recipe.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns NOTHING_TO_FILL when all days already have content", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-16T00:00:00.000Z"),
+      entries: [
+        {
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          locked: false,
+          mealType: "DINNER",
+          note: "",
+          recipe: null,
+          recipeId: "kylling-taco",
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+        {
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          id: "entry-2",
+          locked: false,
+          mealType: "DINNER",
+          note: "Bruk rester",
+          recipe: null,
+          recipeId: null,
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ],
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const result = await autoFillMealPlanEntries({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      filledCount: 0,
+      status: "NOTHING_TO_FILL",
+    });
+    expect(dbMock.mealPlanEntry.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects auto-fill when every recipe was used in recent meal plans", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-16T00:00:00.000Z"),
+      entries: [],
+      id: "meal-plan-3",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 22",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        entries: [{ recipeId: "kylling-taco" }],
+      },
+    ]);
+    dbMock.recipe.findMany.mockResolvedValue([{ id: "kylling-taco" }]);
+
+    const result = await autoFillMealPlanEntries({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-3",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      formError:
+        "Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de to forrige ukeplanene.",
+      status: "NO_ELIGIBLE_RECIPES",
+    });
+    expect(dbMock.mealPlanEntry.upsert).not.toHaveBeenCalled();
+  });
+
+  it("auto-fills only empty days while excluding recent recipes", async () => {
+    const planningMealPlan = {
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-24T00:00:00.000Z"),
+      entries: [
+        {
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          date: new Date("2026-05-22T00:00:00.000Z"),
+          id: "entry-1",
+          locked: false,
+          mealType: "DINNER",
+          note: "",
+          recipe: null,
+          recipeId: "recipe-d",
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ],
+      id: "meal-plan-3",
+      startDate: new Date("2026-05-22T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 22",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    };
+
+    dbMock.mealPlan.findFirst
+      .mockResolvedValueOnce(planningMealPlan)
+      .mockResolvedValueOnce({
+        endDate: planningMealPlan.endDate,
+        id: planningMealPlan.id,
+        startDate: planningMealPlan.startDate,
+      });
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        entries: [{ recipeId: "recipe-a" }],
+      },
+    ]);
+    dbMock.recipe.findMany
+      .mockResolvedValueOnce([
+        { id: "recipe-a" },
+        { id: "recipe-b" },
+        { id: "recipe-c" },
+      ])
+      .mockResolvedValueOnce([{ id: "recipe-b" }, { id: "recipe-c" }, { id: "recipe-d" }]);
+    dbMock.mealPlanEntry.findMany.mockResolvedValue([
+      {
+        date: new Date("2026-05-22T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+
+    const result = await autoFillMealPlanEntries({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-3",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("AUTO_FILLED");
+    expect(result).toMatchObject({
+      excludedCount: 1,
+      filledCount: 2,
+    });
+    expect(dbMock.mealPlanEntry.upsert).toHaveBeenCalledTimes(3);
+    expect(dbMock.mealPlanEntry.deleteMany).not.toHaveBeenCalled();
+
+    const upsertedRecipeIds = dbMock.mealPlanEntry.upsert.mock.calls.map(
+      (call) => call[0].create.recipeId,
+    );
+
+    expect(upsertedRecipeIds).toContain("recipe-d");
+    expect(upsertedRecipeIds).not.toContain("recipe-a");
+    expect(new Set(upsertedRecipeIds).size).toBe(3);
+  });
+
+  it("warns when repeats are required because the eligible pool is too small", async () => {
+    const planningMealPlan = {
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-24T00:00:00.000Z"),
+      entries: [],
+      id: "meal-plan-3",
+      startDate: new Date("2026-05-22T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 22",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    };
+
+    dbMock.mealPlan.findFirst
+      .mockResolvedValueOnce(planningMealPlan)
+      .mockResolvedValueOnce({
+        endDate: planningMealPlan.endDate,
+        id: planningMealPlan.id,
+        startDate: planningMealPlan.startDate,
+      });
+    dbMock.mealPlan.findMany.mockResolvedValue([]);
+    dbMock.recipe.findMany
+      .mockResolvedValueOnce([{ id: "recipe-b" }])
+      .mockResolvedValueOnce([{ id: "recipe-b" }]);
+
+    const result = await autoFillMealPlanEntries({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-3",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      excludedCount: 0,
+      filledCount: 3,
+      status: "AUTO_FILLED",
+      warning:
+        "Noen middager ble valgt flere ganger fordi det var for fa oppskrifter igjen.",
     });
   });
 });

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -1,3 +1,5 @@
+import { randomInt } from "node:crypto";
+
 import { MealPlanStatus, MealType, Prisma, RecipeScope } from "@prisma/client";
 
 import {
@@ -149,7 +151,15 @@ interface MealPlanListInput {
 
 type MealPlanPlanningInput = GetMealPlanInput;
 
+interface AutoFillMealPlanEntriesInput extends DeleteMealPlanInput {}
+
 type MealPlanApprovalAction = "APPROVE" | "REOPEN";
+
+const AUTO_FILL_NOT_DRAFT_MESSAGE = "Godkjente ukeplaner kan ikke fylles automatisk.";
+const AUTO_FILL_NO_ELIGIBLE_RECIPES_MESSAGE =
+  "Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de to forrige ukeplanene.";
+const AUTO_FILL_REPEAT_WARNING_MESSAGE =
+  "Noen middager ble valgt flere ganger fordi det var for fa oppskrifter igjen.";
 
 export function formatDateOnly(date: Date) {
   return [
@@ -681,6 +691,179 @@ export async function deleteMealPlan({ familyId, mealPlanId, userId }: DeleteMea
   };
 }
 
+export async function getRecentlyUsedRecipeIds({
+  currentMealPlanId,
+  familyId,
+}: {
+  currentMealPlanId: string;
+  familyId: string;
+}) {
+  const priorPlans = await db.mealPlan.findMany({
+    orderBy: {
+      endDate: "desc",
+    },
+    select: {
+      entries: {
+        select: {
+          recipeId: true,
+        },
+        where: {
+          mealType: PLANNING_MEAL_TYPE,
+          recipeId: {
+            not: null,
+          },
+        },
+      },
+    },
+    take: 2,
+    where: {
+      familyId,
+      id: {
+        not: currentMealPlanId,
+      },
+    },
+  });
+
+  return new Set(
+    priorPlans.flatMap((plan) =>
+      plan.entries
+        .map((entry) => entry.recipeId)
+        .filter((recipeId): recipeId is string => Boolean(recipeId)),
+    ),
+  );
+}
+
+export async function autoFillMealPlanEntries({
+  familyId,
+  mealPlanId,
+  userId,
+}: AutoFillMealPlanEntriesInput) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: mealPlanPlanningDetailSelect,
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (mealPlan.status !== MealPlanStatus.DRAFT) {
+    return {
+      formError: AUTO_FILL_NOT_DRAFT_MESSAGE,
+      status: "NOT_DRAFT" as const,
+    };
+  }
+
+  const visibleDates = getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate);
+  const dinnerEntriesByDate = new Map(
+    mealPlan.entries
+      .filter((entry) => entry.mealType === PLANNING_MEAL_TYPE)
+      .map((entry) => [formatDateOnly(entry.date), entry]),
+  );
+  const targetDates = visibleDates.filter((date) => {
+    const entry = dinnerEntriesByDate.get(date);
+
+    return !entry?.recipeId && !entry?.note;
+  });
+
+  if (targetDates.length === 0) {
+    return {
+      filledCount: 0,
+      status: "NOTHING_TO_FILL" as const,
+    };
+  }
+
+  const recipes = await db.recipe.findMany({
+    orderBy: [{ title: "asc" }],
+    select: {
+      id: true,
+    },
+    where: {
+      OR: [{ scope: RecipeScope.GLOBAL }, { familyId, scope: RecipeScope.FAMILY }],
+    },
+  });
+  const excludedRecipeIds = await getRecentlyUsedRecipeIds({
+    currentMealPlanId: mealPlan.id,
+    familyId,
+  });
+  const eligibleRecipeIds = recipes
+    .map((recipe) => recipe.id)
+    .filter((recipeId) => !excludedRecipeIds.has(recipeId));
+
+  if (eligibleRecipeIds.length === 0) {
+    return {
+      formError: AUTO_FILL_NO_ELIGIBLE_RECIPES_MESSAGE,
+      status: "NO_ELIGIBLE_RECIPES" as const,
+    };
+  }
+
+  const usedRecipeIdsInPlan = new Set(
+    [...dinnerEntriesByDate.values()]
+      .map((entry) => entry.recipeId)
+      .filter((recipeId): recipeId is string => Boolean(recipeId)),
+  );
+  const { assignments, hadRepeats } = assignRecipesToDates({
+    eligibleRecipeIds,
+    targetDateCount: targetDates.length,
+    usedRecipeIdsInPlan,
+  });
+  const assignmentsByDate = new Map(
+    targetDates.map((date, index) => [date, assignments[index]!]),
+  );
+  const entries = visibleDates.map((date) => {
+    const existingEntry = dinnerEntriesByDate.get(date);
+    const assignedRecipeId = assignmentsByDate.get(date);
+
+    if (assignedRecipeId) {
+      return {
+        date,
+        note: "",
+        recipeId: assignedRecipeId,
+      };
+    }
+
+    return {
+      date,
+      note: existingEntry?.note ?? "",
+      recipeId: existingEntry?.recipeId ?? "",
+    };
+  });
+  const entryVersions = Object.fromEntries(
+    visibleDates.map((date) => [
+      date,
+      dinnerEntriesByDate.get(date)?.updatedAt.toISOString() ?? "",
+    ]),
+  );
+  const saveResult = await saveMealPlanEntries({
+    entries,
+    entryVersions,
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (saveResult.status !== "UPDATED") {
+    return saveResult;
+  }
+
+  return {
+    excludedCount: excludedRecipeIds.size,
+    filledCount: targetDates.length,
+    status: "AUTO_FILLED" as const,
+    warning: hadRepeats ? AUTO_FILL_REPEAT_WARNING_MESSAGE : undefined,
+  };
+}
+
 export async function saveMealPlanEntries({
   entries,
   entryVersions,
@@ -1078,6 +1261,53 @@ function getMealPlanApprovalTransitionError(action: MealPlanApprovalAction, curr
   }
 
   return "Ukeplanen kan ikke gjenapnes fra gjeldende status.";
+}
+
+function shuffleRecipeIds(recipeIds: string[]) {
+  const shuffled = [...recipeIds];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = randomInt(0, index + 1);
+    const currentValue = shuffled[index]!;
+    shuffled[index] = shuffled[swapIndex]!;
+    shuffled[swapIndex] = currentValue;
+  }
+
+  return shuffled;
+}
+
+function assignRecipesToDates({
+  eligibleRecipeIds,
+  targetDateCount,
+  usedRecipeIdsInPlan,
+}: {
+  eligibleRecipeIds: string[];
+  targetDateCount: number;
+  usedRecipeIdsInPlan: Set<string>;
+}) {
+  const uniquePool = shuffleRecipeIds(
+    eligibleRecipeIds.filter((recipeId) => !usedRecipeIdsInPlan.has(recipeId)),
+  );
+  const assignments: string[] = [];
+  let hadRepeats = false;
+
+  for (let index = 0; index < targetDateCount; index += 1) {
+    if (index < uniquePool.length) {
+      const recipeId = uniquePool[index]!;
+      assignments.push(recipeId);
+      usedRecipeIdsInPlan.add(recipeId);
+      continue;
+    }
+
+    hadRepeats = true;
+    const repeatPool = shuffleRecipeIds(eligibleRecipeIds);
+    assignments.push(repeatPool[index % repeatPool.length]!);
+  }
+
+  return {
+    assignments,
+    hadRepeats,
+  };
 }
 
 function normalizeMealPlanEntryValues(entry: MealPlanEntryValues): MealPlanEntryValues {

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -151,7 +151,7 @@ interface MealPlanListInput {
 
 type MealPlanPlanningInput = GetMealPlanInput;
 
-interface AutoFillMealPlanEntriesInput extends DeleteMealPlanInput {}
+type AutoFillMealPlanEntriesInput = DeleteMealPlanInput;
 
 type MealPlanApprovalAction = "APPROVE" | "REOPEN";
 

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -92,7 +92,9 @@ vi.mock("./stock.server", () => {
 import {
   createManualShoppingItem,
   deleteManualShoppingItem,
+  excludeGeneratedShoppingItem,
   optInStockShoppingItems,
+  restoreGeneratedShoppingItem,
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
   updateGeneratedShoppingItemOverride,
@@ -273,15 +275,12 @@ describe("shopping-write.server", () => {
     });
     dbMock.shoppingItemOverride.findUnique.mockResolvedValue({
       checked: true,
-      createdAt: new Date("2026-05-15T00:00:00.000Z"),
+      excludedFromList: false,
       id: "override-1",
       includeDespiteStock: false,
-      mealPlanId: "meal-plan-1",
       note: null,
       postponedUntilDate: null,
       preferredStoreId: null,
-      sourceKey: "entry-1:ingredient-1",
-      sourceType: ShoppingItemSource.GENERATED,
       updatedAt: new Date("2026-05-15T00:00:00.000Z"),
     });
 
@@ -304,6 +303,7 @@ describe("shopping-write.server", () => {
     expect(dbMock.shoppingItemOverride.updateMany).toHaveBeenCalledWith({
       data: {
         checked: true,
+        excludedFromList: false,
         includeDespiteStock: false,
         note: "Husk tilbud",
         postponedUntilDate: new Date("2026-05-17T00:00:00.000Z"),
@@ -315,6 +315,68 @@ describe("shopping-write.server", () => {
         updatedAt: new Date("2026-05-15T00:00:00.000Z"),
       },
     });
+  });
+
+  it("marks a generated shopping item as excluded from the list", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue(null);
+
+    const result = await excludeGeneratedShoppingItem({
+      expectedUpdatedAt: "",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "EXCLUDED",
+    });
+    expect(dbMock.shoppingItemOverride.create).toHaveBeenCalledWith({
+      data: {
+        checked: false,
+        excludedFromList: true,
+        includeDespiteStock: false,
+        mealPlanId: "meal-plan-1",
+        note: null,
+        postponedUntilDate: null,
+        preferredStoreId: null,
+        sourceKey: "entry-1:ingredient-1",
+        sourceType: ShoppingItemSource.GENERATED,
+        updatedByUserId: "user-1",
+      },
+    });
+  });
+
+  it("restores a generated shopping item by clearing excludedFromList", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue({
+      checked: false,
+      excludedFromList: true,
+      id: "override-1",
+      includeDespiteStock: false,
+      note: null,
+      postponedUntilDate: null,
+      preferredStoreId: null,
+      updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+    });
+
+    const result = await restoreGeneratedShoppingItem({
+      expectedUpdatedAt: new Date("2026-05-15T00:00:00.000Z").toISOString(),
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "RESTORED",
+    });
+    expect(dbMock.shoppingItemOverride.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: "override-1",
+        updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+      },
+    });
+    expect(dbMock.shoppingItemOverride.updateMany).not.toHaveBeenCalled();
   });
 
   it("opts stock ingredients into the generated shopping list", async () => {

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -375,6 +375,282 @@ export async function deleteManualShoppingItem({
   }
 }
 
+export async function excludeGeneratedShoppingItem({
+  expectedUpdatedAt,
+  familyId,
+  mealPlanId,
+  sourceKey,
+  userId,
+}: {
+  expectedUpdatedAt: string;
+  familyId: string;
+  mealPlanId: string;
+  sourceKey: string;
+  userId: string;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const existingOverride = await db.shoppingItemOverride.findUnique({
+    select: {
+      checked: true,
+      id: true,
+      includeDespiteStock: true,
+      note: true,
+      postponedUntilDate: true,
+      preferredStoreId: true,
+      updatedAt: true,
+    },
+    where: {
+      mealPlanId_sourceType_sourceKey: {
+        mealPlanId: mealPlan.id,
+        sourceKey,
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+    },
+  });
+
+  if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingOverride?.updatedAt)) {
+    return buildShoppingConflictResult({
+      action: "exclude-generated-shopping-item",
+      entityId: existingOverride?.id ?? sourceKey,
+      entityType: "shopping-item-override",
+      familyId,
+      mealPlanId: mealPlan.id,
+      userId,
+    });
+  }
+
+  const nextData = {
+    checked: existingOverride?.checked ?? false,
+    excludedFromList: true,
+    includeDespiteStock: existingOverride?.includeDespiteStock ?? false,
+    note: existingOverride?.note ?? null,
+    postponedUntilDate: existingOverride?.postponedUntilDate ?? null,
+    preferredStoreId: existingOverride?.preferredStoreId ?? null,
+  };
+
+  try {
+    if (existingOverride) {
+      const updateResult = await db.shoppingItemOverride.updateMany({
+        data: {
+          ...nextData,
+          ...buildActorUpdate(userId),
+        },
+        where: {
+          id: existingOverride.id,
+          updatedAt: existingOverride.updatedAt,
+        },
+      });
+
+      if (updateResult.count === 0) {
+        return buildShoppingConflictResult({
+          action: "exclude-generated-shopping-item",
+          entityId: existingOverride.id,
+          entityType: "shopping-item-override",
+          familyId,
+          mealPlanId: mealPlan.id,
+          userId,
+        });
+      }
+    } else {
+      await db.shoppingItemOverride.create({
+        data: {
+          ...nextData,
+          mealPlanId: mealPlan.id,
+          sourceKey,
+          sourceType: ShoppingItemSource.GENERATED,
+          ...buildActorUpdate(userId),
+        },
+      });
+    }
+
+    logCollaborationWrite({
+      action: "exclude-generated-shopping-item",
+      domain: "shopping",
+      entityId: existingOverride?.id ?? sourceKey,
+      entityType: "shopping-item-override",
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "UPDATED",
+      userId,
+    });
+
+    return {
+      status: "EXCLUDED" as const,
+    };
+  } catch (error) {
+    logCollaborationFailure({
+      action: "exclude-generated-shopping-item",
+      domain: "shopping",
+      entityId: existingOverride?.id ?? sourceKey,
+      entityType: "shopping-item-override",
+      error,
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "VALIDATION_ERROR",
+      userId,
+    });
+
+    throw error;
+  }
+}
+
+export async function restoreGeneratedShoppingItem({
+  expectedUpdatedAt,
+  familyId,
+  mealPlanId,
+  sourceKey,
+  userId,
+}: {
+  expectedUpdatedAt: string;
+  familyId: string;
+  mealPlanId: string;
+  sourceKey: string;
+  userId: string;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const existingOverride = await db.shoppingItemOverride.findUnique({
+    select: {
+      checked: true,
+      excludedFromList: true,
+      id: true,
+      includeDespiteStock: true,
+      note: true,
+      postponedUntilDate: true,
+      preferredStoreId: true,
+      updatedAt: true,
+    },
+    where: {
+      mealPlanId_sourceType_sourceKey: {
+        mealPlanId: mealPlan.id,
+        sourceKey,
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+    },
+  });
+
+  if (!existingOverride?.excludedFromList) {
+    return {
+      formError: "Varelinjen er ikke fjernet fra handlelisten.",
+      status: "NOT_EXCLUDED" as const,
+    };
+  }
+
+  if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingOverride.updatedAt)) {
+    return buildShoppingConflictResult({
+      action: "restore-generated-shopping-item",
+      entityId: existingOverride.id,
+      entityType: "shopping-item-override",
+      familyId,
+      mealPlanId: mealPlan.id,
+      userId,
+    });
+  }
+
+  const nextData = {
+    checked: existingOverride.checked,
+    excludedFromList: false,
+    includeDespiteStock: existingOverride.includeDespiteStock,
+    note: existingOverride.note,
+    postponedUntilDate: existingOverride.postponedUntilDate,
+    preferredStoreId: existingOverride.preferredStoreId,
+  };
+
+  try {
+    if (isOverrideEmpty(nextData)) {
+      const deleteResult = await db.shoppingItemOverride.deleteMany({
+        where: {
+          id: existingOverride.id,
+          updatedAt: existingOverride.updatedAt,
+        },
+      });
+
+      if (deleteResult.count === 0) {
+        return buildShoppingConflictResult({
+          action: "restore-generated-shopping-item",
+          entityId: existingOverride.id,
+          entityType: "shopping-item-override",
+          familyId,
+          mealPlanId: mealPlan.id,
+          userId,
+        });
+      }
+    } else {
+      const updateResult = await db.shoppingItemOverride.updateMany({
+        data: {
+          ...nextData,
+          ...buildActorUpdate(userId),
+        },
+        where: {
+          id: existingOverride.id,
+          updatedAt: existingOverride.updatedAt,
+        },
+      });
+
+      if (updateResult.count === 0) {
+        return buildShoppingConflictResult({
+          action: "restore-generated-shopping-item",
+          entityId: existingOverride.id,
+          entityType: "shopping-item-override",
+          familyId,
+          mealPlanId: mealPlan.id,
+          userId,
+        });
+      }
+    }
+
+    logCollaborationWrite({
+      action: "restore-generated-shopping-item",
+      domain: "shopping",
+      entityId: existingOverride.id,
+      entityType: "shopping-item-override",
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "UPDATED",
+      userId,
+    });
+
+    return {
+      status: "RESTORED" as const,
+    };
+  } catch (error) {
+    logCollaborationFailure({
+      action: "restore-generated-shopping-item",
+      domain: "shopping",
+      entityId: existingOverride.id,
+      entityType: "shopping-item-override",
+      error,
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "VALIDATION_ERROR",
+      userId,
+    });
+
+    throw error;
+  }
+}
+
 export async function toggleShoppingItemChecked({
   checked,
   expectedUpdatedAt,
@@ -425,6 +701,7 @@ export async function toggleShoppingItemChecked({
   const existingOverride = await db.shoppingItemOverride.findUnique({
     select: {
       checked: true,
+      excludedFromList: true,
       id: true,
       includeDespiteStock: true,
       note: true,
@@ -654,6 +931,7 @@ export async function optInStockShoppingItems({
       const existingOverride = await db.shoppingItemOverride.findUnique({
         select: {
           checked: true,
+          excludedFromList: true,
           id: true,
           note: true,
           postponedUntilDate: true,
@@ -671,6 +949,7 @@ export async function optInStockShoppingItems({
       await db.shoppingItemOverride.upsert({
         create: {
           checked: existingOverride?.checked ?? false,
+          excludedFromList: existingOverride?.excludedFromList ?? false,
           includeDespiteStock: true,
           mealPlanId: mealPlan.id,
           note: existingOverride?.note ?? null,
@@ -769,6 +1048,7 @@ export async function updateGeneratedShoppingItemOverride({
   const existingOverride = await db.shoppingItemOverride.findUnique({
     select: {
       checked: true,
+      excludedFromList: true,
       id: true,
       includeDespiteStock: true,
       note: true,
@@ -798,12 +1078,14 @@ export async function updateGeneratedShoppingItemOverride({
 
   const nextData: {
     checked: boolean;
+    excludedFromList: boolean;
     includeDespiteStock: boolean;
     note: string | null;
     postponedUntilDate: Date | null;
     preferredStoreId: string | null;
   } = {
     checked: existingOverride?.checked ?? false,
+    excludedFromList: existingOverride?.excludedFromList ?? false,
     includeDespiteStock: existingOverride?.includeDespiteStock ?? false,
     note: validation.values.note || null,
     postponedUntilDate: validation.postponedUntilDate ?? null,
@@ -1314,6 +1596,7 @@ function parseDateOnly(value: string) {
 }
 
 function shouldDeleteOverrideAfterUnchecked(existingOverride: {
+  excludedFromList: boolean;
   includeDespiteStock: boolean;
   note: string | null;
   postponedUntilDate: Date | null;
@@ -1325,6 +1608,7 @@ function shouldDeleteOverrideAfterUnchecked(existingOverride: {
   }
 
   return (
+    !existingOverride.excludedFromList &&
     !existingOverride.includeDespiteStock &&
     !existingOverride.note &&
     !existingOverride.postponedUntilDate &&
@@ -1334,6 +1618,7 @@ function shouldDeleteOverrideAfterUnchecked(existingOverride: {
 
 function isOverrideEmpty(values: {
   checked: boolean;
+  excludedFromList: boolean;
   includeDespiteStock: boolean;
   note: string | null;
   postponedUntilDate: Date | null;
@@ -1341,6 +1626,7 @@ function isOverrideEmpty(values: {
 }) {
   return (
     !values.checked &&
+    !values.excludedFromList &&
     !values.includeDespiteStock &&
     !values.note &&
     !values.postponedUntilDate &&

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -852,6 +852,7 @@ describe("shopping.server", () => {
       shoppingOverrides: [
         {
           checked: false,
+          excludedFromList: false,
           includeDespiteStock: true,
           note: null,
           postponedUntilDate: null,
@@ -884,6 +885,100 @@ describe("shopping.server", () => {
     expect(result.itemCounts.generated).toBe(1);
     expect(result.projectedItems[0]?.name).toBe("Lime");
     expect(result.stockIngredientCount).toBe(0);
+  });
+
+  it("omits generated shopping items marked as excluded from the list", async () => {
+    getFamilyStockMatchSetMock.mockResolvedValue({
+      displayNameNormalized: new Set(),
+      ingredientIds: new Set(),
+    });
+
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: null,
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  displayName: "Frukt og gront",
+                  id: "category-produce",
+                },
+                categoryId: "category-produce",
+                displayName: "Lime",
+                id: "ingredient-1",
+                ingredientId: "canonical-lime",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+              {
+                amount: "1",
+                category: {
+                  displayName: "Brod",
+                  id: "category-bakery",
+                },
+                categoryId: "category-bakery",
+                displayName: "Tortillalefser",
+                id: "ingredient-2",
+                ingredientId: "canonical-tortilla",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 2,
+                unit: "pk",
+              },
+            ],
+            title: "Taco",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [
+        {
+          checked: false,
+          excludedFromList: true,
+          includeDespiteStock: false,
+          note: null,
+          postponedUntilDate: null,
+          preferredStore: null,
+          preferredStoreId: null,
+          sourceKey: "entry-1:ingredient-1",
+          sourceType: "GENERATED",
+          updatedAt: new Date("2026-05-15T10:00:00.000Z"),
+        },
+      ],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 20",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [],
+      },
+    ]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.itemCounts.generated).toBe(1);
+    expect(result.projectedItems.map((item) => item.name)).toEqual(["Tortillalefser"]);
+    expect(result.excludedGeneratedItems.map((item) => item.name)).toEqual(["Lime"]);
+    expect(result.excludedGeneratedCount).toBe(1);
   });
 
   it("throws a not-found response when the meal plan is outside the family scope", async () => {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -61,6 +61,7 @@ const generatedShoppingMealPlanEntrySelect =
 const shoppingOverrideSelect =
   Prisma.validator<Prisma.ShoppingItemOverrideSelect>()({
     checked: true,
+    excludedFromList: true,
     id: true,
     includeDespiteStock: true,
     note: true,
@@ -331,12 +332,18 @@ export async function getMealPlanShoppingData({
     mealPlan,
     stores,
   });
+  const excludedGeneratedItems = projectExcludedGeneratedShoppingItems({
+    mealPlan,
+    stores,
+  });
   const projectedItems = [...generatedItems, ...manualItems].sort(
     compareProjectedItems,
   );
 
   return {
     categories,
+    excludedGeneratedCount: excludedGeneratedItems.length,
+    excludedGeneratedItems,
     family: {
       id: membership.family.id,
       name: membership.family.name,
@@ -522,7 +529,6 @@ function projectGeneratedShoppingItems({
   stockMatchSet: FamilyStockMatchSet;
   stores: ShoppingStore[];
 }) {
-  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
   const overrideBySourceKey = buildOverrideMap(
     mealPlan.shoppingOverrides,
     ShoppingItemSource.GENERATED,
@@ -531,43 +537,94 @@ function projectGeneratedShoppingItems({
   return buildGeneratedProjectionBuckets(mealPlan)
     .filter((bucket) => {
       const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
+      const override = overrideBySourceKey.get(sourceKey);
+
+      if (override?.excludedFromList) {
+        return false;
+      }
+
       const isStock = isStockIngredientMatch(bucket, stockMatchSet);
 
       return !isStock || includeDespiteStockKeys.has(sourceKey);
     })
-    .map((bucket) => {
+    .map((bucket) =>
+      mapGeneratedProjectionBucketToItem({
+        bucket,
+        overrideBySourceKey,
+        stores,
+      }),
+    );
+}
+
+function projectExcludedGeneratedShoppingItems({
+  mealPlan,
+  stores,
+}: {
+  mealPlan: ShoppingMealPlan;
+  stores: ShoppingStore[];
+}) {
+  const overrideBySourceKey = buildOverrideMap(
+    mealPlan.shoppingOverrides,
+    ShoppingItemSource.GENERATED,
+  );
+
+  return buildGeneratedProjectionBuckets(mealPlan).flatMap((bucket) => {
     const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
     const override = overrideBySourceKey.get(sourceKey);
-    const preferredStore = override?.preferredStore ?? bucket.preferredStore;
-    const section = resolveStoreSection({
-      category: bucket.category,
-      preferredStore,
-      storeSectionsByStoreId,
-    });
-    const occurrences = [...bucket.occurrences].sort(
-      compareProjectedOccurrences,
-    );
 
-    return {
-      amount: bucket.amount,
-      category: bucket.category,
-      checked: override?.checked ?? false,
-      firstDate: occurrences[0]!.date,
-      lastDate: occurrences[occurrences.length - 1]!.date,
-      name: bucket.name,
-      note: override?.note ?? null,
-      occurrenceCount: occurrences.length,
-      occurrences,
-      collaborationVersion: override?.updatedAt?.toISOString() ?? "",
-      postponedUntilDate: override?.postponedUntilDate ?? null,
-      preferredStore,
-      quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
-      section,
-      sourceKey,
-      sourceType: ShoppingItemSource.GENERATED,
-      unit: bucket.unit,
-    } satisfies ProjectedGeneratedShoppingItem;
-    });
+    if (!override?.excludedFromList) {
+      return [];
+    }
+
+    return [
+      mapGeneratedProjectionBucketToItem({
+        bucket,
+        overrideBySourceKey,
+        stores,
+      }),
+    ];
+  });
+}
+
+function mapGeneratedProjectionBucketToItem({
+  bucket,
+  overrideBySourceKey,
+  stores,
+}: {
+  bucket: GeneratedProjectionBucket;
+  overrideBySourceKey: Map<string, ShoppingOverride>;
+  stores: ShoppingStore[];
+}) {
+  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
+  const sourceKey = buildMergedGeneratedSourceKey(bucket.occurrenceKeys);
+  const override = overrideBySourceKey.get(sourceKey);
+  const preferredStore = override?.preferredStore ?? bucket.preferredStore;
+  const section = resolveStoreSection({
+    category: bucket.category,
+    preferredStore,
+    storeSectionsByStoreId,
+  });
+  const occurrences = [...bucket.occurrences].sort(compareProjectedOccurrences);
+
+  return {
+    amount: bucket.amount,
+    category: bucket.category,
+    checked: override?.checked ?? false,
+    firstDate: occurrences[0]!.date,
+    lastDate: occurrences[occurrences.length - 1]!.date,
+    name: bucket.name,
+    note: override?.note ?? null,
+    occurrenceCount: occurrences.length,
+    occurrences,
+    collaborationVersion: override?.updatedAt?.toISOString() ?? "",
+    postponedUntilDate: override?.postponedUntilDate ?? null,
+    preferredStore,
+    quantityLabel: buildQuantityLabel(bucket.amount, bucket.unit),
+    section,
+    sourceKey,
+    sourceType: ShoppingItemSource.GENERATED,
+    unit: bucket.unit,
+  } satisfies ProjectedGeneratedShoppingItem;
 }
 
 function buildGeneratedProjectionBuckets(mealPlan: ShoppingMealPlan) {

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -68,6 +68,8 @@ describe("family meal plan shopping route", () => {
         id: "family-1",
         name: "Solberg",
       },
+      excludedGeneratedCount: 0,
+      excludedGeneratedItems: [],
       itemCounts: {
         generated: 1,
         manual: 1,
@@ -252,6 +254,8 @@ describe("family meal plan shopping route", () => {
       userId: "user-1",
     });
     expect(result).toEqual({
+      excludedGeneratedCount: 0,
+      excludedGeneratedItems: [],
       family: {
         id: "family-1",
         name: "Solberg",
@@ -380,6 +384,8 @@ describe("family meal plan shopping route", () => {
         id: "family-1",
         name: "Solberg",
       },
+      excludedGeneratedCount: 0,
+      excludedGeneratedItems: [],
       itemCounts: {
         generated: 1,
         manual: 0,

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -12,7 +12,9 @@ import { getMealPlanShoppingData } from "../lib/shopping.server";
 import {
   createManualShoppingItem,
   deleteManualShoppingItem,
+  excludeGeneratedShoppingItem,
   optInStockShoppingItems,
+  restoreGeneratedShoppingItem,
   toggleShoppingItemChecked,
   updateGeneratedShoppingItemOverride,
   updateManualShoppingItem,
@@ -23,6 +25,8 @@ import {
 } from "../lib/shopping-write.server";
 
 type ShoppingNotice =
+  | "generated-shopping-item-excluded"
+  | "generated-shopping-item-restored"
   | "generated-shopping-item-updated"
   | "manual-shopping-item-added"
   | "manual-shopping-item-deleted"
@@ -33,7 +37,9 @@ type ShoppingNotice =
 type ShoppingIntent =
   | "add-manual-shopping-item"
   | "delete-manual-shopping-item"
+  | "exclude-generated-shopping-item"
   | "opt-in-stock-shopping-item"
+  | "restore-generated-shopping-item"
   | "opt-in-stock-shopping-items"
   | "toggle-shopping-item-checked"
   | "update-generated-shopping-item"
@@ -115,6 +121,10 @@ export async function loader({
       startDate: formatDateOnly(result.mealPlan.startDate),
       updatedAt: result.mealPlan.updatedAt.toISOString(),
     },
+    excludedGeneratedCount: result.excludedGeneratedCount,
+    excludedGeneratedItems: result.excludedGeneratedItems.map(
+      serializeProjectedShoppingItem,
+    ),
     notice: getShoppingNotice(request),
     storeGroups: result.storeGroups.map((group) => ({
       sections: group.sections.map((section) => ({
@@ -124,13 +134,15 @@ export async function loader({
       store: group.store,
     })),
     stockIngredientCount: result.stockIngredientCount,
-    stockIngredientsForPlan: result.stockIngredientsForPlan.map((ingredient) => ({
-      ...ingredient,
-      occurrences: ingredient.occurrences.map((occurrence) => ({
-        ...occurrence,
-        date: formatDateOnly(occurrence.date),
-      })),
-    })),
+    stockIngredientsForPlan: result.stockIngredientsForPlan.map(
+      (ingredient) => ({
+        ...ingredient,
+        occurrences: ingredient.occurrences.map((occurrence) => ({
+          ...occurrence,
+          date: formatDateOnly(occurrence.date),
+        })),
+      }),
+    ),
     stores: result.stores,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
@@ -251,6 +263,87 @@ export async function action({
       familyId,
       mealPlanId,
       notice: "manual-shopping-item-deleted",
+      request,
+    });
+  }
+
+  if (intent === "exclude-generated-shopping-item") {
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+
+    if (!sourceKey) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle fjernes.",
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    const result = await excludeGeneratedShoppingItem({
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      mealPlanId,
+      sourceKey,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "generated-shopping-item-excluded",
+      request,
+    });
+  }
+
+  if (intent === "restore-generated-shopping-item") {
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+
+    if (!sourceKey) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle legges tilbake.",
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    const result = await restoreGeneratedShoppingItem({
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      mealPlanId,
+      sourceKey,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "NOT_EXCLUDED") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "generated-shopping-item-restored",
       request,
     });
   }
@@ -553,6 +646,82 @@ export default function FamilyMealPlanShoppingRoute({
           </section>
         ) : null}
 
+        {loaderData.excludedGeneratedCount > 0 ? (
+          <section className="rounded-[28px] border border-slate-200 bg-slate-50 px-6 py-5 text-slate-950 shadow-sm">
+            <details open>
+              <summary className="cursor-pointer text-base font-semibold">
+                {loaderData.excludedGeneratedCount} varelinjer fjernet fra
+                listen
+              </summary>
+              <div className="mt-4 space-y-4">
+                <p className="text-sm leading-6 text-slate-600">
+                  Disse varene er skjult fra handlelisten, men ligger fortsatt i
+                  ukeplanen. Du kan legge dem tilbake nar du trenger dem.
+                </p>
+                <ul className="grid gap-3">
+                  {loaderData.excludedGeneratedItems.map((item) => {
+                    const isPendingRestore =
+                      navigation.state === "submitting" &&
+                      pendingIntent === "restore-generated-shopping-item" &&
+                      pendingSourceKey === item.sourceKey;
+
+                    return (
+                      <li
+                        key={item.sourceKey}
+                        className="rounded-[20px] border border-slate-200 bg-white px-4 py-4"
+                      >
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div>
+                          <p className="text-sm font-semibold text-slate-950">
+                            {item.name}
+                            {item.quantityLabel
+                              ? ` · ${item.quantityLabel}`
+                              : ""}
+                          </p>
+                          {item.sourceType === "GENERATED" ? (
+                            <p className="mt-1 text-xs leading-5 text-slate-600">
+                              {item.occurrenceCount === 1
+                                ? `Fra ${item.occurrences[0]?.recipeTitle}`
+                                : `Fra ${item.occurrenceCount} planlagte middager`}
+                            </p>
+                          ) : null}
+                          </div>
+                          <Form method="post">
+                          <input
+                            name="intent"
+                            type="hidden"
+                            value="restore-generated-shopping-item"
+                          />
+                          <input
+                            name="sourceKey"
+                            type="hidden"
+                            value={item.sourceKey}
+                          />
+                          <input
+                            name="expectedUpdatedAt"
+                            type="hidden"
+                            value={item.collaborationVersion}
+                          />
+                          <button
+                            className="rounded-xl bg-slate-950 px-4 py-2 text-xs font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                            disabled={isPendingRestore}
+                            type="submit"
+                          >
+                            {isPendingRestore
+                              ? "Legger tilbake..."
+                              : "Legg tilbake i handlelisten"}
+                          </button>
+                        </Form>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            </details>
+          </section>
+        ) : null}
+
         <section className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
@@ -800,6 +969,11 @@ export default function FamilyMealPlanShoppingRoute({
                             pendingIntent ===
                               "update-generated-shopping-item" &&
                             pendingSourceKey === item.sourceKey;
+                          const isPendingGeneratedExclude =
+                            navigation.state === "submitting" &&
+                            pendingIntent ===
+                              "exclude-generated-shopping-item" &&
+                            pendingSourceKey === item.sourceKey;
                           const manualValues =
                             actionData?.intent ===
                               "update-manual-shopping-item" &&
@@ -961,7 +1135,7 @@ export default function FamilyMealPlanShoppingRoute({
                                           : "Krysser av..."
                                         : item.checked
                                           ? "Fjern avkryssing"
-                                          : "Marker som kjopt"}
+                                          : "Marker som kjøpt"}
                                     </button>
                                   </Form>
 
@@ -1061,12 +1235,47 @@ export default function FamilyMealPlanShoppingRoute({
 
                                       <button
                                         className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
-                                        disabled={isPendingGeneratedSave}
+                                        disabled={
+                                          isPendingGeneratedSave ||
+                                          isPendingGeneratedExclude
+                                        }
                                         type="submit"
                                       >
                                         {isPendingGeneratedSave
                                           ? "Lagrer tilpasninger..."
                                           : "Lagre tilpasninger"}
+                                      </button>
+                                    </Form>
+                                  ) : null}
+
+                                  {item.sourceType === "GENERATED" ? (
+                                    <Form method="post">
+                                      <input
+                                        name="intent"
+                                        type="hidden"
+                                        value="exclude-generated-shopping-item"
+                                      />
+                                      <input
+                                        name="sourceKey"
+                                        type="hidden"
+                                        value={item.sourceKey}
+                                      />
+                                      <input
+                                        name="expectedUpdatedAt"
+                                        type="hidden"
+                                        value={item.collaborationVersion}
+                                      />
+                                      <button
+                                        className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
+                                        disabled={
+                                          isPendingGeneratedExclude ||
+                                          isPendingGeneratedSave
+                                        }
+                                        type="submit"
+                                      >
+                                        {isPendingGeneratedExclude
+                                          ? "Fjerner varelinje..."
+                                          : "Fjern fra handlelisten"}
                                       </button>
                                     </Form>
                                   ) : null}
@@ -1460,6 +1669,8 @@ function getShoppingNotice(request: Request): ShoppingNotice | null {
   const notice = new URL(request.url).searchParams.get("notice");
 
   if (
+    notice === "generated-shopping-item-excluded" ||
+    notice === "generated-shopping-item-restored" ||
     notice === "generated-shopping-item-updated" ||
     notice === "manual-shopping-item-added" ||
     notice === "manual-shopping-item-deleted" ||
@@ -1511,6 +1722,18 @@ function getShoppingNoticeContent(notice: ShoppingNotice) {
         description:
           "Den manuelle varelinjen og eventuell avkryssing ble fjernet fra handlelisten.",
         title: "Varelinje slettet",
+      };
+    case "generated-shopping-item-excluded":
+      return {
+        description:
+          "Varelinjen ble fjernet fra handlelisten. Du kan legge den tilbake i seksjonen for fjernede varer.",
+        title: "Varelinje fjernet",
+      };
+    case "generated-shopping-item-restored":
+      return {
+        description:
+          "Varelinjen vises igjen i handlelisten med eventuelle tilpasninger du hadde lagret.",
+        title: "Varelinje lagt tilbake",
       };
     case "generated-shopping-item-updated":
       return {

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -132,6 +132,7 @@ describe("family meal plan route", () => {
       entriesSnapshot:
         "2026-05-15T00:00:00.000Z:DINNER:2026-05-01T12:00:00.000Z",
       notice: "meal-plan-created",
+      noticeMeta: null,
       recipes: [
         {
           defaultServings: 4,

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -13,6 +13,7 @@ import {
 } from "../lib/collaboration.server";
 import {
   approveMealPlan,
+  autoFillMealPlanEntries,
   formatDateOnly,
   getMealPlanPlanningData,
   reopenMealPlan,
@@ -23,15 +24,22 @@ import {
 
 type MealPlanNotice =
   | "meal-plan-approved"
+  | "meal-plan-auto-filled"
   | "meal-plan-created"
   | "meal-plan-entries-saved"
   | "meal-plan-reopened"
   | "meal-plan-updated";
 type MealPlanIntent =
   | "approve-meal-plan"
+  | "auto-fill-meal-plan-entries"
   | "reopen-meal-plan"
   | "save-meal-plan-entries"
   | "update-meal-plan";
+
+interface MealPlanNoticeMeta {
+  filledCount: number;
+  warning?: string;
+}
 
 const CALENDAR_DOWNLOAD_TARGET = "meal-plan-calendar-download";
 
@@ -42,6 +50,7 @@ interface MealPlanEntryFormState {
 }
 
 interface MealPlanActionData {
+  autoFillFormError?: string;
   entryFormError?: string;
   entryValues?: Record<string, MealPlanEntryFormState>;
   fieldErrors?: {
@@ -143,6 +152,7 @@ export async function loader({
     },
     entriesSnapshot,
     notice: getMealPlanNotice(request),
+    noticeMeta: getMealPlanNoticeMeta(request),
     recipes: result.recipes,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
@@ -168,6 +178,68 @@ export async function action({
   );
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "auto-fill-meal-plan-entries") {
+    const result = await autoFillMealPlanEntries({
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw new Response("Fant ikke ukeplanen.", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    }
+
+    if (
+      result.status === "NOT_DRAFT" ||
+      result.status === "NO_ELIGIBLE_RECIPES"
+    ) {
+      return {
+        autoFillFormError: result.formError,
+        intent,
+      } satisfies MealPlanActionData;
+    }
+
+    if (result.status === "NOTHING_TO_FILL") {
+      return {
+        autoFillFormError: "Alle dagene har allerede en oppskrift eller et notat.",
+        intent,
+      } satisfies MealPlanActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        autoFillFormError: result.formError,
+        intent,
+      } satisfies MealPlanActionData;
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        autoFillFormError: result.formError,
+        intent,
+      } satisfies MealPlanActionData;
+    }
+
+    if (result.status === "AUTO_FILLED") {
+      return buildMealPlanRedirect({
+        familyId,
+        filledCount: result.filledCount,
+        mealPlanId,
+        notice: "meal-plan-auto-filled",
+        request,
+        warning: result.warning,
+      });
+    }
+
+    return {
+      autoFillFormError: "Kunne ikke fylle ukeplanen automatisk.",
+      intent,
+    } satisfies MealPlanActionData;
+  }
 
   if (intent === "save-meal-plan-entries") {
     const entryVersions = parseMealPlanEntryVersions(formData);
@@ -318,6 +390,9 @@ export default function FamilyMealPlanRoute({
     navigation.state === "submitting" && pendingIntent === "approve-meal-plan";
   const isReopeningMealPlan =
     navigation.state === "submitting" && pendingIntent === "reopen-meal-plan";
+  const isAutoFillingEntries =
+    navigation.state === "submitting" &&
+    pendingIntent === "auto-fill-meal-plan-entries";
   const isSavingEntries =
     navigation.state === "submitting" &&
     pendingIntent === "save-meal-plan-entries";
@@ -325,8 +400,15 @@ export default function FamilyMealPlanRoute({
     navigation.state === "submitting" && pendingIntent === "update-meal-plan";
   const canManageApproval = loaderData.userRole === "ADMIN";
   const noticeContent = loaderData.notice
-    ? getMealPlanNoticeContent(loaderData.notice)
+    ? getMealPlanNoticeContent(loaderData.notice, loaderData.noticeMeta)
     : null;
+  const emptyDayCount = loaderData.visibleDates.filter((date) => {
+    const entry = loaderData.entriesByDate[date];
+
+    return !entry?.recipeId && !entry?.note;
+  }).length;
+  const canAutoFillEntries =
+    loaderData.mealPlan.status === "DRAFT" && emptyDayCount > 0;
   const titleValue = actionData?.values?.title ?? loaderData.mealPlan.title;
   const startDateValue =
     actionData?.values?.startDate ?? loaderData.mealPlan.startDate;
@@ -438,7 +520,11 @@ export default function FamilyMealPlanRoute({
               </p>
             </div>
 
-            <Form className="mt-6 space-y-4" method="post">
+            <Form
+              key={loaderData.entriesSnapshot}
+              className="mt-6 space-y-4"
+              method="post"
+            >
               <input
                 name="intent"
                 type="hidden"
@@ -558,12 +644,45 @@ export default function FamilyMealPlanRoute({
                 </p>
               ) : null}
 
+              <div className="grid gap-3 sm:grid-cols-2">
+                <button
+                  className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                  disabled={isSavingEntries || isAutoFillingEntries}
+                  type="submit"
+                >
+                  {isSavingEntries ? "Lagrer middager..." : "Lagre middager"}
+                </button>
+              </div>
+            </Form>
+
+            <Form className="mt-4 space-y-3" method="post">
+              <input
+                name="intent"
+                type="hidden"
+                value="auto-fill-meal-plan-entries"
+              />
+              <p className="text-sm leading-6 text-slate-600">
+                Fyll tomme dager med tilfeldige oppskrifter. Oppskrifter fra de
+                to forrige ukeplanene utelates.
+              </p>
+
+              {actionData?.intent === "auto-fill-meal-plan-entries" &&
+              actionData.autoFillFormError ? (
+                <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                  {actionData.autoFillFormError}
+                </p>
+              ) : null}
+
               <button
-                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={isSavingEntries}
+                className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+                disabled={
+                  !canAutoFillEntries || isAutoFillingEntries || isSavingEntries
+                }
                 type="submit"
               >
-                {isSavingEntries ? "Lagrer middager..." : "Lagre middager"}
+                {isAutoFillingEntries
+                  ? "Fyller tomme dager..."
+                  : "Fyll tomme dager"}
               </button>
             </Form>
           </article>
@@ -853,6 +972,7 @@ function getMealPlanNotice(request: Request): MealPlanNotice | null {
 
   if (
     notice === "meal-plan-approved" ||
+    notice === "meal-plan-auto-filled" ||
     notice === "meal-plan-created" ||
     notice === "meal-plan-entries-saved" ||
     notice === "meal-plan-reopened" ||
@@ -864,16 +984,38 @@ function getMealPlanNotice(request: Request): MealPlanNotice | null {
   return null;
 }
 
+function getMealPlanNoticeMeta(request: Request): MealPlanNoticeMeta | null {
+  const params = new URL(request.url).searchParams;
+
+  if (params.get("notice") !== "meal-plan-auto-filled") {
+    return null;
+  }
+
+  const filledCount = Number(params.get("filled") ?? "0");
+
+  const warningMessage =
+    params.get("warning") === "1" ? params.get("warningMessage") ?? undefined : undefined;
+
+  return {
+    filledCount: Number.isFinite(filledCount) ? filledCount : 0,
+    warning: warningMessage,
+  };
+}
+
 function buildMealPlanRedirect({
   familyId,
+  filledCount,
   mealPlanId,
   notice,
   request,
+  warning,
 }: {
   familyId: string;
+  filledCount?: number;
   mealPlanId: string;
   notice: MealPlanNotice;
   request: Request;
+  warning?: string;
 }) {
   const url = new URL(
     `/families/${familyId}/meal-plans/${mealPlanId}`,
@@ -881,10 +1023,22 @@ function buildMealPlanRedirect({
   );
   url.searchParams.set("notice", notice);
 
+  if (filledCount !== undefined) {
+    url.searchParams.set("filled", String(filledCount));
+  }
+
+  if (warning) {
+    url.searchParams.set("warning", "1");
+    url.searchParams.set("warningMessage", warning);
+  }
+
   return Response.redirect(url, 302);
 }
 
-function getMealPlanNoticeContent(notice: MealPlanNotice) {
+function getMealPlanNoticeContent(
+  notice: MealPlanNotice,
+  noticeMeta: MealPlanNoticeMeta | null,
+) {
   switch (notice) {
     case "meal-plan-approved":
       return {
@@ -892,6 +1046,17 @@ function getMealPlanNoticeContent(notice: MealPlanNotice) {
           "Ukeplanen er markert som godkjent og klar for neste steg.",
         title: "Ukeplan godkjent",
       };
+    case "meal-plan-auto-filled": {
+      const filledCount = noticeMeta?.filledCount ?? 0;
+      const warning = noticeMeta?.warning;
+
+      return {
+        description: warning
+          ? `${filledCount} tomme dager ble fylt automatisk. ${warning}`
+          : `${filledCount} tomme dager ble fylt automatisk med oppskrifter som ikke var i de to forrige ukeplanene.`,
+        title: "Tomme dager fylt",
+      };
+    }
     case "meal-plan-created":
       return {
         description:

--- a/prisma/migrations/20260519140000_shopping_item_excluded_from_list/migration.sql
+++ b/prisma/migrations/20260519140000_shopping_item_excluded_from_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ShoppingItemOverride" ADD COLUMN "excludedFromList" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -260,6 +260,7 @@ model ShoppingItemOverride {
   sourceType         ShoppingItemSource
   sourceKey          String
   checked               Boolean            @default(false)
+  excludedFromList      Boolean            @default(false)
   includeDespiteStock   Boolean            @default(false)
   postponedUntilDate    DateTime?          @db.Date
   preferredStoreId      String?

--- a/prototype/page.tsx
+++ b/prototype/page.tsx
@@ -81,9 +81,14 @@ export function MealPlannerPrototype() {
 
   let activeStore = getStoreById(state.selectedStoreId) ?? stores[0];
   let activeStoreOrder = getStoreOrder(state, activeStore.id);
-  let selectedRecipeIds = new Set(visibleDays.map((dayId) => selectedWeek.mealPlan[dayId]).filter(Boolean));
+  let selectedRecipeIds = new Set(
+    visibleDays.map((dayId) => selectedWeek.mealPlan[dayId]).filter(Boolean),
+  );
 
-  let shoppingItems = useMemo(() => buildShoppingItems(selectedWeek), [selectedWeek]);
+  let shoppingItems = useMemo(
+    () => buildShoppingItems(selectedWeek),
+    [selectedWeek],
+  );
   let dueItems = useMemo(
     () => getItemsDueToday(shoppingItems, selectedWeek.shoppingDay),
     [shoppingItems, selectedWeek.shoppingDay],
@@ -100,14 +105,17 @@ export function MealPlannerPrototype() {
   }, [dueItems, laterItems, shoppingItems, state.shoppingFilter]);
 
   let groupedItems = useMemo(
-    () => groupItemsBySection(visibleShoppingItems, activeStore, activeStoreOrder),
+    () =>
+      groupItemsBySection(visibleShoppingItems, activeStore, activeStoreOrder),
     [activeStore, activeStoreOrder, visibleShoppingItems],
   );
 
   let checkedItemIds = new Set(selectedWeek.checkedItemIds);
   let plannedMealCount = getPlannedMealCount(selectedWeek);
   let shoppingProgress = getShoppingProgress(selectedWeek, dueItems);
-  let openLaterCount = laterItems.filter((item) => !checkedItemIds.has(item.id)).length;
+  let openLaterCount = laterItems.filter(
+    (item) => !checkedItemIds.has(item.id),
+  ).length;
   let nextWeekStartDate = getNextWeekStartDate(state.weeks);
   let [weekDraft, setWeekDraft] = useState<WeekDraft>(() =>
     createWeekDraft(`Ny uke ${state.weeks.length + 1}`, nextWeekStartDate),
@@ -120,7 +128,9 @@ export function MealPlannerPrototype() {
   function updateSelectedWeek(recipe: (week: MealPlanWeek) => MealPlanWeek) {
     updateState((current) => ({
       ...current,
-      weeks: current.weeks.map((week) => (week.id === current.selectedWeekId ? recipe(week) : week)),
+      weeks: current.weeks.map((week) =>
+        week.id === current.selectedWeekId ? recipe(week) : week,
+      ),
     }));
   }
 
@@ -161,7 +171,10 @@ export function MealPlannerPrototype() {
       mealPlan: {
         ...week.mealPlan,
         ...Object.fromEntries(
-          getVisibleDays(week).map((dayId, index) => [dayId, recipes[index % recipes.length].id]),
+          getVisibleDays(week).map((dayId, index) => [
+            dayId,
+            recipes[index % recipes.length].id,
+          ]),
         ),
       },
       checkedItemIds: [],
@@ -175,7 +188,9 @@ export function MealPlannerPrototype() {
       planApproved: false,
       mealPlan: {
         ...week.mealPlan,
-        ...Object.fromEntries(getVisibleDays(week).map((dayId) => [dayId, null])),
+        ...Object.fromEntries(
+          getVisibleDays(week).map((dayId) => [dayId, null]),
+        ),
       },
       checkedItemIds: [],
       postponedItemDays: {},
@@ -183,7 +198,10 @@ export function MealPlannerPrototype() {
   }
 
   function toggleApproved() {
-    updateSelectedWeek((week) => ({ ...week, planApproved: !week.planApproved }));
+    updateSelectedWeek((week) => ({
+      ...week,
+      planApproved: !week.planApproved,
+    }));
   }
 
   function toggleChecked(itemId: string) {
@@ -205,12 +223,19 @@ export function MealPlannerPrototype() {
     }));
   }
 
-  function moveStoreCategory(category: IngredientCategory, direction: "up" | "down") {
+  function moveStoreCategory(
+    category: IngredientCategory,
+    direction: "up" | "down",
+  ) {
     updateState((current) => ({
       ...current,
       storeOrders: {
         ...current.storeOrders,
-        [activeStore.id]: moveCategoryOrder(getStoreOrder(current, activeStore.id), category, direction),
+        [activeStore.id]: moveCategoryOrder(
+          getStoreOrder(current, activeStore.id),
+          category,
+          direction,
+        ),
       },
     }));
   }
@@ -218,8 +243,16 @@ export function MealPlannerPrototype() {
   function createNextWeek() {
     let title = weekDraft.title.trim() || `Ny uke ${state.weeks.length + 1}`;
     let week = createBlankWeek(title, weekDraft.startDate, weekDraft.endDate);
-    setManualDraft((current) => ({ ...current, buyOnDay: getVisibleDays(week)[0] ?? "now" }));
-    setWeekDraft(createWeekDraft(`Ny uke ${state.weeks.length + 2}`, getNextWeekStartDate([...state.weeks, week])));
+    setManualDraft((current) => ({
+      ...current,
+      buyOnDay: getVisibleDays(week)[0] ?? "now",
+    }));
+    setWeekDraft(
+      createWeekDraft(
+        `Ny uke ${state.weeks.length + 2}`,
+        getNextWeekStartDate([...state.weeks, week]),
+      ),
+    );
     updateState((current) => ({
       ...current,
       selectedWeekId: week.id,
@@ -230,10 +263,21 @@ export function MealPlannerPrototype() {
 
   function reuseSelectedWeek() {
     let title = weekDraft.title.trim() || `${selectedWeek.title} kopi`;
-    let weekCopy = cloneWeek(selectedWeek, title, weekDraft.startDate, weekDraft.endDate);
-    setManualDraft((current) => ({ ...current, buyOnDay: getVisibleDays(weekCopy)[0] ?? "now" }));
+    let weekCopy = cloneWeek(
+      selectedWeek,
+      title,
+      weekDraft.startDate,
+      weekDraft.endDate,
+    );
+    setManualDraft((current) => ({
+      ...current,
+      buyOnDay: getVisibleDays(weekCopy)[0] ?? "now",
+    }));
     setWeekDraft(
-      createWeekDraft(`Ny uke ${state.weeks.length + 2}`, getNextWeekStartDate([...state.weeks, weekCopy])),
+      createWeekDraft(
+        `Ny uke ${state.weeks.length + 2}`,
+        getNextWeekStartDate([...state.weeks, weekCopy]),
+      ),
     );
     updateState((current) => ({
       ...current,
@@ -281,7 +325,10 @@ export function MealPlannerPrototype() {
       return;
     }
 
-    let content = createCalendarFile(`Mealplanner - ${selectedWeek.title}`, events);
+    let content = createCalendarFile(
+      `Mealplanner - ${selectedWeek.title}`,
+      events,
+    );
     downloadCalendarFile(`${toSlug(selectedWeek.title)}-ukeplan.ics`, content);
   }
 
@@ -342,17 +389,25 @@ export function MealPlannerPrototype() {
               </span>
               <div className="space-y-3">
                 <h1 className="max-w-2xl text-3xl font-semibold tracking-tight sm:text-4xl">
-                  Ukeplan og handleliste for familier som planlegger flere uker samtidig.
+                  Ukeplan og handleliste for familier som planlegger flere uker
+                  samtidig.
                 </h1>
                 <p className="max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">
-                  Denne versjonen tester flere planuker, gjenbruk av tidligere uker og aktive uker
-                  som kan starte midt i kalenderuken, for eksempel pa torsdag.
+                  Denne versjonen tester flere planuker, gjenbruk av tidligere
+                  uker og aktive uker som kan starte midt i kalenderuken, for
+                  eksempel pa torsdag.
                 </p>
               </div>
               <div className="flex flex-wrap gap-3 text-sm text-slate-200">
                 <InfoPill label="Sprak" value="Norsk" />
-                <InfoPill label="Oppsett" value={`${state.weeks.length} planuker`} />
-                <InfoPill label="Lagring" value={hydrated ? "LocalStorage aktiv" : "Laster demo-data"} />
+                <InfoPill
+                  label="Oppsett"
+                  value={`${state.weeks.length} planuker`}
+                />
+                <InfoPill
+                  label="Lagring"
+                  value={hydrated ? "LocalStorage aktiv" : "Laster demo-data"}
+                />
               </div>
             </div>
 
@@ -367,7 +422,11 @@ export function MealPlannerPrototype() {
                 value={`${shoppingProgress.totalCount - shoppingProgress.checkedCount} varer`}
                 tone="sky"
               />
-              <StatCard label="Senere i perioden" value={`${openLaterCount} varer`} tone="amber" />
+              <StatCard
+                label="Senere i perioden"
+                value={`${openLaterCount} varer`}
+                tone="amber"
+              />
             </div>
           </div>
         </header>
@@ -377,7 +436,8 @@ export function MealPlannerPrototype() {
             <div>
               <p className="text-sm font-medium text-slate-500">Navigasjon</p>
               <p className="text-sm text-slate-600">
-                Bytt raskt mellom planlegging, handleliste, butikkmodus og butikkoppsett.
+                Bytt raskt mellom planlegging, handleliste, butikkmodus og
+                butikkoppsett.
               </p>
             </div>
 
@@ -404,16 +464,25 @@ export function MealPlannerPrototype() {
           <section className="rounded-[28px] bg-white p-4 shadow-sm ring-1 ring-slate-200 sm:p-5">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
               <div className="space-y-2">
-                <p className="text-sm font-medium text-slate-500">Klar til a handle</p>
+                <p className="text-sm font-medium text-slate-500">
+                  Klar til a handle
+                </p>
                 <h2 className="text-xl font-semibold tracking-tight text-slate-950">
                   Sjekk butikk og uke, sa er du klar.
                 </h2>
                 <div className="flex flex-wrap gap-2">
-                  <InfoPill label="Periode" value={getWeekWindowLabel(selectedWeek)} dark={false} />
+                  <InfoPill
+                    label="Periode"
+                    value={getWeekWindowLabel(selectedWeek)}
+                    dark={false}
+                  />
                   <InfoPill
                     label="Datoer"
                     value={`${formatDateLabel(getDateForWeekDay(selectedWeek, visibleDays[0]))} - ${formatDateLabel(
-                      getDateForWeekDay(selectedWeek, visibleDays[visibleDays.length - 1]),
+                      getDateForWeekDay(
+                        selectedWeek,
+                        visibleDays[visibleDays.length - 1],
+                      ),
                     )}`}
                     dark={false}
                   />
@@ -474,19 +543,26 @@ export function MealPlannerPrototype() {
                   <article className="rounded-[28px] border border-dashed border-slate-300 bg-slate-50 p-4 md:col-span-2">
                     <div className="grid gap-3 lg:grid-cols-[1.2fr_1fr_1fr_auto]">
                       <label className="grid gap-1.5 text-sm">
-                        <span className="font-medium text-slate-700">Tittel</span>
+                        <span className="font-medium text-slate-700">
+                          Tittel
+                        </span>
                         <input
                           className={inputClassName}
                           value={weekDraft.title}
                           onChange={(event) =>
-                            setWeekDraft((current) => ({ ...current, title: event.target.value }))
+                            setWeekDraft((current) => ({
+                              ...current,
+                              title: event.target.value,
+                            }))
                           }
                           placeholder="F.eks. Høstferie uke"
                         />
                       </label>
 
                       <label className="grid gap-1.5 text-sm">
-                        <span className="font-medium text-slate-700">Startdato</span>
+                        <span className="font-medium text-slate-700">
+                          Startdato
+                        </span>
                         <input
                           className={inputClassName}
                           type="date"
@@ -494,7 +570,10 @@ export function MealPlannerPrototype() {
                           onChange={(event) =>
                             setWeekDraft((current) => {
                               let startDate = event.target.value;
-                              let maxEndDate = addDaysToDateString(startDate, 6);
+                              let maxEndDate = addDaysToDateString(
+                                startDate,
+                                6,
+                              );
                               let endDate = current.endDate;
                               if (endDate < startDate) endDate = startDate;
                               if (endDate > maxEndDate) endDate = maxEndDate;
@@ -510,7 +589,9 @@ export function MealPlannerPrototype() {
                       </label>
 
                       <label className="grid gap-1.5 text-sm">
-                        <span className="font-medium text-slate-700">Sluttdato</span>
+                        <span className="font-medium text-slate-700">
+                          Sluttdato
+                        </span>
                         <input
                           className={inputClassName}
                           type="date"
@@ -518,13 +599,18 @@ export function MealPlannerPrototype() {
                           max={addDaysToDateString(weekDraft.startDate, 6)}
                           value={weekDraft.endDate}
                           onChange={(event) =>
-                            setWeekDraft((current) => ({ ...current, endDate: event.target.value }))
+                            setWeekDraft((current) => ({
+                              ...current,
+                              endDate: event.target.value,
+                            }))
                           }
                         />
                       </label>
 
                       <div className="flex flex-col justify-end gap-2">
-                        <ActionButton onClick={createNextWeek}>Ny tom uke</ActionButton>
+                        <ActionButton onClick={createNextWeek}>
+                          Ny tom uke
+                        </ActionButton>
                         <ActionButton onClick={reuseSelectedWeek} tone="subtle">
                           Gjenbruk valgt uke
                         </ActionButton>
@@ -532,7 +618,8 @@ export function MealPlannerPrototype() {
                     </div>
 
                     <p className="mt-3 text-sm text-slate-600">
-                      Velg start- og sluttdato for planuken. Prototypen tillater opptil 7 dager per uke.
+                      Velg start- og sluttdato for planuken. Prototypen tillater
+                      opptil 7 dager per uke.
                     </p>
                   </article>
 
@@ -562,22 +649,33 @@ export function MealPlannerPrototype() {
                     }
                   >
                     <div className="flex flex-wrap gap-2">
-                      <InfoPill label="Periode" value={getWeekWindowLabel(selectedWeek)} dark={false} />
+                      <InfoPill
+                        label="Periode"
+                        value={getWeekWindowLabel(selectedWeek)}
+                        dark={false}
+                      />
                       <InfoPill
                         label="Datoer"
                         value={`${formatDateLabel(getDateForWeekDay(selectedWeek, visibleDays[0]))} - ${formatDateLabel(
-                          getDateForWeekDay(selectedWeek, visibleDays[visibleDays.length - 1]),
+                          getDateForWeekDay(
+                            selectedWeek,
+                            visibleDays[visibleDays.length - 1],
+                          ),
                         )}`}
                         dark={false}
                       />
                       <InfoPill
                         label="Handledag"
-                        value={capitalize(getDayLabel(selectedWeek.shoppingDay))}
+                        value={capitalize(
+                          getDayLabel(selectedWeek.shoppingDay),
+                        )}
                         dark={false}
                       />
                       <InfoPill
                         label="Status"
-                        value={selectedWeek.planApproved ? "Godkjent" : "Utkast"}
+                        value={
+                          selectedWeek.planApproved ? "Godkjent" : "Utkast"
+                        }
                         dark={false}
                       />
                     </div>
@@ -650,7 +748,8 @@ export function MealPlannerPrototype() {
                       onClick={() =>
                         updateState((current) => ({
                           ...current,
-                          shoppingFilter: filterOption.id as PrototypeState["shoppingFilter"],
+                          shoppingFilter:
+                            filterOption.id as PrototypeState["shoppingFilter"],
                         }))
                       }
                       className={
@@ -677,15 +776,22 @@ export function MealPlannerPrototype() {
               )}.`}
               actions={
                 <div className="flex flex-wrap gap-2">
-                  <ActionButton onClick={autoFillWeek}>Fyll perioden automatisk</ActionButton>
+                  <ActionButton onClick={autoFillWeek}>
+                    Fyll perioden automatisk
+                  </ActionButton>
                   <ActionButton onClick={exportWeekToCalendar} tone="subtle">
                     Eksporter uke til iCal
                   </ActionButton>
                   <ActionButton onClick={clearWeekPlan} tone="subtle">
                     Tom periode
                   </ActionButton>
-                  <ActionButton onClick={toggleApproved} tone={selectedWeek.planApproved ? "success" : "primary"}>
-                    {selectedWeek.planApproved ? "Godkjent av familien" : "Marker som godkjent"}
+                  <ActionButton
+                    onClick={toggleApproved}
+                    tone={selectedWeek.planApproved ? "success" : "primary"}
+                  >
+                    {selectedWeek.planApproved
+                      ? "Godkjent av familien"
+                      : "Marker som godkjent"}
                   </ActionButton>
                 </div>
               }
@@ -695,7 +801,9 @@ export function MealPlannerPrototype() {
                   <DayPlanCard
                     key={dayId}
                     dayLabel={capitalize(getDayLabel(dayId))}
-                    dateLabel={formatDateLabel(getDateForWeekDay(selectedWeek, dayId))}
+                    dateLabel={formatDateLabel(
+                      getDateForWeekDay(selectedWeek, dayId),
+                    )}
                     recipe={getRecipeById(selectedWeek.mealPlan[dayId])}
                     selectedRecipeId={selectedWeek.mealPlan[dayId] ?? ""}
                     onExport={() => exportDayToCalendar(dayId)}
@@ -736,7 +844,10 @@ export function MealPlannerPrototype() {
                       className={inputClassName}
                       value={manualDraft.name}
                       onChange={(event) =>
-                        setManualDraft((current) => ({ ...current, name: event.target.value }))
+                        setManualDraft((current) => ({
+                          ...current,
+                          name: event.target.value,
+                        }))
                       }
                       placeholder="F.eks. dopapir eller tacochips"
                     />
@@ -747,7 +858,10 @@ export function MealPlannerPrototype() {
                       className={inputClassName}
                       value={manualDraft.quantity}
                       onChange={(event) =>
-                        setManualDraft((current) => ({ ...current, quantity: event.target.value }))
+                        setManualDraft((current) => ({
+                          ...current,
+                          quantity: event.target.value,
+                        }))
                       }
                       placeholder="F.eks. 2 poser"
                     />
@@ -822,7 +936,10 @@ export function MealPlannerPrototype() {
                     className={inputClassName}
                     value={manualDraft.note}
                     onChange={(event) =>
-                      setManualDraft((current) => ({ ...current, note: event.target.value }))
+                      setManualDraft((current) => ({
+                        ...current,
+                        note: event.target.value,
+                      }))
                     }
                     placeholder="F.eks. kun hvis det er tilbud"
                   />
@@ -839,11 +956,31 @@ export function MealPlannerPrototype() {
               description="Generert fra den valgte planuken. Hver uke har sin egen handleliste og egne utsatte varer."
             >
               <div className="mb-4 flex flex-wrap gap-2 text-sm text-slate-600">
-                <InfoPill label="Butikk" value={activeStore.name} dark={false} />
-                <InfoPill label="Periode" value={getWeekWindowLabel(selectedWeek)} dark={false} />
-                <InfoPill label="Filter" value={filterLabel(state.shoppingFilter)} dark={false} />
-                <InfoPill label="Na" value={`${dueItems.length} varer`} dark={false} />
-                <InfoPill label="Senere" value={`${laterItems.length} varer`} dark={false} />
+                <InfoPill
+                  label="Butikk"
+                  value={activeStore.name}
+                  dark={false}
+                />
+                <InfoPill
+                  label="Periode"
+                  value={getWeekWindowLabel(selectedWeek)}
+                  dark={false}
+                />
+                <InfoPill
+                  label="Filter"
+                  value={filterLabel(state.shoppingFilter)}
+                  dark={false}
+                />
+                <InfoPill
+                  label="Na"
+                  value={`${dueItems.length} varer`}
+                  dark={false}
+                />
+                <InfoPill
+                  label="Senere"
+                  value={`${laterItems.length} varer`}
+                  dark={false}
+                />
               </div>
 
               <div className="space-y-4">
@@ -883,27 +1020,37 @@ export function MealPlannerPrototype() {
               </div>
               <div className="rounded-2xl bg-white/10 p-4">
                 <p className="text-sm text-slate-300">Handledag</p>
-                <p className="mt-1 text-lg font-semibold">{capitalize(getDayLabel(selectedWeek.shoppingDay))}</p>
+                <p className="mt-1 text-lg font-semibold">
+                  {capitalize(getDayLabel(selectedWeek.shoppingDay))}
+                </p>
               </div>
               <div className="rounded-2xl bg-emerald-500/20 p-4 ring-1 ring-emerald-400/30">
                 <p className="text-sm text-emerald-100">Fremdrift</p>
                 <p className="mt-1 text-lg font-semibold">
-                  {shoppingProgress.checkedCount}/{shoppingProgress.totalCount} krysset av
+                  {shoppingProgress.checkedCount}/{shoppingProgress.totalCount}{" "}
+                  krysset av
                 </p>
               </div>
             </div>
 
             <div className="space-y-5">
-              {groupItemsBySection(dueItems, activeStore, activeStoreOrder).length === 0 ? (
+              {groupItemsBySection(dueItems, activeStore, activeStoreOrder)
+                .length === 0 ? (
                 <EmptyState
                   title="Ingen varer ma handles na"
                   description="Alt er enten ferdig handlet eller utsatt til senere i den valgte uken."
                 />
               ) : (
-                groupItemsBySection(dueItems, activeStore, activeStoreOrder).map((group) => (
+                groupItemsBySection(
+                  dueItems,
+                  activeStore,
+                  activeStoreOrder,
+                ).map((group) => (
                   <div key={group.section} className="space-y-3">
                     <div className="flex items-center justify-between">
-                      <h3 className="text-lg font-semibold text-slate-900">{group.section}</h3>
+                      <h3 className="text-lg font-semibold text-slate-900">
+                        {group.section}
+                      </h3>
                       <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
                         {group.items.length} varer
                       </span>
@@ -932,11 +1079,18 @@ export function MealPlannerPrototype() {
                           </span>
                           <div className="min-w-0 flex-1">
                             <div className="flex flex-wrap items-center gap-2">
-                              <p className="text-base font-semibold text-slate-900">{item.name}</p>
+                              <p className="text-base font-semibold text-slate-900">
+                                {item.name}
+                              </p>
                               <Badge>{item.quantity}</Badge>
-                              {item.source === "manual" ? <Badge tone="amber">Manuell</Badge> : null}
-                              {item.preferredStoreId && item.preferredStoreId !== activeStore.id ? (
-                                <Badge tone="sky">{getStoreById(item.preferredStoreId)?.name}</Badge>
+                              {item.source === "manual" ? (
+                                <Badge tone="amber">Manuell</Badge>
+                              ) : null}
+                              {item.preferredStoreId &&
+                              item.preferredStoreId !== activeStore.id ? (
+                                <Badge tone="sky">
+                                  {getStoreById(item.preferredStoreId)?.name}
+                                </Badge>
                               ) : null}
                             </div>
                             <p className="mt-1 text-sm text-slate-600">
@@ -953,10 +1107,14 @@ export function MealPlannerPrototype() {
               )}
 
               <div className="rounded-[28px] border border-dashed border-slate-300 bg-slate-50 p-4">
-                <h3 className="text-sm font-semibold text-slate-900">Varer som er utsatt til senere</h3>
+                <h3 className="text-sm font-semibold text-slate-900">
+                  Varer som er utsatt til senere
+                </h3>
                 <div className="mt-3 flex flex-wrap gap-2">
                   {laterItems.length === 0 ? (
-                    <p className="text-sm text-slate-500">Ingen utsatte varer akkurat na.</p>
+                    <p className="text-sm text-slate-500">
+                      Ingen utsatte varer akkurat na.
+                    </p>
                   ) : (
                     laterItems.map((item) => (
                       <span
@@ -1008,7 +1166,9 @@ export function MealPlannerPrototype() {
                     className="flex items-center justify-between rounded-[24px] border border-slate-200 bg-white px-4 py-3 shadow-sm"
                   >
                     <div>
-                      <p className="text-sm text-slate-500">Plass {index + 1}</p>
+                      <p className="text-sm text-slate-500">
+                        Plass {index + 1}
+                      </p>
                       <p className="font-medium text-slate-900">{category}</p>
                     </div>
                     <div className="flex gap-2">
@@ -1038,18 +1198,22 @@ export function MealPlannerPrototype() {
             >
               <div className="space-y-4 text-sm leading-6 text-slate-600">
                 <p>
-                  Dagens prototype tester kjerneverdien: planlegg flere uker, gjenbruk en uke som
-                  fungerte bra, og bruk en mobilvennlig butikkvisning for hver enkelt uke.
+                  Dagens prototype tester kjerneverdien: planlegg flere uker,
+                  gjenbruk en uke som fungerte bra, og bruk en mobilvennlig
+                  butikkvisning for hver enkelt uke.
                 </p>
                 <ul className="space-y-2">
                   <li className="rounded-2xl bg-slate-50 px-4 py-3">
-                    Neste naturlige steg er a koble pa ekte lagring med Prisma og PostgreSQL.
+                    Neste naturlige steg er a koble pa ekte lagring med Prisma
+                    og PostgreSQL.
                   </li>
                   <li className="rounded-2xl bg-slate-50 px-4 py-3">
-                    Deretter kan familiekontoer og godkjenning mellom flere brukere legges pa.
+                    Deretter kan familiekontoer og godkjenning mellom flere
+                    brukere legges pa.
                   </li>
                   <li className="rounded-2xl bg-slate-50 px-4 py-3">
-                    Notion-import kan passe inn som en mate a fylle oppskriftsbanken pa uten a endre UI-flyten.
+                    Notion-import kan passe inn som en mate a fylle
+                    oppskriftsbanken pa uten a endre UI-flyten.
                   </li>
                 </ul>
 
@@ -1082,8 +1246,12 @@ function SectionCard({
     <section className="rounded-[32px] bg-white p-5 shadow-sm ring-1 ring-slate-200 sm:p-6">
       <div className="mb-5 flex flex-col gap-4 border-b border-slate-100 pb-5">
         <div className="space-y-1">
-          <h2 className="text-xl font-semibold tracking-tight text-slate-950">{title}</h2>
-          <p className="max-w-2xl text-sm leading-6 text-slate-600">{description}</p>
+          <h2 className="text-xl font-semibold tracking-tight text-slate-950">
+            {title}
+          </h2>
+          <p className="max-w-2xl text-sm leading-6 text-slate-600">
+            {description}
+          </p>
         </div>
         {actions}
       </div>
@@ -1141,14 +1309,21 @@ function WeekCard({
         <div>
           <h3 className="text-lg font-semibold text-slate-950">{week.title}</h3>
           <p className="mt-1 text-sm leading-6 text-slate-600">
-            Aktiv periode: {getWeekWindowLabel(week)} · {plannedMealCount}/{visibleDays.length} middager planlagt
+            Aktiv periode: {getWeekWindowLabel(week)} · {plannedMealCount}/
+            {visibleDays.length} middager planlagt
           </p>
           <p className="mt-1 text-sm text-slate-500">
             {formatDateLabel(getDateForWeekDay(week, visibleDays[0]))} -{" "}
-            {formatDateLabel(getDateForWeekDay(week, visibleDays[visibleDays.length - 1]))}
+            {formatDateLabel(
+              getDateForWeekDay(week, visibleDays[visibleDays.length - 1]),
+            )}
           </p>
         </div>
-        {week.planApproved ? <Badge tone="success">Godkjent</Badge> : <Badge>Utkast</Badge>}
+        {week.planApproved ? (
+          <Badge tone="success">Godkjent</Badge>
+        ) : (
+          <Badge>Utkast</Badge>
+        )}
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2">
@@ -1185,7 +1360,15 @@ function StatCard({
   );
 }
 
-function InfoPill({ label, value, dark = true }: { label: string; value: string; dark?: boolean }) {
+function InfoPill({
+  label,
+  value,
+  dark = true,
+}: {
+  label: string;
+  value: string;
+  dark?: boolean;
+}) {
   return (
     <span
       className={
@@ -1194,7 +1377,9 @@ function InfoPill({ label, value, dark = true }: { label: string; value: string;
           : "inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-700"
       }
     >
-      <span className={dark ? "text-slate-300" : "text-slate-500"}>{label}</span>
+      <span className={dark ? "text-slate-300" : "text-slate-500"}>
+        {label}
+      </span>
       <span>{value}</span>
     </span>
   );
@@ -1244,7 +1429,9 @@ function DayPlanCard({
     <article className="rounded-[28px] border border-slate-200 bg-slate-50 p-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
-          <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">Middag</p>
+          <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+            Middag
+          </p>
           <h3 className="text-lg font-semibold text-slate-950">{dayLabel}</h3>
           <p className="text-sm font-medium text-slate-500">{dateLabel}</p>
           <p className="text-sm leading-6 text-slate-600">
@@ -1301,8 +1488,12 @@ function RecipeCard({
     >
       <div className="flex items-start justify-between gap-3">
         <div>
-          <h3 className="text-lg font-semibold text-slate-950">{recipe.title}</h3>
-          <p className="mt-1 text-sm leading-6 text-slate-600">{recipe.description}</p>
+          <h3 className="text-lg font-semibold text-slate-950">
+            {recipe.title}
+          </h3>
+          <p className="mt-1 text-sm leading-6 text-slate-600">
+            {recipe.description}
+          </p>
         </div>
         {selected ? <Badge tone="success">I ukeplanen</Badge> : null}
       </div>
@@ -1314,9 +1505,14 @@ function RecipeCard({
       </div>
 
       <div className="mt-4 rounded-[24px] bg-white p-3 ring-1 ring-slate-200">
-        <p className="text-sm font-medium text-slate-800">{recipe.ingredients.length} ingredienser</p>
+        <p className="text-sm font-medium text-slate-800">
+          {recipe.ingredients.length} ingredienser
+        </p>
         <p className="mt-1 text-sm text-slate-600">
-          {recipe.ingredients.slice(0, 3).map((ingredient) => ingredient.name).join(", ")}
+          {recipe.ingredients
+            .slice(0, 3)
+            .map((ingredient) => ingredient.name)
+            .join(", ")}
           {recipe.ingredients.length > 3 ? " og mer" : ""}
         </p>
       </div>
@@ -1372,12 +1568,20 @@ function ShoppingGroup({
                         : "rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700"
                     }
                   >
-                    {checkedItemIds.has(item.id) ? "Kjopt" : "Marker som kjopt"}
+                    {checkedItemIds.has(item.id) ? "Kjopt" : "Marker som kjøpt"}
                   </button>
-                  <p className="text-base font-semibold text-slate-950">{item.name}</p>
+                  <p className="text-base font-semibold text-slate-950">
+                    {item.name}
+                  </p>
                   <Badge>{item.quantity}</Badge>
-                  {item.preferredStoreId ? <Badge tone="sky">{getStoreById(item.preferredStoreId)?.name}</Badge> : null}
-                  {item.source === "manual" ? <Badge tone="amber">Manuell</Badge> : null}
+                  {item.preferredStoreId ? (
+                    <Badge tone="sky">
+                      {getStoreById(item.preferredStoreId)?.name}
+                    </Badge>
+                  ) : null}
+                  {item.source === "manual" ? (
+                    <Badge tone="amber">Manuell</Badge>
+                  ) : null}
                 </div>
 
                 <p className="text-sm leading-6 text-slate-600">
@@ -1393,7 +1597,9 @@ function ShoppingGroup({
                   <select
                     className={inputClassName}
                     value={item.buyOnDay}
-                    onChange={(event) => onPostpone(item.id, event.target.value as BuyOnDay)}
+                    onChange={(event) =>
+                      onPostpone(item.id, event.target.value as BuyOnDay)
+                    }
                   >
                     <option value="now">Sa snart som mulig</option>
                     {availableDays.map((dayId) => (
@@ -1441,7 +1647,13 @@ function Badge({
   return <span className={className}>{children}</span>;
 }
 
-function EmptyState({ title, description }: { title: string; description: string }) {
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
   return (
     <div className="rounded-[28px] border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
       <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
@@ -1450,12 +1662,18 @@ function EmptyState({ title, description }: { title: string; description: string
   );
 }
 
-function groupItemsBySection(items: ShoppingItem[], store: Store, order: IngredientCategory[]) {
+function groupItemsBySection(
+  items: ShoppingItem[],
+  store: Store,
+  order: IngredientCategory[],
+) {
   let sections = new Map<ShoppingSection, ShoppingItem[]>();
 
   for (let item of items) {
     let section: ShoppingSection =
-      item.preferredStoreId && item.preferredStoreId !== store.id ? "Annen butikk" : item.category;
+      item.preferredStoreId && item.preferredStoreId !== store.id
+        ? "Annen butikk"
+        : item.category;
     let existing = sections.get(section);
     if (existing) {
       existing.push(item);
@@ -1521,7 +1739,9 @@ function getNextWeekStartDate(weeks: MealPlanWeek[]) {
     return todayAsDateString();
   }
 
-  let sortedWeeks = [...weeks].sort((left, right) => left.startDate.localeCompare(right.startDate));
+  let sortedWeeks = [...weeks].sort((left, right) =>
+    left.startDate.localeCompare(right.startDate),
+  );
   let latestWeek = sortedWeeks[sortedWeeks.length - 1];
   let [year, month, day] = latestWeek.startDate.split("-").map(Number);
   let date = new Date(year, month - 1, day);


### PR DESCRIPTION
## Summary

- Add **Fyll tomme dager** on draft meal plans to randomly assign recipes to empty dinner slots, excluding recipes used in the two most recent other family meal plans.
- Fix meal plan form so dropdowns refresh after auto-fill (`key` on entries snapshot).
- Add **Fjern fra handlelisten** for generated shopping items via `excludedFromList` on `ShoppingItemOverride` (new migration).
- Add a collapsible **fjernede varer** section with **Legg tilbake i handlelisten** to restore excluded items.

## Test plan

- [x] `npx vitest run app/lib/meal-plan.server.test.ts`
- [x] `npx vitest run app/lib/shopping.server.test.ts app/lib/shopping-write.server.test.ts`
- [ ] Run `npx prisma migrate deploy` locally before testing shopping exclude/restore
- [ ] Auto-fill on a draft plan with empty days; confirm excluded recipes from prior two plans are not picked
- [ ] Remove a generated shopping line and restore it from the excluded section
- [ ] Delete a manual shopping line via **Slett varelinje**

Closes #39