### PR TITLE
Automate Fly.io deployments with GitHub Actions

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: fly-deploy-mealplanner-xzvzow
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CI: true
+      DATABASE_URL: postgresql://mealplanner:mealplanner@localhost:5466/mealplanner?schema=public
+      SESSION_SECRET: ci-session-secret-that-is-at-least-thirty-two-characters
+
+    steps:
+      # Keep in sync with .github/workflows/pr-validation.yml
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npm run prisma:generate
+
+      - name: Lint source
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:run
+
+      - name: Typecheck source
+        run: npm run typecheck
+
+      - name: Build application
+        run: npm run build
+
+  deploy:
+    name: Deploy
+    needs: validate
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: fly deploy --remote-only -a mealplanner-xzvzow
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,20 +2,18 @@
 
 ## Current Objective
 
-Issue #46 shipped on branch `issue/46-remove-notion-import`: Notion import removed; env requires only `DATABASE_URL` and `SESSION_SECRET`.
+Issue #42: GitHub Actions Fly deploy workflow ready for PR merge to `main`.
 
 ## Completed
 
-- Deleted Notion import service, admin import route, and tests.
-- Removed import route registration and "Importer fra Notion" UI link.
-- Simplified `app/lib/env.server.ts`; updated `.env.example`, Vitest, and CI env.
-- Updated `README.md` and `docs/deploy-fly.md` (including legacy `fly secrets unset`).
-- Removed `@notionhq/client` dependency.
+- Added [`.github/workflows/fly-deploy.yml`](.github/workflows/fly-deploy.yml) — validate (mirrors PR CI) then `fly deploy --remote-only` to `mealplanner-xzvzow` on `main` and `workflow_dispatch`.
+- Extended [`docs/deploy-fly.md`](docs/deploy-fly.md) — CI/CD triggers, `FLY_API_TOKEN` setup, pre-deploy checks, failure handling, rollback notes, correct Fly app name.
+- Updated [`README.md`](README.md) — deploy workflow links and automated vs manual release paths.
 
 ## Files To Read First
 
-- `app/lib/env.server.ts` — required env vars.
-- `docs/deploy-fly.md` — deploy and legacy Notion secret cleanup.
+- `.github/workflows/fly-deploy.yml` — deploy pipeline.
+- `docs/deploy-fly.md` — operator setup and smoke checks.
 
 ## Validation
 
@@ -26,9 +24,9 @@ Issue #46 shipped on branch `issue/46-remove-notion-import`: Notion import remov
 
 ## Open Items
 
-- After merge/deploy: `fly secrets unset NOTION_API_TOKEN NOTION_INGREDIENTS_DATABASE_ID NOTION_RECIPES_DATABASE_ID -a mealplanner` if those secrets still exist on Fly.
-- Optional: reword Notion mention in `prototype/page.tsx` (non-blocking).
+- Operator: `fly tokens create deploy -a mealplanner-xzvzow` → GitHub repo secret `FLY_API_TOKEN`.
+- Operator: after merge, confirm Actions run on `main`, run post-deploy smoke checks in `docs/deploy-fly.md`.
 
 ## Next Step
 
-Merge PR; operator unsets Fly Notion secrets post-deploy if needed.
+Merge PR; add `FLY_API_TOKEN` if not set; verify first automated deploy and smoke checklist.

--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ docker compose down
 
 ## Pull Request Validation
 
-Pull requests now run [`.github/workflows/pr-validation.yml`](.github/workflows/pr-validation.yml) automatically when they are opened, updated, or reopened.
+Pull requests run [`.github/workflows/pr-validation.yml`](.github/workflows/pr-validation.yml) when they are opened, updated, or reopened.
 
