### PR TITLE
Faster manual shopping items: recents, autocomplete, and quick-add

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,35 @@
 
 ## Current Objective
 
-Issue #60 — PR ready on branch `issue/60-dedupe-shopping-ingredients`: deduplicate shopping list ingredients across recipes and days, with clear per-meal attribution.
+Issue #62 — PR ready on branch `issue/62-faster-manual-shopping`: faster manual shopping items with recents, autocomplete, and quick-add defaults.
 
 ## Completed
 
-- Merge generated shopping lines by canonical ingredient / name + category (not amount or preferred store).
-- Sum quantities when the same unit appears across multiple planned meals (e.g. Lasagne Mon + Tue → 2 stk).
-- Per-occurrence amounts in Kilder; `preferredStoreConflict` badge when stores differ.
-- Legacy `shoppingOverrides` fallback for old single-occurrence `sourceKey`s.
-- Store mode and shopping list show every planned meal (e.g. `Lasagne mandag 11. mai og Lasagne tirsdag 12. mai`).
-- Shared helpers in `app/lib/shopping-display.ts` + tests.
+- Quick-add bar on the shopping list: one-click recents, ingredient typeahead, and add-new with Annet / qty 1 defaults.
+- Server quick-add path resolves category server-side (`other` / Annet, ingredient default, or recent quantity+category).
+- Lightweight `shopping/ingredient-search` route for typeahead (avoids refetching full shopping loader).
+- `ManualShoppingQuickAdd` client component with debounced `useFetcher` search and `useSubmit` for reliable adds.
+- Collapsible advanced form retained for full-field manual entry.
+- Fixed layout jump on search and cancelled typeahead submits (unmount-before-POST).
 
 ## Files To Read First
 
-- `app/lib/shopping.server.ts` — merge, sum, overrides
-- `app/lib/shopping-display.ts` — occurrence attribution copy
-- `app/routes/family-meal-plan-shopping.tsx` — list UI
-- `app/routes/family-meal-plan-store-mode.tsx` — store mode UI
+- `app/components/manual-shopping-quick-add.tsx` — quick-add UI, search fetcher, submit flow
+- `app/lib/shopping-write.server.ts` — `createQuickManualShoppingItem`, value resolution
+- `app/routes/family-meal-plan-shopping.tsx` — loader/action integration
+- `app/routes/family-meal-plan-shopping-ingredient-search.ts` — typeahead loader
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 167 tests passed (32 files)
+- `npm run test:run` — 174 tests passed (33 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke-test: shared ingredient across recipes, same recipe on two days, store mode attribution.
+- Manual smoke-test: recent chip, typeahead pick, new name quick-add, edit line after add.
 
 ## Next Step
 

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useFetcher, useNavigation, useSubmit } from "react-router";
+
+import type { RecentManualShoppingItem } from "../lib/shopping.server";
+
+export interface IngredientSearchResult {
+  canonicalName: string;
+  defaultCategoryId: string | null;
+  id: string;
+}
+
+interface ManualShoppingQuickAddLoaderSlice {
+  ingredientSearchResults: IngredientSearchResult[];
+}
+
+interface ManualShoppingQuickAddProps {
+  ingredientSearchPath: string;
+  recentManualItems: RecentManualShoppingItem[];
+}
+
+const MIN_SEARCH_LENGTH = 2;
+const SEARCH_DEBOUNCE_MS = 250;
+const QUICK_ADD_INTENT = "quick-add-manual-shopping-item";
+
+export function ManualShoppingQuickAdd({
+  ingredientSearchPath,
+  recentManualItems,
+}: ManualShoppingQuickAddProps) {
+  const listboxId = useId();
+  const navigation = useNavigation();
+  const submit = useSubmit();
+  const searchFetcher = useFetcher<ManualShoppingQuickAddLoaderSlice>({
+    key: "manual-shopping-ingredient-search",
+  });
+  const [query, setQuery] = useState("");
+  const [isListOpen, setIsListOpen] = useState(false);
+  const [displayedResults, setDisplayedResults] = useState<IngredientSearchResult[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lastRequestedQueryRef = useRef<string | null>(null);
+  const searchFetcherRef = useRef(searchFetcher);
+  searchFetcherRef.current = searchFetcher;
+  const pendingIntent = navigation.formData?.get("intent");
+  const isQuickAdding =
+    navigation.state === "submitting" && pendingIntent === QUICK_ADD_INTENT;
+
+  const trimmedQuery = query.trim();
+  const isSearching =
+    searchFetcher.state === "loading" && trimmedQuery.length >= MIN_SEARCH_LENGTH;
+
+  function submitQuickAdd(fields: {
+    ingredientId?: string;
+    name?: string;
+    recentNameNormalized?: string;
+  }) {
+    const formData = new FormData();
+    formData.set("intent", QUICK_ADD_INTENT);
+
+    if (fields.ingredientId) {
+      formData.set("ingredientId", fields.ingredientId);
+    }
+
+    if (fields.name) {
+      formData.set("name", fields.name);
+    }
+
+    if (fields.recentNameNormalized) {
+      formData.set("recentNameNormalized", fields.recentNameNormalized);
+    }
+
+    submit(formData, { method: "post" });
+  }
+
+  useEffect(() => {
+    if (searchFetcher.data?.ingredientSearchResults) {
+      setDisplayedResults(searchFetcher.data.ingredientSearchResults);
+    }
+  }, [searchFetcher.data]);
+
+  useEffect(() => {
+    if (trimmedQuery.length < MIN_SEARCH_LENGTH) {
+      lastRequestedQueryRef.current = null;
+      setDisplayedResults([]);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      if (lastRequestedQueryRef.current === trimmedQuery) {
+        return;
+      }
+
+      lastRequestedQueryRef.current = trimmedQuery;
+      const params = new URLSearchParams({ q: trimmedQuery });
+      searchFetcherRef.current.load(`${ingredientSearchPath}?${params.toString()}`);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [ingredientSearchPath, trimmedQuery]);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsListOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isQuickAdding) {
+      return;
+    }
+
+    setIsListOpen(false);
+    setQuery("");
+    lastRequestedQueryRef.current = null;
+  }, [isQuickAdding]);
+
+  const hasExactMatch = useMemo(
+    () =>
+      displayedResults.some(
+        (ingredient) =>
+          ingredient.canonicalName.trim().toLowerCase() === trimmedQuery.toLowerCase(),
+      ),
+    [displayedResults, trimmedQuery],
+  );
+  const showDropdown = isListOpen && trimmedQuery.length >= MIN_SEARCH_LENGTH;
+  const showCreateOption = trimmedQuery.length > 0 && !hasExactMatch && !isSearching;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label className="block text-sm font-medium text-slate-700" htmlFor={`${listboxId}-input`}>
+          Legg til vare
+        </label>
+        <p className="text-sm leading-6 text-slate-600">
+          Søk i ingrediensregisteret, skriv et nytt navn, eller velg en nylig brukt vare.
+        </p>
+      </div>
+
+      <div className="relative" ref={containerRef}>
+        <div className="flex gap-2">
+          <input
+            aria-autocomplete="list"
+            aria-controls={showDropdown ? listboxId : undefined}
+            aria-expanded={showDropdown}
+            className="min-w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            id={`${listboxId}-input`}
+            name="quickAddQuery"
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setIsListOpen(true);
+            }}
+            onFocus={() => {
+              setIsListOpen(true);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                setIsListOpen(false);
+                return;
+              }
+
+              if (event.key === "Enter" && trimmedQuery && !isQuickAdding) {
+                event.preventDefault();
+                submitQuickAdd({ name: trimmedQuery });
+              }
+            }}
+            placeholder="For eksempel melk"
+            type="search"
+            value={query}
+          />
+          <button
+            className="inline-flex h-full shrink-0 items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+            disabled={!trimmedQuery || isQuickAdding}
+            onClick={() => {
+              submitQuickAdd({ name: trimmedQuery });
+            }}
+            type="button"
+          >
+            {isQuickAdding ? "Legger til..." : "Legg til"}
+          </button>
+        </div>
+
+        {showDropdown ? (
+          <ul
+            className="absolute z-10 mt-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg"
+            id={listboxId}
+            role="listbox"
+          >
+            {isSearching ? (
+              <li className="px-4 py-2 text-sm text-slate-500" role="presentation">
+                Søker...
+              </li>
+            ) : null}
+            {displayedResults.map((ingredient) => (
+              <li key={ingredient.id} role="option">
+                <button
+                  className="flex w-full items-center justify-between px-4 py-3 text-left text-sm text-slate-900 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={isQuickAdding}
+                  onClick={() => {
+                    submitQuickAdd({ ingredientId: ingredient.id });
+                  }}
+                  type="button"
+                >
+                  <span className="font-medium">{ingredient.canonicalName}</span>
+                  <span className="text-xs text-slate-500">Fra register</span>
+                </button>
+              </li>
+            ))}
+            {showCreateOption ? (
+              <li role="option">
+                <button
+                  className="flex w-full px-4 py-3 text-left text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={isQuickAdding}
+                  onClick={() => {
+                    submitQuickAdd({ name: trimmedQuery });
+                  }}
+                  type="button"
+                >
+                  Legg til «{trimmedQuery}»
+                </button>
+              </li>
+            ) : null}
+          </ul>
+        ) : null}
+      </div>
+
+      {recentManualItems.length > 0 ? (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-slate-700">Nylig brukt</p>
+          <div className="flex flex-wrap gap-2">
+            {recentManualItems.map((item) => (
+              <button
+                key={item.nameNormalized}
+                className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-800 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isQuickAdding}
+                onClick={() => {
+                  submitQuickAdd({ recentNameNormalized: item.nameNormalized });
+                }}
+                type="button"
+              >
+                {item.displayName}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -21,6 +21,9 @@ const {
   return {
     dbMock: {
       $transaction: vi.fn(),
+      ingredient: {
+        findUnique: vi.fn(),
+      },
       ingredientCategory: {
         findUnique: vi.fn(),
       },
@@ -28,6 +31,7 @@ const {
         create: vi.fn(),
         deleteMany: vi.fn(),
         findFirst: vi.fn(),
+        findMany: vi.fn(),
         update: vi.fn(),
         updateMany: vi.fn(),
       },
@@ -91,7 +95,9 @@ vi.mock("./stock.server", () => {
 
 import {
   createManualShoppingItem,
+  createQuickManualShoppingItem,
   deleteManualShoppingItem,
+  resolveQuickAddManualShoppingItemValues,
   excludeGeneratedShoppingItem,
   optInStockShoppingItems,
   restoreGeneratedShoppingItem,
@@ -196,6 +202,98 @@ describe("shopping-write.server", () => {
         note: "Til smoothien",
         preferredStoreId: "store-1",
         quantity: "6 stk",
+        updatedByUserId: "user-1",
+      },
+    });
+  });
+
+  it("resolves quick-add values from a canonical ingredient", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.ingredient.findUnique.mockResolvedValue({
+      canonicalName: "Melk",
+      defaultCategoryId: "category-dairy",
+    });
+
+    const result = await resolveQuickAddManualShoppingItemValues({
+      familyId: "family-1",
+      input: {
+        ingredientId: "ingredient-milk",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-dairy",
+        name: "Melk",
+        note: "",
+        preferredStoreId: "",
+        quantity: "1",
+      },
+    });
+  });
+
+  it("resolves quick-add values from a recent manual item with quantity and category", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.manualShoppingItem.findMany.mockResolvedValue([
+      {
+        categoryId: "category-bakery",
+        name: "Brød",
+        quantity: "2 stk",
+      },
+    ]);
+
+    const result = await resolveQuickAddManualShoppingItemValues({
+      familyId: "family-1",
+      input: {
+        recentNameNormalized: "brød",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-bakery",
+        name: "Brød",
+        note: "",
+        preferredStoreId: "",
+        quantity: "2 stk",
+      },
+    });
+  });
+
+  it("creates a quick-add manual item with Annet defaults for new names", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+
+    const result = await createQuickManualShoppingItem({
+      familyId: "family-1",
+      input: {
+        name: "Tannkrem",
+      },
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "CREATED",
+    });
+    expect(dbMock.manualShoppingItem.create).toHaveBeenCalledWith({
+      data: {
+        buyOnDate: null,
+        categoryId: "category-other",
+        mealPlanId: "meal-plan-1",
+        name: "Tannkrem",
+        note: null,
+        preferredStoreId: null,
+        quantity: "1",
         updatedByUserId: "user-1",
       },
     });

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -7,6 +7,7 @@ import {
 } from "./collaboration.server";
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import {
   getStockIngredientsForMealPlan,
   loadShoppingMealPlan,
@@ -30,6 +31,15 @@ export interface ManualShoppingItemFieldErrors {
   preferredStoreId?: string;
 }
 
+export interface QuickAddManualShoppingItemInput {
+  ingredientId?: string;
+  name?: string;
+  recentNameNormalized?: string;
+}
+
+const OTHER_INGREDIENT_CATEGORY_KEY = "other";
+const QUICK_ADD_DEFAULT_QUANTITY = "1";
+
 export interface GeneratedShoppingItemOverrideValues {
   note: string;
   postponedUntilDate: string;
@@ -43,6 +53,39 @@ export interface GeneratedShoppingItemOverrideFieldErrors {
 
 export interface ActiveShoppingDateFieldErrors {
   activeShoppingDate?: string;
+}
+
+export async function createQuickManualShoppingItem({
+  familyId,
+  input,
+  mealPlanId,
+  userId,
+}: {
+  familyId: string;
+  input: QuickAddManualShoppingItemInput;
+  mealPlanId: string;
+  userId: string;
+}) {
+  const resolvedValues = await resolveQuickAddManualShoppingItemValues({
+    familyId,
+    input,
+  });
+
+  if (!resolvedValues.ok) {
+    return {
+      fieldErrors: resolvedValues.fieldErrors,
+      formError: resolvedValues.formError,
+      status: "VALIDATION_ERROR" as const,
+      values: resolvedValues.values,
+    };
+  }
+
+  return createManualShoppingItem({
+    familyId,
+    mealPlanId,
+    userId,
+    values: resolvedValues.values,
+  });
 }
 
 export async function createManualShoppingItem({
@@ -1506,6 +1549,169 @@ function normalizeManualShoppingItemValues(values: ManualShoppingItemValues): Ma
     note: values.note.trim(),
     preferredStoreId: values.preferredStoreId.trim(),
     quantity: values.quantity.trim(),
+  };
+}
+
+function buildEmptyManualShoppingItemValues(): ManualShoppingItemValues {
+  return {
+    buyOnDate: "",
+    categoryId: "",
+    name: "",
+    note: "",
+    preferredStoreId: "",
+    quantity: "",
+  };
+}
+
+function buildQuickAddManualShoppingItemValues({
+  categoryId,
+  name,
+  quantity = QUICK_ADD_DEFAULT_QUANTITY,
+}: {
+  categoryId: string;
+  name: string;
+  quantity?: string;
+}): ManualShoppingItemValues {
+  return {
+    buyOnDate: "",
+    categoryId,
+    name,
+    note: "",
+    preferredStoreId: "",
+    quantity,
+  };
+}
+
+export async function resolveOtherCategoryId() {
+  const category = await db.ingredientCategory.findUnique({
+    select: {
+      id: true,
+    },
+    where: {
+      key: OTHER_INGREDIENT_CATEGORY_KEY,
+    },
+  });
+
+  return category?.id ?? null;
+}
+
+async function findLatestManualShoppingItemForFamilyByNormalizedName({
+  familyId,
+  nameNormalized,
+}: {
+  familyId: string;
+  nameNormalized: string;
+}) {
+  const rows = await db.manualShoppingItem.findMany({
+    orderBy: [{ updatedAt: "desc" }],
+    select: {
+      categoryId: true,
+      name: true,
+      quantity: true,
+    },
+    take: 50,
+    where: {
+      mealPlan: {
+        familyId,
+      },
+    },
+  });
+
+  return (
+    rows.find(
+      (row) => normalizeIngredientCanonicalName(row.name) === nameNormalized,
+    ) ?? null
+  );
+}
+
+export async function resolveQuickAddManualShoppingItemValues({
+  familyId,
+  input,
+}: {
+  familyId: string;
+  input: QuickAddManualShoppingItemInput;
+}) {
+  const otherCategoryId = await resolveOtherCategoryId();
+
+  if (!otherCategoryId) {
+    return {
+      fieldErrors: {
+        categoryId: "Standardkategorien Annet mangler i systemet.",
+      },
+      formError: "Kunne ikke legge til varelinjen.",
+      ok: false as const,
+      values: buildEmptyManualShoppingItemValues(),
+    };
+  }
+
+  const ingredientId = input.ingredientId?.trim();
+
+  if (ingredientId) {
+    const ingredient = await db.ingredient.findUnique({
+      select: {
+        canonicalName: true,
+        defaultCategoryId: true,
+      },
+      where: {
+        id: ingredientId,
+      },
+    });
+
+    if (ingredient) {
+      return {
+        ok: true as const,
+        values: buildQuickAddManualShoppingItemValues({
+          categoryId: ingredient.defaultCategoryId ?? otherCategoryId,
+          name: ingredient.canonicalName,
+        }),
+      };
+    }
+  }
+
+  const recentNameNormalized = input.recentNameNormalized?.trim().toLowerCase();
+
+  if (recentNameNormalized) {
+    const recentItem = await findLatestManualShoppingItemForFamilyByNormalizedName({
+      familyId,
+      nameNormalized: recentNameNormalized,
+    });
+
+    if (recentItem) {
+      return {
+        ok: true as const,
+        values: buildQuickAddManualShoppingItemValues({
+          categoryId: recentItem.categoryId,
+          name: recentItem.name.trim(),
+          quantity: recentItem.quantity?.trim() || QUICK_ADD_DEFAULT_QUANTITY,
+        }),
+      };
+    }
+  }
+
+  const name = input.name?.trim() ?? "";
+  const fieldErrors: ManualShoppingItemFieldErrors = {};
+
+  if (!name) {
+    fieldErrors.name = "Skriv inn et varenavn.";
+  }
+
+  if (fieldErrors.name) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: buildQuickAddManualShoppingItemValues({
+        categoryId: otherCategoryId,
+        name,
+      }),
+    };
+  }
+
+  return {
+    ok: true as const,
+    values: buildQuickAddManualShoppingItemValues({
+      categoryId: otherCategoryId,
+      name,
+    }),
   };
 }
 

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -7,6 +7,9 @@ const { dbMock, getFamilyStockMatchSetMock, requireFamilyMembershipMock } =
         ingredientCategory: {
           findMany: vi.fn(),
         },
+        manualShoppingItem: {
+          findMany: vi.fn(),
+        },
         mealPlan: {
           findFirst: vi.fn(),
         },
@@ -43,7 +46,11 @@ vi.mock("./stock.server", async (importOriginal) => {
   };
 });
 
-import { getMealPlanShoppingData, getMealPlanStoreModeData } from "./shopping.server";
+import {
+  getMealPlanShoppingData,
+  getMealPlanStoreModeData,
+  listRecentManualShoppingItemsForFamily,
+} from "./shopping.server";
 
 const mockMembership = {
   family: {
@@ -1719,5 +1726,59 @@ describe("shopping.server", () => {
 
     expect(dbMock.store.findMany).not.toHaveBeenCalled();
     expect(dbMock.ingredientCategory.findMany).not.toHaveBeenCalled();
+  });
+
+  it("lists recent manual shopping items deduped by normalized name", async () => {
+    dbMock.manualShoppingItem.findMany.mockResolvedValue([
+      {
+        categoryId: "category-dairy",
+        name: "Melk",
+        quantity: "2 liter",
+      },
+      {
+        categoryId: "category-other",
+        name: "melk",
+        quantity: "1 liter",
+      },
+      {
+        categoryId: "category-bakery",
+        name: "Brød",
+        quantity: null,
+      },
+    ]);
+
+    const result = await listRecentManualShoppingItemsForFamily({
+      familyId: "family-1",
+      limit: 5,
+    });
+
+    expect(dbMock.manualShoppingItem.findMany).toHaveBeenCalledWith({
+      orderBy: [{ updatedAt: "desc" }],
+      select: {
+        categoryId: true,
+        name: true,
+        quantity: true,
+      },
+      take: 100,
+      where: {
+        mealPlan: {
+          familyId: "family-1",
+        },
+      },
+    });
+    expect(result).toEqual([
+      {
+        categoryId: "category-dairy",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "2 liter",
+      },
+      {
+        categoryId: "category-bakery",
+        displayName: "Brød",
+        nameNormalized: "brød",
+        quantity: "1",
+      },
+    ]);
   });
 });

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -2,6 +2,7 @@ import { MealType, Prisma, ShoppingItemSource } from "@prisma/client";
 
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import { getMealPlanDateRange } from "./meal-plan.server";
 import {
   getFamilyStockMatchSet,
@@ -370,6 +371,69 @@ export async function getMealPlanShoppingData({
     userRole: membership.role,
     visibleDates: getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate),
   };
+}
+
+export const RECENT_MANUAL_SHOPPING_ITEM_LIMIT = 10;
+
+export interface RecentManualShoppingItem {
+  categoryId: string;
+  displayName: string;
+  nameNormalized: string;
+  quantity: string;
+}
+
+export async function listRecentManualShoppingItemsForFamily({
+  familyId,
+  limit = RECENT_MANUAL_SHOPPING_ITEM_LIMIT,
+}: {
+  familyId: string;
+  limit?: number;
+}) {
+  const rows = await db.manualShoppingItem.findMany({
+    orderBy: [{ updatedAt: "desc" }],
+    select: {
+      categoryId: true,
+      name: true,
+      quantity: true,
+    },
+    take: 100,
+    where: {
+      mealPlan: {
+        familyId,
+      },
+    },
+  });
+
+  const seen = new Set<string>();
+  const recentItems: RecentManualShoppingItem[] = [];
+
+  for (const row of rows) {
+    const displayName = row.name.trim();
+
+    if (!displayName) {
+      continue;
+    }
+
+    const nameNormalized = normalizeIngredientCanonicalName(displayName);
+
+    if (seen.has(nameNormalized)) {
+      continue;
+    }
+
+    seen.add(nameNormalized);
+    recentItems.push({
+      categoryId: row.categoryId,
+      displayName,
+      nameNormalized,
+      quantity: row.quantity?.trim() || "1",
+    });
+
+    if (recentItems.length >= limit) {
+      break;
+    }
+  }
+
+  return recentItems;
 }
 
 export async function getMealPlanStoreModeData({

--- a/app/lib/stock.server.ts
+++ b/app/lib/stock.server.ts
@@ -126,6 +126,7 @@ export async function searchCanonicalIngredients(query: string) {
     orderBy: [{ canonicalName: "asc" }],
     select: {
       canonicalName: true,
+      defaultCategoryId: true,
       id: true,
     },
     take: 20,

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,10 @@ export default [
     "routes/family-meal-plan-day-calendar.ts",
   ),
   route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
+  route(
+    "families/:familyId/meal-plans/:mealPlanId/shopping/ingredient-search",
+    "routes/family-meal-plan-shopping-ingredient-search.ts",
+  ),
   route("families/:familyId/meal-plans/:mealPlanId/store-mode", "routes/family-meal-plan-store-mode.tsx"),
   route("families/:familyId/stores", "routes/family-stores.tsx"),
   route("families/:familyId/stock-ingredients", "routes/family-stock-ingredients.tsx"),

--- a/app/routes/family-meal-plan-shopping-ingredient-search.test.ts
+++ b/app/routes/family-meal-plan-shopping-ingredient-search.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>("../lib/auth.server");
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/stock.server", () => {
+  return {
+    searchCanonicalIngredients: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { searchCanonicalIngredients } from "../lib/stock.server";
+import { loader } from "./family-meal-plan-shopping-ingredient-search";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+describe("family meal plan shopping ingredient search route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty list for short queries", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+
+    const result = await loader({
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping/ingredient-search?q=m",
+      ),
+    });
+
+    expect(searchCanonicalIngredients).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ingredientSearchResults: [],
+    });
+  });
+
+  it("returns canonical ingredient matches for longer queries", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(searchCanonicalIngredients).mockResolvedValue([
+      {
+        canonicalName: "Melk",
+        defaultCategoryId: "category-dairy",
+        id: "ingredient-milk",
+      },
+    ]);
+
+    const result = await loader({
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping/ingredient-search?q=melk",
+      ),
+    });
+
+    expect(searchCanonicalIngredients).toHaveBeenCalledWith("melk");
+    expect(result).toEqual({
+      ingredientSearchResults: [
+        {
+          canonicalName: "Melk",
+          defaultCategoryId: "category-dairy",
+          id: "ingredient-milk",
+        },
+      ],
+    });
+  });
+});

--- a/app/routes/family-meal-plan-shopping-ingredient-search.ts
+++ b/app/routes/family-meal-plan-shopping-ingredient-search.ts
@@ -1,0 +1,20 @@
+import { requireUser } from "../lib/auth.server";
+import { searchCanonicalIngredients } from "../lib/stock.server";
+
+const MIN_SEARCH_LENGTH = 2;
+
+export async function loader({ request }: { request: Request }) {
+  await requireUser(request);
+
+  const searchQuery = new URL(request.url).searchParams.get("q")?.trim() ?? "";
+
+  if (searchQuery.length < MIN_SEARCH_LENGTH) {
+    return {
+      ingredientSearchResults: [],
+    };
+  }
+
+  return {
+    ingredientSearchResults: await searchCanonicalIngredients(searchQuery),
+  };
+}

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -12,12 +12,14 @@ vi.mock("../lib/auth.server", async () => {
 vi.mock("../lib/shopping.server", () => {
   return {
     getMealPlanShoppingData: vi.fn(),
+    listRecentManualShoppingItemsForFamily: vi.fn(),
   };
 });
 
 vi.mock("../lib/shopping-write.server", () => {
   return {
     createManualShoppingItem: vi.fn(),
+    createQuickManualShoppingItem: vi.fn(),
     deleteManualShoppingItem: vi.fn(),
     optInStockShoppingItems: vi.fn(),
     toggleShoppingItemChecked: vi.fn(),
@@ -27,9 +29,10 @@ vi.mock("../lib/shopping-write.server", () => {
 });
 
 import { requireUser } from "../lib/auth.server";
-import { getMealPlanShoppingData } from "../lib/shopping.server";
+import { getMealPlanShoppingData, listRecentManualShoppingItemsForFamily } from "../lib/shopping.server";
 import {
   createManualShoppingItem,
+  createQuickManualShoppingItem,
   optInStockShoppingItems,
   toggleShoppingItemChecked,
   updateGeneratedShoppingItemOverride,
@@ -57,6 +60,14 @@ describe("family meal plan shopping route", () => {
 
   it("loads and serializes generated and manual shopping data", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([
+      {
+        categoryId: "category-dairy",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "1",
+      },
+    ]);
     vi.mocked(getMealPlanShoppingData).mockResolvedValue({
       categories: [
         {
@@ -261,6 +272,9 @@ describe("family meal plan shopping route", () => {
       mealPlanId: "meal-plan-1",
       userId: "user-1",
     });
+    expect(listRecentManualShoppingItemsForFamily).toHaveBeenCalledWith({
+      familyId: "family-1",
+    });
     expect(result).toEqual({
       excludedGeneratedCount: 0,
       excludedGeneratedItems: [],
@@ -286,6 +300,14 @@ describe("family meal plan shopping route", () => {
         updatedAt: "2026-05-01T12:00:00.000Z",
       },
       notice: null,
+      recentManualItems: [
+        {
+          categoryId: "category-dairy",
+          displayName: "Melk",
+          nameNormalized: "melk",
+          quantity: "1",
+        },
+      ],
       categories: [
         {
           displayName: "Frukt og gront",
@@ -390,6 +412,7 @@ describe("family meal plan shopping route", () => {
 
   it("serializes stock ingredients for the active meal plan", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([]);
     vi.mocked(getMealPlanShoppingData).mockResolvedValue({
       categories: [],
       family: {
@@ -488,6 +511,41 @@ describe("family meal plan shopping route", () => {
       familyId: "family-1",
       mealPlanId: "meal-plan-1",
       sourceKeys: ["entry-1:ingredient-1"],
+      userId: "user-1",
+    });
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+  });
+
+  it("redirects after a quick-add manual shopping item", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createQuickManualShoppingItem).mockResolvedValue({
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "quick-add-manual-shopping-item");
+    formData.set("name", "Tannkrem");
+
+    const response = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping",
+        formData,
+      ),
+    });
+
+    expect(createQuickManualShoppingItem).toHaveBeenCalledWith({
+      familyId: "family-1",
+      input: {
+        ingredientId: "",
+        name: "Tannkrem",
+        recentNameNormalized: "",
+      },
+      mealPlanId: "meal-plan-1",
       userId: "user-1",
     });
     expect(response).toBeInstanceOf(Response);

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -13,9 +13,14 @@ import {
   formatGeneratedQuantityBadge,
   formatOccurrenceSourceLine,
 } from "../lib/shopping-display";
-import { getMealPlanShoppingData } from "../lib/shopping.server";
+import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
+import {
+  getMealPlanShoppingData,
+  listRecentManualShoppingItemsForFamily,
+} from "../lib/shopping.server";
 import {
   createManualShoppingItem,
+  createQuickManualShoppingItem,
   deleteManualShoppingItem,
   excludeGeneratedShoppingItem,
   optInStockShoppingItems,
@@ -41,6 +46,7 @@ type ShoppingNotice =
 
 type ShoppingIntent =
   | "add-manual-shopping-item"
+  | "quick-add-manual-shopping-item"
   | "delete-manual-shopping-item"
   | "exclude-generated-shopping-item"
   | "opt-in-stock-shopping-item"
@@ -104,11 +110,16 @@ export async function loader({
     params.mealPlanId,
     "Fant ikke ukeplanen.",
   );
-  const result = await getMealPlanShoppingData({
-    familyId,
-    mealPlanId,
-    userId: user.id,
-  });
+  const [result, recentManualItems] = await Promise.all([
+    getMealPlanShoppingData({
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    }),
+    listRecentManualShoppingItemsForFamily({
+      familyId,
+    }),
+  ]);
 
   return {
     categories: result.categories,
@@ -131,6 +142,7 @@ export async function loader({
       serializeProjectedShoppingItem,
     ),
     notice: getShoppingNotice(request),
+    recentManualItems,
     storeGroups: result.storeGroups.map((group) => ({
       sections: group.sections.map((section) => ({
         ...section,
@@ -187,6 +199,35 @@ export async function action({
 
     if (result.status === "VALIDATION_ERROR") {
       return {
+        intent,
+        manualFieldErrors: result.fieldErrors,
+        manualValues: result.values,
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "manual-shopping-item-added",
+      request,
+    });
+  }
+
+  if (intent === "quick-add-manual-shopping-item") {
+    const result = await createQuickManualShoppingItem({
+      familyId,
+      input: parseQuickAddManualShoppingItemInput(formData),
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        formError: "formError" in result ? result.formError : undefined,
         intent,
         manualFieldErrors: result.fieldErrors,
         manualValues: result.values,
@@ -492,9 +533,12 @@ export default function FamilyMealPlanShoppingRoute({
   const pendingIntent = navigation.formData?.get("intent");
   const pendingSourceKey = getPendingSourceKey(navigation.formData);
   const addManualValues =
-    actionData?.intent === "add-manual-shopping-item" && actionData.manualValues
+    (actionData?.intent === "add-manual-shopping-item" ||
+      actionData?.intent === "quick-add-manual-shopping-item") &&
+    actionData.manualValues
       ? actionData.manualValues
       : defaultManualShoppingItemValues;
+  const ingredientSearchPath = `/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping/ingredient-search`;
   const noticeContent = loaderData.notice
     ? getShoppingNoticeContent(loaderData.notice)
     : null;
@@ -801,7 +845,30 @@ export default function FamilyMealPlanShoppingRoute({
               </p>
             </div>
 
-            <Form className="mt-6 space-y-4" method="post">
+            {actionData?.intent === "quick-add-manual-shopping-item" &&
+            actionData.formError ? (
+              <p className="mt-4 text-sm text-rose-600">{actionData.formError}</p>
+            ) : null}
+            {actionData?.intent === "quick-add-manual-shopping-item" &&
+            actionData.manualFieldErrors?.name ? (
+              <p className="mt-2 text-sm text-rose-600">
+                {actionData.manualFieldErrors.name}
+              </p>
+            ) : null}
+
+            <div className="mt-6">
+              <ManualShoppingQuickAdd
+                ingredientSearchPath={ingredientSearchPath}
+                recentManualItems={loaderData.recentManualItems}
+              />
+            </div>
+
+            <details className="mt-6 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <summary className="cursor-pointer text-sm font-medium text-slate-800">
+                Avansert: legg til med alle felt
+              </summary>
+
+            <Form className="mt-4 space-y-4" method="post">
               <input
                 name="intent"
                 type="hidden"
@@ -927,6 +994,7 @@ export default function FamilyMealPlanShoppingRoute({
                   : "Legg til varelinje"}
               </button>
             </Form>
+            </details>
           </article>
         </section>
 
@@ -1644,6 +1712,14 @@ function getToggleExpectedVersion(item: {
   }
 
   return item.collaborationVersion;
+}
+
+function parseQuickAddManualShoppingItemInput(formData: FormData) {
+  return {
+    ingredientId: String(formData.get("ingredientId") ?? ""),
+    name: String(formData.get("name") ?? ""),
+    recentNameNormalized: String(formData.get("recentNameNormalized") ?? ""),
+  };
 }
 
 function parseManualShoppingItemValues(


### PR DESCRIPTION
## Summary
- Add a quick-add bar on the shopping list: one-click recents, ingredient typeahead, and immediate add for new names with Annet / qty 1 defaults.
- Resolve quick-add values on the server (canonical ingredient, recent quantity+category, or Annet fallback) and keep the full manual form under an advanced section.
- Add a lightweight ingredient-search route so typeahead does not refetch the entire shopping loader; fix dropdown layout shift and typeahead submit via `useSubmit`.

## Related issue
Closes #62

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Add item via recent chip — appears on list with last quantity/category
- [ ] Pick item from typeahead — adds with ingredient name and category
- [ ] Type new name and press Enter or “Legg til «…»” — adds with Annet, qty 1
- [ ] Edit line after quick-add (quantity, category, store, date)

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck