### PR TITLE
Add global top navigation bar

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,35 @@
 
 ## Current Objective
 
-Issue #64 — seed a global ingredient catalog (181 items) so manual shopping typeahead works before first use. PR ready on branch `issue/64-ingredient-catalog-seed`.
+Issue #67 — global top navigation bar shipped on branch `issue/67-global-top-nav`; PR ready for review.
 
 ## Completed
 
-- Added `prisma/data/catalog-ingredient-seeds.csv` with 181 grocery/household items.
-- CSV parser and merge into `buildIngredientSeeds()` in `prisma/seed-data.ts` (catalog display casing preserved).
-- Case-insensitive ingredient upsert in `prisma/seed.ts` to avoid duplicate case variants on re-seed.
-- Tests in `prisma/seed-data.test.ts`; README and `docs/deploy-fly.md` updated for catalog seeding.
+- Added `app-layout.tsx` layout route wrapping `/app` and all `/families/*` routes with a loader that resolves `familyId` from params or single membership on `/app`.
+- Added `AppTopNav` with logo placeholder (links to `/`), family nav links, active `NavLink` states, and mobile hamburger menu.
+- Restructured `app/routes.ts` so public/auth routes stay outside the layout.
+- Removed duplicate nav button row from `family.tsx` (now covered by top nav).
+- Tests: `app-top-nav.test.tsx` (5), `app-layout.test.ts` (3).
 
 ## Files To Read First
 
-- `prisma/seed-data.ts` — catalog loader, `buildIngredientSeeds`, validation
-- `prisma/data/catalog-ingredient-seeds.csv` — maintained catalog list
-- `prisma/seed.ts` — DB upsert including case-insensitive merge
+- `app/routes/app-layout.tsx` — layout loader and `familyId` resolution
+- `app/components/app-top-nav.tsx` — top nav UI and link config
+- `app/routes.ts` — layout route nesting
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 178 tests passed (33 files)
+- `npm run test:run` — 186 tests passed (35 files)
 - `npm run typecheck` — passed
-- `npm run prisma:seed` — passed (181 ingredients)
 
 ## Open Items
 
 - PR review and merge.
-- Production: run `DATABASE_URL=<prod> npm run prisma:seed` once for typeahead (see `docs/deploy-fly.md`).
-- Manual smoke-test: shopping quick-add type `toale` → Toalettpapir with household category.
+- Uncommitted local change in `app/routes/family-stores.tsx` (column reorder / rename) — not part of issue #67 commit.
+- Manual smoke: multi-family `/app`, mobile hamburger, meal-plan sub-nav unchanged.
 
 ## Next Step
 
-Merge PR when CI is green; seed production DB if typeahead is needed there.
+Merge PR when CI is green; optionally commit or discard `family-stores.tsx` layout tweak separately.

--- a/app/components/app-top-nav.test.tsx
+++ b/app/components/app-top-nav.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AppTopNav } from "./app-top-nav";
+import { renderWithRouter } from "../test/render-with-router";
+
+describe("AppTopNav", () => {
+  it("renders all family links when familyId is provided", () => {
+    renderWithRouter(<AppTopNav familyId="family-1" />, {
+      initialEntries: ["/families/family-1"],
+    });
+
+    expect(screen.getByRole("link", { name: "Familie" })).toHaveAttribute(
+      "href",
+      "/families/family-1",
+    );
+    expect(screen.getByRole("link", { name: "Ukeplaner" })).toHaveAttribute(
+      "href",
+      "/families/family-1/meal-plans",
+    );
+    expect(screen.getByRole("link", { name: "Butikker" })).toHaveAttribute(
+      "href",
+      "/families/family-1/stores",
+    );
+    expect(screen.getByRole("link", { name: "Oppskrifter" })).toHaveAttribute(
+      "href",
+      "/families/family-1/recipes",
+    );
+    expect(screen.getByRole("link", { name: "Basisvarer" })).toHaveAttribute(
+      "href",
+      "/families/family-1/stock-ingredients",
+    );
+    expect(screen.getByRole("link", { name: "Oversikt" })).toHaveAttribute("href", "/app");
+  });
+
+  it("renders only oversikt when familyId is missing", () => {
+    renderWithRouter(<AppTopNav familyId={null} />, {
+      initialEntries: ["/app"],
+    });
+
+    expect(screen.getByRole("link", { name: "Oversikt" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Familie" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Ukeplaner" })).not.toBeInTheDocument();
+  });
+
+  it("links the logo placeholder to the application root", () => {
+    renderWithRouter(<AppTopNav familyId={null} />);
+
+    expect(screen.getByRole("link", { name: "Mealplanner forsiden" })).toHaveAttribute("href", "/");
+  });
+
+  it("toggles the mobile menu and closes it with Escape", () => {
+    renderWithRouter(<AppTopNav familyId="family-1" />, {
+      initialEntries: ["/families/family-1"],
+    });
+
+    const toggle = screen.getByRole("button", { name: "Åpne meny" });
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: "Lukk meny" })).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Hovedmeny mobil" })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.getByRole("button", { name: "Åpne meny" })).toBeInTheDocument();
+    expect(screen.queryByRole("navigation", { name: "Hovedmeny mobil" })).not.toBeInTheDocument();
+  });
+
+  it("marks the active route in the desktop navigation", () => {
+    renderWithRouter(<AppTopNav familyId="family-1" />, {
+      initialEntries: ["/families/family-1/stores"],
+    });
+
+    expect(screen.getByRole("link", { name: "Butikker" })).toHaveClass("bg-emerald-500");
+  });
+});

--- a/app/components/app-top-nav.tsx
+++ b/app/components/app-top-nav.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useId, useState } from "react";
+import { Link, NavLink } from "react-router";
+
+interface NavItem {
+  end?: boolean;
+  label: string;
+  to: string;
+}
+
+function buildFamilyNavItems(familyId: string): NavItem[] {
+  return [
+    { end: true, label: "Familie", to: `/families/${familyId}` },
+    { end: false, label: "Ukeplaner", to: `/families/${familyId}/meal-plans` },
+    { end: true, label: "Butikker", to: `/families/${familyId}/stores` },
+    { end: false, label: "Oppskrifter", to: `/families/${familyId}/recipes` },
+    {
+      end: true,
+      label: "Basisvarer",
+      to: `/families/${familyId}/stock-ingredients`,
+    },
+    { end: true, label: "Oversikt", to: "/app" },
+  ];
+}
+
+function navLinkClassName({ isActive }: { isActive: boolean }) {
+  return [
+    "rounded-2xl px-4 py-2 text-sm font-medium transition",
+    isActive
+      ? "bg-emerald-500 text-white"
+      : "text-slate-200 hover:bg-white/10 hover:text-white",
+  ].join(" ");
+}
+
+function NavLinks({
+  items,
+  onNavigate,
+}: {
+  items: NavItem[];
+  onNavigate?: () => void;
+}) {
+  return (
+    <>
+      {items.map((item) => (
+        <NavLink
+          key={item.to}
+          className={navLinkClassName}
+          end={item.end}
+          onClick={onNavigate}
+          to={item.to}
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </>
+  );
+}
+
+export function AppTopNav({ familyId }: { familyId: string | null }) {
+  const menuId = useId();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navItems = familyId ? buildFamilyNavItems(familyId) : [{ end: true, label: "Oversikt", to: "/app" }];
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-slate-950 text-slate-100">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3">
+        <Link
+          aria-label="Mealplanner forsiden"
+          className="flex shrink-0 items-center gap-2 rounded-lg border border-white/15 bg-white/5 px-3 py-2 transition hover:bg-white/10"
+          to="/"
+        >
+          <span
+            aria-hidden
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-emerald-500/20 text-xs font-semibold text-emerald-200"
+          >
+            MP
+          </span>
+          <span className="text-sm font-semibold tracking-tight">Mealplanner</span>
+        </Link>
+
+        <nav aria-label="Hovedmeny" className="hidden items-center gap-2 md:flex">
+          <NavLinks items={navItems} />
+        </nav>
+
+        <button
+          aria-controls={menuId}
+          aria-expanded={menuOpen}
+          aria-label={menuOpen ? "Lukk meny" : "Åpne meny"}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-slate-100 transition hover:bg-white/15 md:hidden"
+          onClick={() => {
+            setMenuOpen((open) => !open);
+          }}
+          type="button"
+        >
+          <span aria-hidden className="relative block h-3.5 w-4">
+            <span
+              className={[
+                "absolute left-0 block h-0.5 w-4 rounded-full bg-current transition",
+                menuOpen ? "top-1.5 rotate-45" : "top-0",
+              ].join(" ")}
+            />
+            <span
+              className={[
+                "absolute left-0 top-1.5 block h-0.5 w-4 rounded-full bg-current transition",
+                menuOpen ? "opacity-0" : "opacity-100",
+              ].join(" ")}
+            />
+            <span
+              className={[
+                "absolute left-0 block h-0.5 w-4 rounded-full bg-current transition",
+                menuOpen ? "top-1.5 -rotate-45" : "top-3",
+              ].join(" ")}
+            />
+          </span>
+        </button>
+      </div>
+
+      {menuOpen ? (
+        <nav
+          aria-label="Hovedmeny mobil"
+          className="border-t border-white/10 px-4 py-3 md:hidden"
+          id={menuId}
+        >
+          <div className="flex flex-col gap-2">
+            <NavLinks
+              items={navItems}
+              onNavigate={() => {
+                setMenuOpen(false);
+              }}
+            />
+          </div>
+        </nav>
+      ) : null}
+    </header>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,27 +1,35 @@
-import { type RouteConfig, index, route } from "@react-router/dev/routes";
+import { type RouteConfig, index, layout, route } from "@react-router/dev/routes";
 
 export default [
   index("routes/home.tsx"),
-  route("app", "routes/app.tsx"),
-  route("families/:familyId", "routes/family.tsx"),
-  route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
-  route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
-  route("families/:familyId/meal-plans/:mealPlanId/calendar.ics", "routes/family-meal-plan-calendar.ts"),
-  route(
-    "families/:familyId/meal-plans/:mealPlanId/days/:date/calendar.ics",
-    "routes/family-meal-plan-day-calendar.ts",
-  ),
-  route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
-  route(
-    "families/:familyId/meal-plans/:mealPlanId/shopping/ingredient-search",
-    "routes/family-meal-plan-shopping-ingredient-search.ts",
-  ),
-  route("families/:familyId/meal-plans/:mealPlanId/store-mode", "routes/family-meal-plan-store-mode.tsx"),
-  route("families/:familyId/stores", "routes/family-stores.tsx"),
-  route("families/:familyId/stock-ingredients", "routes/family-stock-ingredients.tsx"),
-  route("families/:familyId/recipes", "routes/family-recipes.tsx"),
-  route("families/:familyId/recipes/:recipeId", "routes/family-recipe.tsx"),
   route("login", "routes/login.tsx"),
   route("logout", "routes/logout.tsx"),
   route("register", "routes/register.tsx"),
+  layout("routes/app-layout.tsx", [
+    route("app", "routes/app.tsx"),
+    route("families/:familyId", "routes/family.tsx"),
+    route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
+    route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
+    route(
+      "families/:familyId/meal-plans/:mealPlanId/calendar.ics",
+      "routes/family-meal-plan-calendar.ts",
+    ),
+    route(
+      "families/:familyId/meal-plans/:mealPlanId/days/:date/calendar.ics",
+      "routes/family-meal-plan-day-calendar.ts",
+    ),
+    route("families/:familyId/meal-plans/:mealPlanId/shopping", "routes/family-meal-plan-shopping.tsx"),
+    route(
+      "families/:familyId/meal-plans/:mealPlanId/shopping/ingredient-search",
+      "routes/family-meal-plan-shopping-ingredient-search.ts",
+    ),
+    route(
+      "families/:familyId/meal-plans/:mealPlanId/store-mode",
+      "routes/family-meal-plan-store-mode.tsx",
+    ),
+    route("families/:familyId/stores", "routes/family-stores.tsx"),
+    route("families/:familyId/stock-ingredients", "routes/family-stock-ingredients.tsx"),
+    route("families/:familyId/recipes", "routes/family-recipes.tsx"),
+    route("families/:familyId/recipes/:recipeId", "routes/family-recipe.tsx"),
+  ]),
 ] satisfies RouteConfig;

--- a/app/routes/app-layout.test.ts
+++ b/app/routes/app-layout.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/family.server", () => {
+  return {
+    getFamilyMembershipsForUser: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getFamilyMembershipsForUser } from "../lib/family.server";
+import { loader } from "./app-layout";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(url: string) {
+  return new Request(url);
+}
+
+describe("app-layout loader", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns familyId from route params on family routes", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+
+    const result = await loader({
+      params: { familyId: "family-1" },
+      request: buildRequest("http://localhost/families/family-1/stores"),
+    } as never);
+
+    expect(result).toEqual({ familyId: "family-1" });
+    expect(getFamilyMembershipsForUser).not.toHaveBeenCalled();
+  });
+
+  it("returns the only family on /app when the user has one membership", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getFamilyMembershipsForUser).mockResolvedValue([
+      {
+        id: "membership-1",
+        role: "ADMIN",
+        family: { id: "family-1", name: "Solberg" },
+      },
+    ] as never);
+
+    const result = await loader({
+      params: {},
+      request: buildRequest("http://localhost/app"),
+    } as never);
+
+    expect(result).toEqual({ familyId: "family-1" });
+  });
+
+  it("returns null familyId on /app when the user has multiple memberships", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getFamilyMembershipsForUser).mockResolvedValue([
+      {
+        id: "membership-1",
+        role: "ADMIN",
+        family: { id: "family-1", name: "Solberg" },
+      },
+      {
+        id: "membership-2",
+        role: "MEMBER",
+        family: { id: "family-2", name: "Nordvik" },
+      },
+    ] as never);
+
+    const result = await loader({
+      params: {},
+      request: buildRequest("http://localhost/app"),
+    } as never);
+
+    expect(result).toEqual({ familyId: null });
+  });
+});

--- a/app/routes/app-layout.tsx
+++ b/app/routes/app-layout.tsx
@@ -1,0 +1,35 @@
+import { Outlet } from "react-router";
+
+import { AppTopNav } from "../components/app-top-nav";
+import { requireUser } from "../lib/auth.server";
+import { getFamilyMembershipsForUser } from "../lib/family.server";
+import type { Route } from "./+types/app-layout";
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const user = await requireUser(request);
+
+  if (params.familyId) {
+    return { familyId: params.familyId };
+  }
+
+  const url = new URL(request.url);
+
+  if (url.pathname === "/app") {
+    const memberships = await getFamilyMembershipsForUser(user.id);
+
+    if (memberships.length === 1) {
+      return { familyId: memberships[0].family.id };
+    }
+  }
+
+  return { familyId: null };
+}
+
+export default function AppLayoutRoute({ loaderData }: Route.ComponentProps) {
+  return (
+    <>
+      <AppTopNav familyId={loaderData.familyId} />
+      <Outlet />
+    </>
+  );
+}

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -187,39 +187,6 @@ export default function FamilyRoute({
                   : "Du har tilgang til familien og kan bruke den videre beskyttede appen."}
               </p>
             </div>
-
-            <div className="flex flex-wrap gap-3">
-              <Link
-                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
-                to={`/families/${loaderData.family.id}/meal-plans`}
-              >
-                Åpne ukeplaner
-              </Link>
-              <Link
-                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
-                to={`/families/${loaderData.family.id}/stores`}
-              >
-                Administrer butikker
-              </Link>
-              <Link
-                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
-                to={`/families/${loaderData.family.id}/recipes`}
-              >
-                Administrer oppskrifter
-              </Link>
-              <Link
-                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
-                to={`/families/${loaderData.family.id}/stock-ingredients`}
-              >
-                Basisvarer
-              </Link>
-              <Link
-                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
-                to="/app"
-              >
-                Tilbake til oversikten
-              </Link>
-            </div>
           </div>
         </section>
 
@@ -271,8 +238,8 @@ export default function FamilyRoute({
                 Ukeplaner
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                Gå videre til familiens serverlagrede ukeplaner for å opprette,
-                velge og oppdatere planer med start- og sluttdato.
+                Gå videre til familiens ukeplaner for å opprette, velge og
+                oppdatere planer med start- og sluttdato.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- Adds a sticky top navigation bar with logo placeholder (links to `/`), family section links, and a mobile hamburger menu across authenticated routes.
- Wraps `/app` and all `/families/*` routes in a shared layout that resolves `familyId` from the URL or from a single family membership on `/app`.
- Removes the duplicate navigation button row on the family page now covered by the global header.

## Related issue
Closes #67

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: desktop nav across family routes with correct active states
- [ ] Manual: mobile hamburger open/close and Escape to dismiss
- [ ] Manual: `/app` with 0, 1, and 2+ families shows correct link set
- [ ] Manual: `/login` and `/` have no top nav; meal-plan/shopping sub-nav unchanged

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (186 tests)
- npm run typecheck