-The workflow uses Node.js `20.19.0` and runs the same baseline validation commands used locally:
+Pushes to `main` run [`.github/workflows/fly-deploy.yml`](.github/workflows/fly-deploy.yml): the same validation suite, then deploy to Fly.io. You can also trigger a deploy manually from the Actions tab (`workflow_dispatch`). Requires the `FLY_API_TOKEN` repository secret — see [docs/deploy-fly.md](docs/deploy-fly.md#continuous-deployment-github-actions).
+
+The validation workflow uses Node.js `20.19.0` and runs the same baseline validation commands used locally:
 
 ```bash
 npm ci
@@ -171,13 +173,13 @@ When creating issues, the script auto-creates any missing labels in the target r
 
 ### Fly.io (production)
 
-See **[docs/deploy-fly.md](docs/deploy-fly.md)** for the full workflow: secrets, `fly deploy`, migrations on release, rollback, and smoke checks.
+See **[docs/deploy-fly.md](docs/deploy-fly.md)** for secrets, automated GitHub Actions deploys, manual fallback, migrations on release, rollback, and smoke checks.
 
-Quick reference:
+**Routine releases:** merge to `main` (or run **Deploy to Fly.io** from Actions). **Manual fallback:**
 
 ```bash
-fly deploy -a mealplanner
-fly open -a mealplanner
+fly deploy -a mealplanner-xzvzow
+fly open -a mealplanner-xzvzow
 ```
 
 Configuration lives in [`fly.toml`](fly.toml). The Docker image runs `npm run start` (React Router serve on port 3000).

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -5,7 +5,7 @@ This guide covers deploying the **mealplanner** app to [Fly.io](https://fly.io) 
 ## Prerequisites
 
 - [Fly CLI](https://fly.io/docs/hands-on/install-flyctl/) installed and authenticated (`fly auth login`)
-- Access to the Fly org where the `mealplanner` app will run
+- Access to the Fly org where the `mealplanner-xzvzow` app will run
 - A production PostgreSQL `DATABASE_URL` reachable from Fly machines
 - Required secrets ready to set on Fly (see below)
 
@@ -24,7 +24,7 @@ Set secrets on Fly (never commit production values):
 fly secrets set \
   DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE?schema=public" \
   SESSION_SECRET="<generate-a-long-random-string>" \
-  -a mealplanner
+  -a mealplanner-xzvzow
 ```
 
 Generate a strong `SESSION_SECRET`, for example:
@@ -38,7 +38,7 @@ openssl rand -base64 32
 If the app does not exist yet:
 
 ```bash
-fly apps create mealplanner
+fly apps create mealplanner-xzvzow
 ```
 
 Or launch from the repo (uses [`fly.toml`](../fly.toml) and [`Dockerfile`](../Dockerfile)):
@@ -58,51 +58,116 @@ Adjust `primary_region` in `fly.toml` if needed (default: `ams`).
 Check migration status on a running machine:
 
 ```bash
-fly ssh console -a mealplanner -C "npx prisma migrate status"
+fly ssh console -a mealplanner-xzvzow -C "npx prisma migrate status"
 ```
 
 ## Deploy
 
+### Automated (recommended)
+
+Merges to `main` deploy automatically via GitHub Actions after validation. See [Continuous deployment (GitHub Actions)](#continuous-deployment-github-actions).
+
+### Manual (fallback)
+
 From the repository root:
 
 ```bash
-fly deploy -a mealplanner
+fly deploy -a mealplanner-xzvzow
 ```
 
 Useful follow-up commands:
 
 ```bash
-fly status -a mealplanner
-fly logs -a mealplanner
-fly open -a mealplanner
+fly status -a mealplanner-xzvzow
+fly logs -a mealplanner-xzvzow
+fly open -a mealplanner-xzvzow
 ```
 
 Each deploy runs migrations in a release machine before routing traffic to the new image.
+
+## Continuous deployment (GitHub Actions)
+
+Routine production releases use [`.github/workflows/fly-deploy.yml`](../.github/workflows/fly-deploy.yml) (issue #42). The manual `fly deploy` flow from issue #41 remains available as a fallback.
+
+### Triggers
+
+| Trigger | When it runs |
+| ------- | ------------- |
+| Push to `main` | Automatically after validation passes |
+| `workflow_dispatch` | Manually from **Actions → Deploy to Fly.io → Run workflow** (must run on the `main` branch) |
+
+Pull request branches do not trigger this workflow.
+
+### GitHub secret (one-time setup)
+
+Create a deploy token and add it as a **repository** secret (Settings → Secrets and variables → Actions), not only an environment secret:
+
+```bash
+fly tokens create deploy -a mealplanner-xzvzow
+```
+
+Add the token value as `FLY_API_TOKEN`.
+
+Runtime secrets (`DATABASE_URL`, `SESSION_SECRET`, etc.) stay on Fly via `fly secrets set`; they are not stored in GitHub.
+
+### Pre-deploy checks
+
+The workflow `validate` job mirrors PR CI before deploy:
+
+```bash
+npm ci
+npm run prisma:generate
+npm run lint
+npm run test:run
+npm run typecheck
+npm run build
+```
+
+### What deploy does
+
+1. Builds the production image on Fly remote builders (`fly deploy --remote-only`).
+2. Runs `release_command` from [`fly.toml`](../fly.toml) (`npx prisma migrate deploy`).
+3. Routes traffic to the new release when the release machine succeeds.
+
+### Failure handling
+
+| Failure | What to check |
+| ------- | ------------- |
+| `validate` job fails | Fix lint, tests, typecheck, or build locally; merge a fix to `main` |
+| Auth error on deploy | `FLY_API_TOKEN` missing, expired, or stored in the wrong secret scope |
+| Deploy / build fails | GitHub Actions logs for the run; `fly logs -a mealplanner-xzvzow` |
+| `release_command` fails | Database URL, connectivity, or pending migrations; previous release keeps serving traffic |
+
+After fixing the root cause, push to `main` or re-run the workflow via `workflow_dispatch`.
+
+### Rollback after an automated deploy
+
+Automated deploys use the same rollback steps as manual deploys (see below). Redeploying an older image does **not** undo database migrations already applied by a failed or bad release; treat schema rollback as a separate, careful operation.
 
 ## Rollback
 
 List recent releases:
 
 ```bash
-fly releases list -a mealplanner
+fly releases list -a mealplanner-xzvzow
 ```
 
 Redeploy a previous image (replace `<image-ref>` from the releases list):
 
 ```bash
-fly deploy --image <image-ref> -a mealplanner
+fly deploy --image <image-ref> -a mealplanner-xzvzow
 ```
 
 See [Fly rollback docs](https://fly.io/docs/blueprint/rollback/) for machine-level options.
 
 ## Post-deploy smoke checks
 
-Replace `<app>` with your Fly hostname (e.g. `mealplanner.fly.dev`).
+Replace `<app>` with your Fly hostname (e.g. `mealplanner-xzvzow.fly.dev`).
 
 | Check | Command | Expected |
 | ----- | ------- | -------- |
-| App boots | `fly logs -a mealplanner` | No `Invalid server environment configuration` |
-| Migrations | `fly ssh console -a mealplanner -C "npx prisma migrate status"` | All migrations applied |
+| App boots | `fly logs -a mealplanner-xzvzow` | No `Invalid server environment configuration` |
+| Migrations | `fly ssh console -a mealplanner-xzvzow -C "npx prisma migrate status"` | All migrations applied |
 | Home | `curl -sfI https://<app>/` | HTTP `200` |
 | Login | `curl -sfI https://<app>/login` | HTTP `200` |
 | Protected redirect | `curl -sfI https://<app>/app` | HTTP `302` to `/login` when logged out |
@@ -132,7 +197,7 @@ Ensure local Postgres is running (`docker compose up -d`) if using the example U
 If the app was deployed before Notion import was removed, unset obsolete secrets:
 
 ```bash
-fly secrets unset NOTION_API_TOKEN NOTION_INGREDIENTS_DATABASE_ID NOTION_RECIPES_DATABASE_ID -a mealplanner
+fly secrets unset NOTION_API_TOKEN NOTION_INGREDIENTS_DATABASE_ID NOTION_RECIPES_DATABASE_ID -a mealplanner-xzvzow
 ```
 
 ## Troubleshooting
@@ -147,6 +212,7 @@ fly secrets unset NOTION_API_TOKEN NOTION_INGREDIENTS_DATABASE_ID NOTION_RECIPES
 
 ## Related files
 
+- [`.github/workflows/fly-deploy.yml`](../.github/workflows/fly-deploy.yml) — CI validation and Fly deploy on `main`
 - [`fly.toml`](../fly.toml) — Fly app config and `release_command`
 - [`Dockerfile`](../Dockerfile) — production image build
 - [`prisma/migrations/`](../prisma/migrations/) — schema migrations applied on deploy


### PR DESCRIPTION
## Summary
- Add `fly-deploy.yml` workflow: validate (lint, tests, typecheck, build) then deploy to `mealplanner-xzvzow` on `main` push or manual dispatch
- Document CI/CD triggers, `FLY_API_TOKEN` setup, failure handling, and rollback in `docs/deploy-fly.md`
- Update README with automated vs manual release paths and correct Fly app name

## Related issue
Closes #42

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] After merge: add `FLY_API_TOKEN` repository secret (`fly tokens create deploy -a mealplanner-xzvzow`)
- [ ] After merge: confirm Deploy to Fly.io workflow succeeds on `main`
- [ ] Run post-deploy smoke checks from `docs/deploy-fly.md`

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck