### PR TITLE
Fix Fly deploy: use flyctl on GitHub Actions

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -66,6 +66,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
-        run: fly deploy --remote-only -a mealplanner-xzvzow
+        run: flyctl deploy --remote-only -a mealplanner-xzvzow
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,18 +2,16 @@
 
 ## Current Objective
 
-Issue #42: GitHub Actions Fly deploy workflow ready for PR merge to `main`.
+Hotfix: GitHub Actions Fly deploy uses `flyctl` (not `fly`) on CI runners.
 
 ## Completed
 
-- Added [`.github/workflows/fly-deploy.yml`](.github/workflows/fly-deploy.yml) — validate (mirrors PR CI) then `fly deploy --remote-only` to `mealplanner-xzvzow` on `main` and `workflow_dispatch`.
-- Extended [`docs/deploy-fly.md`](docs/deploy-fly.md) — CI/CD triggers, `FLY_API_TOKEN` setup, pre-deploy checks, failure handling, rollback notes, correct Fly app name.
-- Updated [`README.md`](README.md) — deploy workflow links and automated vs manual release paths.
+- Fixed [`.github/workflows/fly-deploy.yml`](.github/workflows/fly-deploy.yml) deploy step: `flyctl deploy --remote-only`.
+- Updated [`docs/deploy-fly.md`](docs/deploy-fly.md) CI section to reference `flyctl`.
 
 ## Files To Read First
 
 - `.github/workflows/fly-deploy.yml` — deploy pipeline.
-- `docs/deploy-fly.md` — operator setup and smoke checks.
 
 ## Validation
 
@@ -24,9 +22,8 @@ Issue #42: GitHub Actions Fly deploy workflow ready for PR merge to `main`.
 
 ## Open Items
 
-- Operator: `fly tokens create deploy -a mealplanner-xzvzow` → GitHub repo secret `FLY_API_TOKEN`.
-- Operator: after merge, confirm Actions run on `main`, run post-deploy smoke checks in `docs/deploy-fly.md`.
+- Merge `bugfix` to `main` and re-run **Deploy to Fly.io** workflow.
 
 ## Next Step
 
-Merge PR; add `FLY_API_TOKEN` if not set; verify first automated deploy and smoke checklist.
+Merge PR; confirm deploy job completes on `main`.

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -125,7 +125,7 @@ npm run build
 
 ### What deploy does
 
-1. Builds the production image on Fly remote builders (`fly deploy --remote-only`).
+1. Builds the production image on Fly remote builders (`flyctl deploy --remote-only`).
 2. Runs `release_command` from [`fly.toml`](../fly.toml) (`npx prisma migrate deploy`).
 3. Routes traffic to the new release when the release machine succeeds.
 


### PR DESCRIPTION
## Summary
- Change deploy step from `fly` to `flyctl` — `setup-flyctl` only installs `flyctl` on runners, so `fly deploy` failed with "command not found" despite a successful setup step
- Align deploy doc wording with the workflow command

## Related issue
Follow-up to #42 (deploy workflow)

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] After merge: re-run **Deploy to Fly.io** on `main` and confirm deploy job succeeds

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck