### PR TITLE
Fix butikkmodus handledato-filter and auto-save picks

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,31 @@
 
 ## Current Objective
 
-Remove the local-only Mealplanner prototype from the running app (issue #47) so production auth and family flows are the only entry points.
+Fix butikkmodus handledato-filter (issue #54): show shopping items from handledato through end of meal plan, exclude past meals, and auto-save store/date selects.
 
 ## Completed
 
-- Deleted `prototype/` module and `app/routes/prototype.tsx`; removed route from `app/routes.ts`.
-- Refocused landing (`home.tsx`), auth sidebar (`auth-form.tsx`), and app shell (`app.tsx`) on production CTAs.
-- Updated `home.test.tsx` and README intro/styling copy.
+- Replaced inverted `isProjectedItemDueBy` with trip/before-shopping/past filters in `getMealPlanStoreModeData`.
+- Added unit tests for multi-day trips, before-shopping-date chips, and past-meal exclusion.
+- Updated butikkmodus copy («fra handledato og utover», «Før handledato»).
+- Auto-submit store and shopping-date selects on change (removed save buttons).
 
 ## Files To Read First
 
-- `app/routes/home.tsx` — production landing copy and CTAs.
-- `app/routes.ts` — route table (no `/prototype`).
+- `app/lib/shopping.server.ts` — store-mode date filtering helpers
+- `app/routes/family-meal-plan-store-mode.tsx` — UI, auto-submit selects
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 157 tests passed (31 files)
+- `npm run test:run` — 159 tests passed (31 files)
 - `npm run typecheck` — passed
-- `npm run build` — passed (earlier in session)
 
 ## Open Items
 
-- Merge PR and confirm `/prototype` returns 404 in deployed app.
-- `ideas/prototype-1-summary.md` still references removed paths (archival; acceptable per issue).
+- PR merge and manual smoke-test in butikkmodus (Monday shop trip shows full week; past days hidden).
 
 ## Next Step
 
-Merge PR for issue #47; smoke-test `/`, `/login`, `/register`, logged-in `/app`, and `/prototype` 404.
+Merge PR; verify store/date dropdowns save on change and item list matches handledato range.

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { afterEach, describe, expect, it, beforeEach, vi } from "vitest";
 
 const { dbMock, getFamilyStockMatchSetMock, requireFamilyMembershipMock } =
   vi.hoisted(() => {
@@ -553,6 +553,16 @@ describe("shopping.server", () => {
     expect(result.projectedItems.map((item) => item.quantityLabel)).toEqual(["1 beger", "2 beger"]);
   });
 
+  describe("getMealPlanStoreModeData", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-05-14T09:30:45.000Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
   it("builds store mode with all due items ordered by the selected store layout", async () => {
     dbMock.mealPlan.findFirst.mockResolvedValue({
       activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
@@ -711,17 +721,241 @@ describe("shopping.server", () => {
       name: "Meny",
     });
     expect(result.activeShoppingDate).toEqual(new Date("2026-05-16T00:00:00.000Z"));
-    expect(result.dueSectionGroups.map((section) => section.displayName)).toEqual([
-      "Brod",
-      "Frukt og gront",
+    expect(result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name))).toEqual([
+      "Yoghurt",
     ]);
-    expect(result.dueSectionGroups[0]?.items.map((item) => item.name)).toEqual(["Wraps"]);
-    expect(result.dueSectionGroups[1]?.items.map((item) => item.name)).toEqual(["Paprika"]);
-    expect(result.laterItems.map((item) => item.name)).toEqual(["Yoghurt"]);
+    expect(result.laterItems.map((item) => item.name).sort()).toEqual(["Paprika", "Wraps"]);
     expect(result.progress).toEqual({
       checkedCount: 0,
-      totalCount: 2,
+      totalCount: 1,
     });
+  });
+
+  it("includes all items from the shopping date through the end of the meal plan", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
+      endDate: new Date("2026-05-17T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-bakery", name: "Brod" },
+                categoryId: "category-bakery",
+                displayName: "Wraps",
+                id: "ingredient-1",
+                ingredientId: "canonical-wraps",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "pk",
+              },
+            ],
+            title: "Mandag",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Paprika",
+                id: "ingredient-2",
+                ingredientId: "canonical-paprika",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Tirsdag",
+          },
+          recipeId: "recipe-2",
+        },
+        {
+          date: new Date("2026-05-17T00:00:00.000Z"),
+          id: "entry-3",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-3",
+            ingredients: [
+              {
+                amount: "2",
+                category: { id: "category-dairy", name: "Meieri" },
+                categoryId: "category-dairy",
+                displayName: "Yoghurt",
+                id: "ingredient-3",
+                ingredientId: "canonical-yoghurt",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "beger",
+              },
+            ],
+            title: "Onsdag",
+          },
+          recipeId: "recipe-3",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Ukehandel",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: "family-1",
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-1",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-2",
+            sortOrder: 2,
+          },
+          {
+            categoryId: "category-dairy",
+            displayName: "Meieri",
+            id: "section-3",
+            sortOrder: 3,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(
+      result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name)),
+    ).toEqual(["Wraps", "Paprika", "Yoghurt"]);
+    expect(result.laterItems).toEqual([]);
+    expect(result.progress).toEqual({
+      checkedCount: 0,
+      totalCount: 3,
+    });
+  });
+
+  it("excludes past meals from both the trip list and the before-shopping-date list", async () => {
+    vi.setSystemTime(new Date("2026-05-16T09:30:45.000Z"));
+
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
+      endDate: new Date("2026-05-17T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-14T00:00:00.000Z"),
+          id: "entry-0",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-0",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-bakery", name: "Brod" },
+                categoryId: "category-bakery",
+                displayName: "Gammel wrap",
+                id: "ingredient-0",
+                ingredientId: "canonical-old-wrap",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "pk",
+              },
+            ],
+            title: "Sondag",
+          },
+          recipeId: "recipe-0",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Paprika",
+                id: "ingredient-1",
+                ingredientId: "canonical-paprika",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Tirsdag",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-14T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Ukehandel",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: "family-1",
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-1",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-2",
+            sortOrder: 2,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(
+      result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name)),
+    ).toEqual(["Paprika"]);
+    expect(result.laterItems.map((item) => item.name)).toEqual([]);
+  });
   });
 
   it("excludes stock ingredients from generated shopping items and exposes a stock summary", async () => {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -443,8 +443,16 @@ export async function getMealPlanStoreModeData({
     selectedStorePreference?.selectedStoreId ?? null,
   );
   const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
+  const todayAtUtcMidnight = getUtcToday();
   const dueItems = projectedItems
-    .filter((item) => isProjectedItemDueBy(item, activeShoppingDate))
+    .filter((item) =>
+      isProjectedItemInStoreModeTrip(
+        item,
+        activeShoppingDate,
+        mealPlan.endDate,
+        todayAtUtcMidnight,
+      ),
+    )
     .sort((left, right) =>
       compareProjectedItemsForStoreMode(
         left,
@@ -454,7 +462,13 @@ export async function getMealPlanStoreModeData({
       ),
     );
   const laterItems = projectedItems
-    .filter((item) => !isProjectedItemDueBy(item, activeShoppingDate))
+    .filter((item) =>
+      isProjectedItemBeforeShoppingDate(
+        item,
+        activeShoppingDate,
+        todayAtUtcMidnight,
+      ),
+    )
     .sort(compareProjectedItemsByRelevantDate);
 
   return {
@@ -1016,14 +1030,67 @@ function resolveSelectedStoreSummary(
   };
 }
 
-function isProjectedItemDueBy(item: ProjectedShoppingItem, activeShoppingDate: Date) {
+function getUtcToday(referenceDate = new Date()) {
+  return new Date(
+    Date.UTC(
+      referenceDate.getUTCFullYear(),
+      referenceDate.getUTCMonth(),
+      referenceDate.getUTCDate(),
+    ),
+  );
+}
+
+function isProjectedItemPast(
+  item: ProjectedShoppingItem,
+  todayAtUtcMidnight: Date,
+) {
+  const relevantDate = getProjectedItemRelevantDate(item);
+
+  if (!relevantDate) {
+    return false;
+  }
+
+  return relevantDate.getTime() < todayAtUtcMidnight.getTime();
+}
+
+function isProjectedItemInStoreModeTrip(
+  item: ProjectedShoppingItem,
+  activeShoppingDate: Date,
+  endDate: Date,
+  todayAtUtcMidnight: Date,
+) {
+  if (isProjectedItemPast(item, todayAtUtcMidnight)) {
+    return false;
+  }
+
   const relevantDate = getProjectedItemRelevantDate(item);
 
   if (!relevantDate) {
     return true;
   }
 
-  return relevantDate.getTime() <= activeShoppingDate.getTime();
+  return (
+    relevantDate.getTime() >= activeShoppingDate.getTime() &&
+    relevantDate.getTime() <= endDate.getTime()
+  );
+}
+
+function isProjectedItemBeforeShoppingDate(
+  item: ProjectedShoppingItem,
+  activeShoppingDate: Date,
+  todayAtUtcMidnight: Date,
+) {
+  if (isProjectedItemPast(item, todayAtUtcMidnight)) {
+    return false;
+  }
+
+  const relevantDate = getProjectedItemRelevantDate(item);
+
+  if (!relevantDate) {
+    return false;
+  }
+
+  return relevantDate.getTime() < activeShoppingDate.getTime();
 }
 
 function getProjectedItemRelevantDate(item: ProjectedShoppingItem) {

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1,10 +1,12 @@
 import { ShoppingItemSource } from "@prisma/client";
+import type { ChangeEvent } from "react";
 import {
   Form,
   Link,
   isRouteErrorResponse,
   useFetcher,
   useNavigation,
+  useSubmit,
   type MetaFunction,
 } from "react-router";
 
@@ -236,8 +238,15 @@ export default function FamilyMealPlanStoreModeRoute({
   loaderData,
 }: FamilyMealPlanStoreModeRouteProps) {
   const navigation = useNavigation();
+  const submit = useSubmit();
   const toggleFetcher = useFetcher<StoreModeActionData>();
   const pendingIntent = navigation.formData?.get("intent");
+  const isSavingStore =
+    navigation.state === "submitting" &&
+    pendingIntent === "update-selected-store";
+  const isSavingShoppingDate =
+    navigation.state === "submitting" &&
+    pendingIntent === "update-active-shopping-date";
   const pendingSourceKey = getPendingSourceKey(toggleFetcher.formData);
   const toggleFormError =
     toggleFetcher.data?.intent === "toggle-shopping-item-checked" &&
@@ -273,8 +282,7 @@ export default function FamilyMealPlanStoreModeRoute({
                 </h1>
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300">
                   Storflatevisning for handleturen med seksjonsrekkefølge fra
-                  valgt butikk og bare varer som er relevante innen
-                  handledatoen.
+                  valgt butikk og varer fra handledato og utover i ukeplanen.
                 </p>
               </div>
               <div className="flex flex-wrap gap-3">
@@ -367,9 +375,14 @@ export default function FamilyMealPlanStoreModeRoute({
                 value="update-selected-store"
               />
               <select
-                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                aria-busy={isSavingStore}
+                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
                 defaultValue={selectedStoreValue}
+                disabled={isSavingStore}
                 name="selectedStoreId"
+                onChange={(event) => {
+                  submitSelectForm(event, selectedStoreValue, submit);
+                }}
               >
                 {loaderData.stores.map((store) => (
                   <option key={store.id} value={store.id}>
@@ -383,19 +396,6 @@ export default function FamilyMealPlanStoreModeRoute({
                   {actionData.selectedStoreFieldErrors.selectedStoreId}
                 </p>
               ) : null}
-              <button
-                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={
-                  navigation.state === "submitting" &&
-                  pendingIntent === "update-selected-store"
-                }
-                type="submit"
-              >
-                {navigation.state === "submitting" &&
-                pendingIntent === "update-selected-store"
-                  ? "Lagrer butikk..."
-                  : "Lagre butikkvalg"}
-              </button>
             </Form>
           </article>
 
@@ -415,9 +415,14 @@ export default function FamilyMealPlanStoreModeRoute({
                 value={loaderData.mealPlan.updatedAt}
               />
               <select
-                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                aria-busy={isSavingShoppingDate}
+                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
                 defaultValue={activeShoppingDateValue}
+                disabled={isSavingShoppingDate}
                 name="activeShoppingDate"
+                onChange={(event) => {
+                  submitSelectForm(event, activeShoppingDateValue, submit);
+                }}
               >
                 {loaderData.visibleDates.map((date) => (
                   <option key={date} value={date}>
@@ -431,19 +436,6 @@ export default function FamilyMealPlanStoreModeRoute({
                   {actionData.activeShoppingDateFieldErrors.activeShoppingDate}
                 </p>
               ) : null}
-              <button
-                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={
-                  navigation.state === "submitting" &&
-                  pendingIntent === "update-active-shopping-date"
-                }
-                type="submit"
-              >
-                {navigation.state === "submitting" &&
-                pendingIntent === "update-active-shopping-date"
-                  ? "Lagrer dato..."
-                  : "Lagre handledato"}
-              </button>
             </Form>
           </article>
         </section>
@@ -593,15 +585,15 @@ export default function FamilyMealPlanStoreModeRoute({
               Ingen varer må handles nå
             </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600">
-              Alt er enten ferdig handlet eller planlagt for senere i den aktive
-              ukeplanen.
+              Alt er enten ferdig handlet, utenfor denne handleturen, eller
+              allerede passert.
             </p>
           </section>
         )}
 
         <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
           <h2 className="text-lg font-semibold text-slate-950">
-            Senere i perioden
+            Før handledato
           </h2>
           <div className="mt-4 flex flex-wrap gap-2">
             {loaderData.laterItems.length > 0 ? (
@@ -621,7 +613,7 @@ export default function FamilyMealPlanStoreModeRoute({
               ))
             ) : (
               <p className="text-sm leading-6 text-slate-600">
-                Ingen senere varer akkurat nå.
+                Ingen varer ligger før handledato akkurat nå.
               </p>
             )}
           </div>
@@ -739,6 +731,24 @@ function buildStoreModeRedirect({
   url.searchParams.set("notice", notice);
 
   return Response.redirect(url, 302);
+}
+
+function submitSelectForm(
+  event: ChangeEvent<HTMLSelectElement>,
+  currentValue: string,
+  submit: ReturnType<typeof useSubmit>,
+) {
+  const nextValue = event.currentTarget.value;
+
+  if (nextValue === currentValue) {
+    return;
+  }
+
+  const form = event.currentTarget.form;
+
+  if (form) {
+    void submit(form);
+  }
 }
 
 function parseShoppingItemSource(value: FormDataEntryValue | null) {


### PR DESCRIPTION
## Summary
- Butikkmodus shows shopping items from handledato through the meal plan end (not only that calendar day).
- Past meals (before today at UTC midnight) are hidden from both the main list and «Før handledato».
- Store and handledato dropdowns save automatically on change; save buttons removed.

## Related issue
Closes #54

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [x] Manual: set handledato to Monday in a Mon–Fri plan — all week items appear in sections
- [x] Manual: change store/date — list updates without clicking save
- [x] Manual: items for days before today are not shown

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (159 tests)
- npm run typecheck