### PR TITLE
Collapse Oppskriftsbank on mobile

### DIFF
--- a/.cursor/skills/fallow-code-health/SKILL.md
+++ b/.cursor/skills/fallow-code-health/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: fallow-code-health
+description: Audits the mealplanner codebase with Fallow for dead code, unused dependencies, duplication, complexity, and architecture issues. Use when the user asks for code health analysis, cleanup, dead code removal, unused exports, duplicate code, complexity hotspots, or to run fallow on this project.
+---
+
+# Fallow code health (mealplanner)
+
+## Goal
+
+Run [Fallow](https://docs.fallow.tools) static analysis on this repo, interpret results with mealplanner-specific context, and propose safe cleanup — without breaking React Router routes, Prisma, or server-only modules.
+
+## Prerequisites
+
+1. **Read the global Fallow skill** at `~/.cursor/skills/fallow-skills/fallow/skills/fallow/SKILL.md` for CLI rules, JSON flags, issue types, `fix` workflow, and MCP tools. Follow its agent rules (especially `--format json --quiet 2>/dev/null`, `|| true`, never `fallow watch`).
+2. **Fallow is a devDependency** — use `npm run analyze:*` or `npx fallow` from the repo root.
+
+3. **No project config yet** — Fallow auto-detects React Router, Vite, Vitest, and Prisma. Only add `.fallowrc.json` after reviewing false positives; do not add remote `extends` URLs.
+
+## What Fallow covers here (and what it does not)
+
+| Use Fallow for | Use something else for |
+|----------------|------------------------|
+| Unused files, exports, types, deps | ESLint style (`npm run lint`) |
+| Duplicate code | Type errors (`npm run typecheck`) |
+| Complexity hotspots | Runtime bugs / test failures (`npm run test:run`) |
+| Circular / boundary issues | Security scanning |
+
+Fallow complements CI (`lint`, `test:run`, `typecheck`, `build`); it does not replace them.
+
+## Project map (interpretation hints)
+
+| Path | Role | Common Fallow notes |
+|------|------|---------------------|
+| `app/routes.ts` | Route manifest (entry) | Exports here are consumed by the framework |
+| `app/routes/**` | Pages, loaders, actions | Route modules are entry points |
+| `app/lib/**.server.ts` | Server-only logic | Imported from routes/actions; `.server` suffix is intentional |
+| `app/components/**` | UI | May look unused until wired into a route |
+| `app/features/**` | Feature modules | Same as components |
+| `app/test/**`, `**/*.test.ts(x)` | Vitest | Use `--production` only when auditing prod-only dead code |
+| `prisma/**`, `prisma.config.ts` | DB schema & seed | Seed scripts may reference deps only at runtime |
+| `prototype/**` | Legacy spike | Often entirely unreachable — confirm with user before deleting |
+| `entry.server.tsx`, `app/root.tsx` | App shell | Entry points |
+
+Stack: React Router 7, Vite, Vitest, Prisma, Tailwind 4, single package (not a monorepo).
+
+## Audit workflow
+
+Copy and track progress:
+
+```
+- [ ] Step 1: Confirm Fallow available
+- [ ] Step 2: Baseline dead code
+- [ ] Step 3: Duplication (if requested or many large files)
+- [ ] Step 4: Complexity (if requested or refactor prep)
+- [ ] Step 5: Summarize with priorities
+- [ ] Step 6: Fix only with explicit user approval
+```
+
+### Step 1: Confirm Fallow
+
+```bash
+npx fallow --version 2>/dev/null
+npx fallow list --entry-points --format json --quiet 2>/dev/null || true
+npx fallow list --plugins --format json --quiet 2>/dev/null || true
+```
+
+Or use the npm scripts: `analyze:dead-code`, `analyze:dupes`, `analyze:health`.
+
+Verify React Router / Vite / Vitest plugins are detected.
+
+### Step 2: Dead code baseline
+
+Full audit (default starting point):
+
+```bash
+npm run analyze:dead-code -- --explain 2>/dev/null || true
+# equivalent: npx fallow dead-code --format json --quiet --explain 2>/dev/null || true
+```
+
+Targeted passes when the user names a concern:
+
+```bash
+# Unused exports only (smaller JSON)
+npx fallow dead-code --format json --quiet --unused-exports 2>/dev/null || true
+
+# Unused dependencies
+npx fallow dead-code --format json --quiet --unused-deps 2>/dev/null || true
+
+# Production code only (excludes tests/stories)
+npx fallow dead-code --format json --quiet --production 2>/dev/null || true
+
+# PR-scoped (replace main with the PR base branch)
+npx fallow dead-code --format json --quiet --changed-since main 2>/dev/null || true
+```
+
+Before deleting a symbol, trace it:
+
+```bash
+npx fallow dead-code --format json --quiet --trace app/lib/example.server.ts:myExport 2>/dev/null || true
+npx fallow dead-code --format json --quiet --trace-file app/components/example.tsx 2>/dev/null || true
+npx fallow dead-code --format json --quiet --trace-dependency some-package 2>/dev/null || true
+```
+
+### Step 3: Duplication (optional)
+
+```bash
+npm run analyze:dupes 2>/dev/null || true
+```
+
+Prioritize clones in `app/lib` and large route files (e.g. `family-recipes.tsx`).
+
+### Step 4: Complexity (optional)
+
+```bash
+npm run analyze:health 2>/dev/null || true
+```
+
+Flag functions with high cyclomatic/cognitive complexity; tie recommendations to concrete files.
+
+### Step 5: Report to the user
+
+Use this structure:
+
+```markdown
+## Fallow code health — mealplanner
+
+### Summary
+- Total issues: …
+- Highest-impact areas: …
+
+### Recommended actions
+1. **Safe now** — …
+2. **Verify first** — … (e.g. `prototype/`, barrel re-exports)
+3. **Defer** — …
+
+### Findings
+| Severity | Type | Location | Notes |
+|----------|------|----------|-------|
+| … | unused-export | … | … |
+
+### Not in scope
+- ESLint / typecheck / test fixes unless linked to a finding
+```
+
+Group by impact: unused dependencies → unused files → unused exports → duplication → complexity.
+
+**False-positive checklist** before recommending deletion:
+
+- React Router route modules and `app/routes.ts` exports
+- Loader/action exports only referenced from route config
+- `.server.ts` modules only imported from other server modules
+- Prisma seed-only or CLI-only dependencies (`tsx`, `prisma`)
+- `prototype/**` — ask whether to delete the folder or add `ignorePatterns`
+- Symbols used only in tests when using `--production`
+
+### Step 6: Fixes (user approval required)
+
+Never run `fallow fix` without explicit user consent.
+
+```bash
+npx fallow fix --dry-run --format json --quiet 2>/dev/null || true
+# After user approves:
+npx fallow fix --yes --format json --quiet 2>/dev/null || true
+```
+
+After fixes: `npm run lint`, `npm run test:run`, `npm run typecheck`.
+
+## npm scripts
+
+| Script | Command |
+|--------|---------|
+| `npm run analyze:dead-code` | Dead code audit (JSON) |
+| `npm run analyze:dupes` | Top 20 duplicate clusters |
+| `npm run analyze:health` | Complexity hotspots (top 15, scored) |
+
+Pass extra flags after `--`, e.g. `npm run analyze:dead-code -- --unused-exports --production`.
+
+## CI (optional, user-driven)
+
+Fallow is not in PR validation today. Suggest `fallow dead-code --ci --changed-since origin/main` only when the user wants a new check; do not wire CI without approval.
+
+## Additional resources
+
+- Full Fallow CLI/MCP reference: `~/.cursor/skills/fallow-skills/fallow/skills/fallow/SKILL.md`
+- Docs: https://docs.fallow.tools

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,18 +2,17 @@
 
 ## Current Objective
 
-Issue #56 shipped on branch `issue/56-mobile-meal-plan-calendar` — mobile week overview, hero approval, family-wide approve/reopen, plus mobile overflow fix for Ukeoversikt.
+Issue #58 on branch `issue/58-collapse-recipe-bank-mobile` — collapse Oppskriftsbank on mobile to cut vertical scrolling on the meal plan page.
 
 ## Completed
 
-- Mobile-first meal plan week view with collapsible day rows and hero approval.
-- Family-wide `approveMealPlan` / `reopenMealPlan` via `requireFamilyMembership`.
-- Fixed horizontal scroll on mobile: `min-w-0` chain, constrained inputs, `overflow-x-hidden` on main.
+- Mobile-only `<details>` for Oppskriftsbank (collapsed by default) with title, recipe count, and Åpne/Lukk affordance.
+- Desktop `lg+` block stays always visible via `hidden lg:block`.
+- Shared `RecipeBankContent` component to avoid duplicating recipe cards and admin link.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan.tsx` — week overview, approval hero, overflow constraints
-- `app/lib/meal-plan.server.ts` — approval authorization
+- `app/routes/family-meal-plan.tsx` — Oppskriftsbank article, `RecipeBankContent`, `formatRecipeCount`
 
 ## Validation
 
@@ -24,8 +23,9 @@ Issue #56 shipped on branch `issue/56-mobile-meal-plan-calendar` — mobile week
 
 ## Open Items
 
-- PR #57 merge and manual mobile smoke-test.
+- PR merge and manual mobile smoke-test (~390px): collapsed on load, expand/collapse, «I planen» badges when expanded.
+- Unrelated local changes (README, package.json, vite.config) were not included in the commit.
 
 ## Next Step
 
-Merge PR #57; confirm no horizontal scroll on Ukeoversikt at ~390px width.
+Merge PR when CI is green; confirm Oppskriftsbank behavior at mobile and desktop breakpoints.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ npm run lint
 npm run test -- --run
 npm run build
 npm run typecheck
+npm run analyze:dead-code
+npm run analyze:dupes
+npm run analyze:health
 npm run prisma:migrate:dev -- --name <migration_name>
 npm run prisma:migrate:deploy
 npm run prisma:migrate:status

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -624,66 +624,44 @@ export default function FamilyMealPlanRoute({
           </article>
 
           <article className="min-w-0 w-full rounded-[28px] bg-white p-4 shadow-sm ring-1 ring-slate-200 sm:p-6">
-            <div className="flex flex-col gap-2">
+            <details className="group min-w-0 lg:hidden">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-2 marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-emerald-500 [&::-webkit-details-marker]:hidden">
+                <div className="min-w-0 flex-1">
+                  <h2 className="text-lg font-semibold text-slate-950">
+                    Oppskriftsbank
+                  </h2>
+                  <p className="text-sm text-slate-600">
+                    {formatRecipeCount(loaderData.recipes.length)}
+                  </p>
+                </div>
+                <div className="flex shrink-0 flex-col items-end gap-1">
+                  <span className="text-xs text-slate-400 group-open:hidden">
+                    Åpne
+                  </span>
+                  <span className="hidden text-xs text-slate-400 group-open:inline">
+                    Lukk
+                  </span>
+                </div>
+              </summary>
+
+              <div className="mt-4 min-w-0 border-t border-slate-200 pt-4">
+                <RecipeBankContent
+                  familyId={loaderData.family.id}
+                  recipes={loaderData.recipes}
+                  selectedRecipeIds={selectedRecipeIds}
+                />
+              </div>
+            </details>
+
+            <div className="hidden min-w-0 lg:block">
               <h2 className="text-lg font-semibold text-slate-950">
                 Oppskriftsbank
               </h2>
-              <p className="text-sm leading-6 text-slate-600">
-                Standard- og familieoppskrifter du kan velge til middagene i
-                planen.
-              </p>
-              <Link
-                className="mt-1 inline-flex w-fit items-center justify-center rounded-2xl bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-800 ring-1 ring-emerald-200 transition hover:bg-emerald-100"
-                to={`/families/${loaderData.family.id}/recipes`}
-              >
-                Administrer oppskrifter
-              </Link>
-            </div>
-
-            <div className="mt-4 grid gap-2 lg:mt-6 lg:gap-3">
-              {loaderData.recipes.map((recipe) => (
-                <article
-                  key={recipe.id}
-                  className={
-                    selectedRecipeIds.has(recipe.id)
-                      ? "rounded-[24px] border border-emerald-200 bg-emerald-50 p-5"
-                      : "rounded-[24px] border border-slate-200 bg-slate-50 p-5"
-                  }
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <h3 className="text-base font-semibold text-slate-950">
-                        {recipe.title}
-                      </h3>
-                      <p className="mt-2 text-sm leading-6 text-slate-600">
-                        {recipe.description}
-                      </p>
-                    </div>
-                    {selectedRecipeIds.has(recipe.id) ? (
-                      <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
-                        I planen
-                      </span>
-                    ) : null}
-                  </div>
-
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
-                      {recipe.prepMinutes ?? "?"} min
-                    </span>
-                    <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
-                      {recipe.defaultServings ?? "?"} personer
-                    </span>
-                    {recipe.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </article>
-              ))}
+              <RecipeBankContent
+                familyId={loaderData.family.id}
+                recipes={loaderData.recipes}
+                selectedRecipeIds={selectedRecipeIds}
+              />
             </div>
           </article>
         </section>
@@ -1082,6 +1060,80 @@ function MealPlanApprovalSection({
         </button>
       </Form>
     </div>
+  );
+}
+
+function formatRecipeCount(count: number) {
+  return count === 1 ? "1 oppskrift" : `${count} oppskrifter`;
+}
+
+function RecipeBankContent({
+  familyId,
+  recipes,
+  selectedRecipeIds,
+}: {
+  familyId: string;
+  recipes: MealPlanRecipeOption[];
+  selectedRecipeIds: Set<string>;
+}) {
+  return (
+    <>
+      <p className="mt-2 text-sm leading-6 text-slate-600">
+        Standard- og familieoppskrifter du kan velge til middagene i planen.
+      </p>
+      <Link
+        className="mt-1 inline-flex w-fit items-center justify-center rounded-2xl bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-800 ring-1 ring-emerald-200 transition hover:bg-emerald-100"
+        to={`/families/${familyId}/recipes`}
+      >
+        Administrer oppskrifter
+      </Link>
+
+      <div className="mt-4 grid gap-2 lg:mt-6 lg:gap-3">
+        {recipes.map((recipe) => (
+          <article
+            key={recipe.id}
+            className={
+              selectedRecipeIds.has(recipe.id)
+                ? "rounded-[24px] border border-emerald-200 bg-emerald-50 p-5"
+                : "rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+            }
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-base font-semibold text-slate-950">
+                  {recipe.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  {recipe.description}
+                </p>
+              </div>
+              {selectedRecipeIds.has(recipe.id) ? (
+                <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
+                  I planen
+                </span>
+              ) : null}
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                {recipe.prepMinutes ?? "?"} min
+              </span>
+              <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                {recipe.defaultServings ?? "?"} personer
+              </span>
+              {recipe.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.1.1",
+        "fallow": "^2.76.0",
         "globals": "^17.6.0",
         "jsdom": "^26.1.0",
         "prisma": "^6.19.3",
@@ -1286,6 +1287,118 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fallow-cli/darwin-arm64": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.76.0.tgz",
+      "integrity": "sha512-6yspnFAzVXErJlucLPmZwzTOvN38WWaMioeLjU8HiOEqtacoI4tS/vUutGPnQYV7iZ4dRnZGvj/9lEodMs2YGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/darwin-x64": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.76.0.tgz",
+      "integrity": "sha512-5ARqPI4Jo+1D6TB7QA7XZy42SkKfokK9buUhsW5vN869bPm3seB3/NcBZSAboV9PVLjvdg0w2Gow53ltMn6xmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-gnu": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.76.0.tgz",
+      "integrity": "sha512-1QFtpLGBO5mqi5CU2Yq1z7mZQlhtI4sGq7oQIYEqYAccN8aP35iRVQU64VC+bUmurfKMlNB1eIh0nmVNuf24NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-musl": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.76.0.tgz",
+      "integrity": "sha512-NqYwMJYEQcG5l9szwxJunySbLTABkQUwdi8lB+1iJ9ONABvjOAR2fUBNAYRdxE/iAOcf7WvfJFepk2GTUz3fCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-gnu": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.76.0.tgz",
+      "integrity": "sha512-lrVeUbPeQpPndTyBKPlOHzwws4flkJ5dCzn4MPtzTwnGfdNXOtHQtSX2XDaDuUhAMG9FSEfhQsNEZk0bmsO6OA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-musl": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.76.0.tgz",
+      "integrity": "sha512-RoIS2W+ZKi0TghZiPZlMj2Ecxj7cK928eU+VVPhLjKm5pg3kumKSuA9wu8OFWyJ7OrbHPU1uWMOBJj6+l9KzsA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-arm64-msvc": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.76.0.tgz",
+      "integrity": "sha512-sjTIR4L5Vr3x4wUWiHbdAbKWm6QSIK1tQUej11kX8Ucm/khXByG/Dy3Jhh3KuYrf1walVDvXcjCWeHPQioKUpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-x64-msvc": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.76.0.tgz",
+      "integrity": "sha512-9m6hvgEUiqZ/r0C16eJ+eXk1kTRmRy980GzCKKdDNUdd9v9gcdFqhaj8f6ChAjfcC0JOMyfoHZ+WSRSpiTyQOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -4412,6 +4525,35 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/fallow": {
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.76.0.tgz",
+      "integrity": "sha512-Z/09g/mPw4wkkbA5nuL7P9k7hbdQ4QpYxmgX+z4RzsosGa3BFfkaBoaMeqdo0ERU529WnbWjnRjY4QLyVyCOIQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "fallow": "bin/fallow",
+        "fallow-lsp": "bin/fallow-lsp",
+        "fallow-mcp": "bin/fallow-mcp"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@fallow-cli/darwin-arm64": "2.76.0",
+        "@fallow-cli/darwin-x64": "2.76.0",
+        "@fallow-cli/linux-arm64-gnu": "2.76.0",
+        "@fallow-cli/linux-arm64-musl": "2.76.0",
+        "@fallow-cli/linux-x64-gnu": "2.76.0",
+        "@fallow-cli/linux-x64-musl": "2.76.0",
+        "@fallow-cli/win32-arm64-msvc": "2.76.0",
+        "@fallow-cli/win32-x64-msvc": "2.76.0"
+      }
     },
     "node_modules/fast-check": {
       "version": "3.23.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "analyze:dead-code": "fallow dead-code --format json --quiet",
+    "analyze:dupes": "fallow dupes --format json --quiet --top 20",
+    "analyze:health": "fallow health --format json --quiet --score --top 15",
     "backlog:issues": "node ./scripts/create-github-issues-from-brief.mjs",
     "build": "react-router build",
     "dev": "react-router dev",
@@ -43,6 +46,7 @@
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "fallow": "^2.76.0",
     "globals": "^17.6.0",
     "jsdom": "^26.1.0",
     "prisma": "^6.19.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [tailwindcss(), reactRouter()],
+  server: {
+    host: true,
+    port: 5173,
+  },
   resolve: {
     tsconfigPaths: true,
   },


### PR DESCRIPTION
## Summary
- Collapse **Oppskriftsbank** by default on viewports below `lg`, with a tap-to-expand `<details>` panel (title, recipe count, Åpne/Lukk).
- Keep the recipe bank always visible on desktop via a separate `lg:block` section.
- Extract shared `RecipeBankContent` so mobile and desktop render the same cards and admin link.

## Related issue
Closes #58

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Mobile (~390px): bank collapsed on load; expand shows full list, admin link, and «I planen» badges; collapse again
- [ ] Desktop (`lg+`): bank visible without toggle
- [ ] Regression: day row expand, recipe `<select>`, save and auto-fill still work

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck