### PR TITLE
Share meal plans for family review with mobile feedback

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,35 @@
 
 ## Current Objective
 
-Issue #67 — global top navigation bar shipped on branch `issue/67-global-top-nav`; PR ready for review.
+Issue #70 — share meal plan for family review shipped on branch `issue/70-share-meal-plan-review`; PR ready for review.
 
 ## Completed
 
-- Added `app-layout.tsx` layout route wrapping `/app` and all `/families/*` routes with a loader that resolves `familyId` from params or single membership on `/app`.
-- Added `AppTopNav` with logo placeholder (links to `/`), family nav links, active `NavLink` states, and mobile hamburger menu.
-- Restructured `app/routes.ts` so public/auth routes stay outside the layout.
-- Removed duplicate nav button row from `family.tsx` (now covered by top nav).
-- Tests: `app-top-nav.test.tsx` (5), `app-layout.test.ts` (3).
+- Added Prisma models and migration for meal plan shares, recipients, and per-day review comments with quick-response presets.
+- Implemented `meal-plan-share.server.ts`: share creation (one open share per plan), mobile review flow, approve-from-review, feedback inbox.
+- Added review routes (`family-meal-plan-reviews`, `family-meal-plan-review`) with one-tap chips (Dette hadde vi for litt siden / Fisk igjen...? / Ja!).
+- Integrated share + feedback panels on meal plan editor; nav badge for pending reviews.
+- Fixed post-approve redirect (no Forbidden), single-share guard, emerald Godkjent badge on meal plans list.
 
 ## Files To Read First
 
-- `app/routes/app-layout.tsx` — layout loader and `familyId` resolution
-- `app/components/app-top-nav.tsx` — top nav UI and link config
-- `app/routes.ts` — layout route nesting
+- `app/lib/meal-plan-share.server.ts` — share/review/approve domain logic
+- `app/routes/family-meal-plan-review.tsx` — mobile-first reviewer UI
+- `app/routes/family-meal-plan.tsx` — planner share + feedback panels
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 186 tests passed (35 files)
+- `npm run test:run` — 201 tests passed (38 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Uncommitted local change in `app/routes/family-stores.tsx` (column reorder / rename) — not part of issue #67 commit.
-- Manual smoke: multi-family `/app`, mobile hamburger, meal-plan sub-nav unchanged.
+- Run migration on deploy: `npx prisma migrate deploy`.
+- Manual smoke: share whole family, review on mobile width, approve without comments, verify no second share while open.
 
 ## Next Step
 
-Merge PR when CI is green; optionally commit or discard `family-stores.tsx` layout tweak separately.
+Merge PR when CI is green.

--- a/app/components/app-top-nav.test.tsx
+++ b/app/components/app-top-nav.test.tsx
@@ -20,6 +20,10 @@ describe("AppTopNav", () => {
       "href",
       "/families/family-1/meal-plans",
     );
+    expect(screen.getByRole("link", { name: "Gjennomgang" })).toHaveAttribute(
+      "href",
+      "/families/family-1/meal-plans/reviews",
+    );
     expect(screen.getByRole("link", { name: "Butikker" })).toHaveAttribute(
       "href",
       "/families/family-1/stores",
@@ -65,6 +69,17 @@ describe("AppTopNav", () => {
     fireEvent.keyDown(window, { key: "Escape" });
     expect(screen.getByRole("button", { name: "Åpne meny" })).toBeInTheDocument();
     expect(screen.queryByRole("navigation", { name: "Hovedmeny mobil" })).not.toBeInTheDocument();
+  });
+
+  it("shows pending review count in the gjennomgang link", () => {
+    renderWithRouter(<AppTopNav familyId="family-1" pendingReviewCount={3} />, {
+      initialEntries: ["/families/family-1"],
+    });
+
+    expect(screen.getByRole("link", { name: "Gjennomgang (3)" })).toHaveAttribute(
+      "href",
+      "/families/family-1/meal-plans/reviews",
+    );
   });
 
   it("marks the active route in the desktop navigation", () => {

--- a/app/components/app-top-nav.tsx
+++ b/app/components/app-top-nav.tsx
@@ -7,10 +7,23 @@ interface NavItem {
   to: string;
 }
 
-function buildFamilyNavItems(familyId: string): NavItem[] {
+function buildFamilyNavItems(
+  familyId: string,
+  pendingReviewCount: number,
+): NavItem[] {
+  const reviewLabel =
+    pendingReviewCount > 0
+      ? `Gjennomgang (${pendingReviewCount})`
+      : "Gjennomgang";
+
   return [
     { end: true, label: "Familie", to: `/families/${familyId}` },
     { end: false, label: "Ukeplaner", to: `/families/${familyId}/meal-plans` },
+    {
+      end: true,
+      label: reviewLabel,
+      to: `/families/${familyId}/meal-plans/reviews`,
+    },
     { end: true, label: "Butikker", to: `/families/${familyId}/stores` },
     { end: false, label: "Oppskrifter", to: `/families/${familyId}/recipes` },
     {
@@ -55,10 +68,18 @@ function NavLinks({
   );
 }
 
-export function AppTopNav({ familyId }: { familyId: string | null }) {
+export function AppTopNav({
+  familyId,
+  pendingReviewCount = 0,
+}: {
+  familyId: string | null;
+  pendingReviewCount?: number;
+}) {
   const menuId = useId();
   const [menuOpen, setMenuOpen] = useState(false);
-  const navItems = familyId ? buildFamilyNavItems(familyId) : [{ end: true, label: "Oversikt", to: "/app" }];
+  const navItems = familyId
+    ? buildFamilyNavItems(familyId, pendingReviewCount)
+    : [{ end: true, label: "Oversikt", to: "/app" }];
 
   useEffect(() => {
     if (!menuOpen) {

--- a/app/lib/family.server.ts
+++ b/app/lib/family.server.ts
@@ -104,6 +104,10 @@ export async function listFamilyMembers(familyId: string) {
   });
 }
 
+export async function listFamilyMembersForCollaboration(familyId: string) {
+  return listFamilyMembers(familyId);
+}
+
 export async function createFamilyForUser({
   userId,
   name,

--- a/app/lib/meal-plan-review-presets.test.ts
+++ b/app/lib/meal-plan-review-presets.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN,
+  MEAL_PLAN_REVIEW_QUICK_RESPONSE_RECENTLY_HAD,
+  MEAL_PLAN_REVIEW_QUICK_RESPONSE_YES,
+  formatMealPlanReviewFeedback,
+  getMealPlanReviewQuickResponseLabel,
+  getMealPlanReviewQuickResponseOptions,
+  isMealPlanReviewQuickResponse,
+} from "./meal-plan-review-presets";
+
+describe("meal-plan-review-presets", () => {
+  it("maps quick response enums to Norwegian labels", () => {
+    expect(
+      getMealPlanReviewQuickResponseLabel(MEAL_PLAN_REVIEW_QUICK_RESPONSE_RECENTLY_HAD),
+    ).toBe("Dette hadde vi for litt siden");
+    expect(
+      getMealPlanReviewQuickResponseLabel(MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN),
+    ).toBe("Fisk igjen...?");
+    expect(getMealPlanReviewQuickResponseLabel(MEAL_PLAN_REVIEW_QUICK_RESPONSE_YES)).toBe(
+      "Ja!",
+    );
+  });
+
+  it("exposes all preset options for the review UI", () => {
+    expect(getMealPlanReviewQuickResponseOptions()).toEqual([
+      {
+        label: "Dette hadde vi for litt siden",
+        value: MEAL_PLAN_REVIEW_QUICK_RESPONSE_RECENTLY_HAD,
+      },
+      {
+        label: "Fisk igjen...?",
+        value: MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN,
+      },
+      {
+        label: "Ja!",
+        value: MEAL_PLAN_REVIEW_QUICK_RESPONSE_YES,
+      },
+    ]);
+  });
+
+  it("validates quick response values", () => {
+    expect(isMealPlanReviewQuickResponse("YES")).toBe(true);
+    expect(isMealPlanReviewQuickResponse("NOPE")).toBe(false);
+  });
+
+  it("formats feedback from preset or body", () => {
+    expect(
+      formatMealPlanReviewFeedback({
+        body: null,
+        quickResponse: MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN,
+      }),
+    ).toBe("Fisk igjen...?");
+    expect(
+      formatMealPlanReviewFeedback({
+        body: "For mye pasta",
+        quickResponse: null,
+      }),
+    ).toBe("For mye pasta");
+  });
+});

--- a/app/lib/meal-plan-review-presets.ts
+++ b/app/lib/meal-plan-review-presets.ts
@@ -1,0 +1,50 @@
+export const MEAL_PLAN_REVIEW_QUICK_RESPONSE_RECENTLY_HAD = "RECENTLY_HAD";
+export const MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN = "FISH_AGAIN";
+export const MEAL_PLAN_REVIEW_QUICK_RESPONSE_YES = "YES";
+
+export type MealPlanReviewQuickResponse =
+  | typeof MEAL_PLAN_REVIEW_QUICK_RESPONSE_RECENTLY_HAD
+  | typeof MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN
+  | typeof MEAL_PLAN_REVIEW_QUICK_RESPONSE_YES;
+
+export const MEAL_PLAN_REVIEW_QUICK_RESPONSES = [
+  MEAL_PLAN_REVIEW_QUICK_RESPONSE_RECENTLY_HAD,
+  MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN,
+  MEAL_PLAN_REVIEW_QUICK_RESPONSE_YES,
+] as const satisfies readonly MealPlanReviewQuickResponse[];
+
+const QUICK_RESPONSE_LABELS: Record<MealPlanReviewQuickResponse, string> = {
+  [MEAL_PLAN_REVIEW_QUICK_RESPONSE_RECENTLY_HAD]: "Dette hadde vi for litt siden",
+  [MEAL_PLAN_REVIEW_QUICK_RESPONSE_FISH_AGAIN]: "Fisk igjen...?",
+  [MEAL_PLAN_REVIEW_QUICK_RESPONSE_YES]: "Ja!",
+};
+
+export function isMealPlanReviewQuickResponse(
+  value: string,
+): value is MealPlanReviewQuickResponse {
+  return (MEAL_PLAN_REVIEW_QUICK_RESPONSES as readonly string[]).includes(value);
+}
+
+export function getMealPlanReviewQuickResponseLabel(
+  quickResponse: MealPlanReviewQuickResponse,
+) {
+  return QUICK_RESPONSE_LABELS[quickResponse];
+}
+
+export function formatMealPlanReviewFeedback(input: {
+  body: string | null;
+  quickResponse: MealPlanReviewQuickResponse | null;
+}) {
+  if (input.quickResponse) {
+    return getMealPlanReviewQuickResponseLabel(input.quickResponse);
+  }
+
+  return input.body?.trim() ?? "";
+}
+
+export function getMealPlanReviewQuickResponseOptions() {
+  return MEAL_PLAN_REVIEW_QUICK_RESPONSES.map((value) => ({
+    label: getMealPlanReviewQuickResponseLabel(value),
+    value,
+  }));
+}

--- a/app/lib/meal-plan-share.server.test.ts
+++ b/app/lib/meal-plan-share.server.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MealPlanReviewQuickResponse, MealPlanStatus } from "@prisma/client";
+
+const { dbMock, listFamilyMembersForCollaborationMock, requireFamilyMembershipMock } =
+  vi.hoisted(() => {
+    return {
+      dbMock: {
+        mealPlan: {
+          findFirst: vi.fn(),
+        },
+        mealPlanReviewComment: {
+          findFirst: vi.fn(),
+          update: vi.fn(),
+          upsert: vi.fn(),
+        },
+        mealPlanShare: {
+          create: vi.fn(),
+          findFirst: vi.fn(),
+          findMany: vi.fn(),
+          updateMany: vi.fn(),
+        },
+        mealPlanShareRecipient: {
+          count: vi.fn(),
+          findFirst: vi.fn(),
+          findMany: vi.fn(),
+          update: vi.fn(),
+        },
+      },
+      listFamilyMembersForCollaborationMock: vi.fn(),
+      requireFamilyMembershipMock: vi.fn(),
+    };
+  });
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  listFamilyMembersForCollaboration: listFamilyMembersForCollaborationMock,
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+vi.mock("./meal-plan.server", async () => {
+  const actual = await vi.importActual<typeof import("./meal-plan.server")>(
+    "./meal-plan.server",
+  );
+
+  return {
+    ...actual,
+    approveMealPlan: vi.fn(),
+  };
+});
+
+import { approveMealPlan } from "./meal-plan.server";
+import {
+  approveMealPlanFromShareReview,
+  closeSharesForMealPlan,
+  createMealPlanShare,
+  markReviewCommentAddressed,
+  upsertDayReviewComment,
+} from "./meal-plan-share.server";
+
+const mockMembership = {
+  family: { id: "family-1", joinCode: "ABC123", name: "Solberg" },
+  familyId: "family-1",
+  id: "membership-1",
+  role: "ADMIN",
+  userId: "user-1",
+};
+
+const draftMealPlan = {
+  endDate: new Date("2026-05-18T00:00:00.000Z"),
+  id: "meal-plan-1",
+  startDate: new Date("2026-05-15T00:00:00.000Z"),
+  status: MealPlanStatus.DRAFT,
+};
+
+describe("meal-plan-share.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue(mockMembership);
+    dbMock.mealPlan.findFirst.mockResolvedValue(draftMealPlan);
+    listFamilyMembersForCollaborationMock.mockResolvedValue([
+      {
+        id: "membership-1",
+        role: "ADMIN",
+        user: { displayName: "Ola", email: "ola@example.com", id: "user-1" },
+      },
+      {
+        id: "membership-2",
+        role: "MEMBER",
+        user: { displayName: "Kari", email: "kari@example.com", id: "user-2" },
+      },
+    ]);
+  });
+
+  it("creates a whole-family share excluding the sharer", async () => {
+    dbMock.mealPlanShare.findFirst.mockResolvedValue(null);
+    dbMock.mealPlanShare.create.mockResolvedValue({
+      closedAt: null,
+      createdAt: new Date("2026-05-20T10:00:00.000Z"),
+      id: "share-1",
+      mealPlanId: "meal-plan-1",
+      message: "Sjekk middagene",
+      sharedByUser: { displayName: "Ola", id: "user-1" },
+      status: "OPEN",
+      wholeFamily: true,
+    });
+
+    const result = await createMealPlanShare({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      message: "Sjekk middagene",
+      recipientUserIds: [],
+      userId: "user-1",
+      wholeFamily: true,
+    });
+
+    expect(result.status).toBe("CREATED");
+    expect(dbMock.mealPlanShare.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          recipients: {
+            create: [{ userId: "user-2" }],
+          },
+          wholeFamily: true,
+        }),
+      }),
+    );
+  });
+
+  it("rejects creating a second open share for the same meal plan", async () => {
+    dbMock.mealPlanShare.findFirst.mockResolvedValue({
+      id: "share-existing",
+    });
+
+    const result = await createMealPlanShare({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      recipientUserIds: ["user-2"],
+      userId: "user-1",
+      wholeFamily: false,
+    });
+
+    expect(result.status).toBe("ALREADY_SHARED");
+    expect(dbMock.mealPlanShare.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects share creation without recipients", async () => {
+    dbMock.mealPlanShare.findFirst.mockResolvedValue(null);
+    const result = await createMealPlanShare({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      recipientUserIds: [],
+      userId: "user-1",
+      wholeFamily: false,
+    });
+
+    expect(result.status).toBe("VALIDATION_ERROR");
+  });
+
+  it("upserts a quick-response comment and marks recipient responded", async () => {
+    dbMock.mealPlanShareRecipient.findFirst.mockResolvedValue({
+      id: "recipient-1",
+      share: {
+        mealPlan: draftMealPlan,
+        status: "OPEN",
+      },
+      status: "VIEWED",
+    });
+    dbMock.mealPlanReviewComment.upsert.mockResolvedValue({
+      addressedAt: null,
+      addressedByUser: null,
+      authorUser: { displayName: "Kari", id: "user-2" },
+      body: null,
+      createdAt: new Date("2026-05-20T10:00:00.000Z"),
+      date: new Date("2026-05-15T00:00:00.000Z"),
+      id: "comment-1",
+      quickResponse: MealPlanReviewQuickResponse.FISH_AGAIN,
+      shareId: "share-1",
+      updatedAt: new Date("2026-05-20T10:00:00.000Z"),
+    });
+
+    const result = await upsertDayReviewComment({
+      date: "2026-05-15",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      quickResponse: "FISH_AGAIN",
+      shareId: "share-1",
+      userId: "user-2",
+    });
+
+    expect(result.status).toBe("SAVED");
+    expect(dbMock.mealPlanReviewComment.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          body: null,
+          quickResponse: MealPlanReviewQuickResponse.FISH_AGAIN,
+        }),
+        update: expect.objectContaining({
+          body: null,
+          quickResponse: MealPlanReviewQuickResponse.FISH_AGAIN,
+        }),
+      }),
+    );
+    expect(dbMock.mealPlanShareRecipient.update).toHaveBeenCalled();
+  });
+
+  it("marks a review comment as addressed", async () => {
+    dbMock.mealPlanReviewComment.findFirst.mockResolvedValue({
+      addressedAt: null,
+      addressedByUser: null,
+      authorUser: { displayName: "Kari", id: "user-2" },
+      body: null,
+      createdAt: new Date("2026-05-20T10:00:00.000Z"),
+      date: new Date("2026-05-15T00:00:00.000Z"),
+      id: "comment-1",
+      quickResponse: MealPlanReviewQuickResponse.YES,
+      shareId: "share-1",
+      updatedAt: new Date("2026-05-20T10:00:00.000Z"),
+    });
+    dbMock.mealPlanReviewComment.update.mockResolvedValue({
+      addressedAt: new Date("2026-05-20T11:00:00.000Z"),
+      addressedByUser: { displayName: "Ola", id: "user-1" },
+      authorUser: { displayName: "Kari", id: "user-2" },
+      body: null,
+      createdAt: new Date("2026-05-20T10:00:00.000Z"),
+      date: new Date("2026-05-15T00:00:00.000Z"),
+      id: "comment-1",
+      quickResponse: MealPlanReviewQuickResponse.YES,
+      shareId: "share-1",
+      updatedAt: new Date("2026-05-20T10:00:00.000Z"),
+    });
+
+    const result = await markReviewCommentAddressed({
+      commentId: "comment-1",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("ADDRESSED");
+    expect(result.comment?.feedbackLabel).toBe("Ja!");
+  });
+
+  it("approves a meal plan from share review without day comments", async () => {
+    dbMock.mealPlanShareRecipient.findFirst.mockResolvedValue({
+      id: "recipient-1",
+      share: {
+        mealPlan: draftMealPlan,
+        status: "OPEN",
+      },
+      status: "VIEWED",
+    });
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      ...draftMealPlan,
+      entries: [],
+      updatedAt: new Date("2026-05-20T10:00:00.000Z"),
+    });
+    vi.mocked(approveMealPlan).mockResolvedValue({
+      mealPlan: { id: "meal-plan-1", status: "APPROVED" },
+      status: "APPROVED",
+    } as never);
+    dbMock.mealPlanShareRecipient.update.mockResolvedValue({});
+
+    const result = await approveMealPlanFromShareReview({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      shareId: "share-1",
+      userId: "user-2",
+    });
+
+    expect(result.status).toBe("APPROVED");
+    expect(approveMealPlan).toHaveBeenCalled();
+    expect(dbMock.mealPlanShareRecipient.update).toHaveBeenCalled();
+  });
+
+  it("closes open shares for a meal plan", async () => {
+    dbMock.mealPlanShare.updateMany.mockResolvedValue({ count: 1 });
+
+    await closeSharesForMealPlan({ mealPlanId: "meal-plan-1" });
+
+    expect(dbMock.mealPlanShare.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          mealPlanId: "meal-plan-1",
+          status: "OPEN",
+        },
+      }),
+    );
+  });
+});

--- a/app/lib/meal-plan-share.server.ts
+++ b/app/lib/meal-plan-share.server.ts
@@ -1,0 +1,1028 @@
+import type { Prisma } from "@prisma/client";
+import { Prisma as PrismaRuntime } from "@prisma/client";
+
+import { buildMealPlanEntriesSnapshot } from "./collaboration.server";
+import { db } from "./db.server";
+import {
+  listFamilyMembersForCollaboration,
+  requireFamilyMembership,
+} from "./family.server";
+import {
+  formatMealPlanReviewFeedback,
+  isMealPlanReviewQuickResponse,
+} from "./meal-plan-review-presets";
+import {
+  approveMealPlan,
+  formatDateOnly,
+  getMealPlanDateRange,
+  parseDateOnly,
+} from "./meal-plan.server";
+
+const PLANNING_MEAL_TYPE = "DINNER" as const;
+const MEAL_PLAN_STATUS_DRAFT = "DRAFT" as const;
+const SHARE_STATUS_OPEN = "OPEN" as const;
+const SHARE_STATUS_CLOSED = "CLOSED" as const;
+const RECIPIENT_STATUS_PENDING = "PENDING" as const;
+const RECIPIENT_STATUS_VIEWED = "VIEWED" as const;
+const RECIPIENT_STATUS_RESPONDED = "RESPONDED" as const;
+
+const shareSummarySelect = PrismaRuntime.validator<Prisma.MealPlanShareSelect>()({
+  closedAt: true,
+  createdAt: true,
+  id: true,
+  mealPlanId: true,
+  message: true,
+  sharedByUser: {
+    select: {
+      displayName: true,
+      id: true,
+    },
+  },
+  status: true,
+  wholeFamily: true,
+});
+
+const reviewCommentSelect = PrismaRuntime.validator<Prisma.MealPlanReviewCommentSelect>()({
+  addressedAt: true,
+  addressedByUser: {
+    select: {
+      displayName: true,
+      id: true,
+    },
+  },
+  authorUser: {
+    select: {
+      displayName: true,
+      id: true,
+    },
+  },
+  body: true,
+  createdAt: true,
+  date: true,
+  id: true,
+  quickResponse: true,
+  shareId: true,
+  updatedAt: true,
+});
+
+const mealPlanReviewEntrySelect = PrismaRuntime.validator<Prisma.MealPlanEntrySelect>()({
+  date: true,
+  mealType: true,
+  note: true,
+  recipe: {
+    select: {
+      id: true,
+      title: true,
+    },
+  },
+  recipeId: true,
+});
+
+interface FamilyScopedInput {
+  familyId: string;
+  userId: string;
+}
+
+interface MealPlanScopedInput extends FamilyScopedInput {
+  mealPlanId: string;
+}
+
+interface CreateMealPlanShareInput extends MealPlanScopedInput {
+  message?: string;
+  recipientUserIds: string[];
+  wholeFamily: boolean;
+}
+
+interface UpsertDayReviewCommentInput {
+  body?: string;
+  date: string;
+  familyId: string;
+  mealPlanId: string;
+  quickResponse?: string;
+  shareId: string;
+  userId: string;
+}
+
+const SHARE_NOT_DRAFT_MESSAGE =
+  "Kun utkast kan deles for gjennomgang.";
+const SHARE_CLOSED_MESSAGE =
+  "Denne delingen er lukket.";
+const SHARE_NOT_RECIPIENT_MESSAGE =
+  "Du er ikke mottaker av denne delingen.";
+const FEEDBACK_REQUIRED_MESSAGE =
+  "Velg et hurtigsvar eller skriv et notat.";
+const INVALID_DATE_MESSAGE = "Datoen er ugyldig.";
+const INVALID_RECIPIENT_MESSAGE = "Velg minst én mottaker i familien.";
+const ALREADY_SHARED_MESSAGE =
+  "Ukeplanen er allerede delt for gjennomgang. Vent til gjennomgangen er ferdig.";
+
+export async function countPendingReviewsForUser({
+  familyId,
+  userId,
+}: FamilyScopedInput) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  return db.mealPlanShareRecipient.count({
+    where: {
+      status: {
+        in: [
+          RECIPIENT_STATUS_PENDING,
+          RECIPIENT_STATUS_VIEWED,
+        ],
+      },
+      share: {
+        mealPlan: {
+          familyId,
+          status: MEAL_PLAN_STATUS_DRAFT,
+        },
+        status: SHARE_STATUS_OPEN,
+      },
+      userId,
+    },
+  });
+}
+
+export async function listPendingReviewsForUser({
+  familyId,
+  userId,
+}: FamilyScopedInput) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const recipients = await db.mealPlanShareRecipient.findMany({
+    orderBy: [{ share: { createdAt: "desc" } }],
+    select: {
+      id: true,
+      respondedAt: true,
+      share: {
+        select: {
+          ...shareSummarySelect,
+          mealPlan: {
+            select: {
+              endDate: true,
+              id: true,
+              startDate: true,
+              title: true,
+            },
+          },
+        },
+      },
+      status: true,
+      viewedAt: true,
+    },
+    where: {
+      status: {
+        in: [
+          RECIPIENT_STATUS_PENDING,
+          RECIPIENT_STATUS_VIEWED,
+          RECIPIENT_STATUS_RESPONDED,
+        ],
+      },
+      share: {
+        mealPlan: {
+          familyId,
+          status: MEAL_PLAN_STATUS_DRAFT,
+        },
+        status: SHARE_STATUS_OPEN,
+      },
+      userId,
+    },
+  });
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    reviews: recipients.map((recipient) => ({
+      id: recipient.id,
+      mealPlan: {
+        endDate: formatDateOnly(recipient.share.mealPlan.endDate),
+        id: recipient.share.mealPlan.id,
+        startDate: formatDateOnly(recipient.share.mealPlan.startDate),
+        title: recipient.share.mealPlan.title,
+      },
+      respondedAt: recipient.respondedAt?.toISOString() ?? null,
+      share: {
+        createdAt: recipient.share.createdAt.toISOString(),
+        id: recipient.share.id,
+        message: recipient.share.message,
+        sharedByDisplayName: recipient.share.sharedByUser.displayName,
+        wholeFamily: recipient.share.wholeFamily,
+      },
+      status: recipient.status,
+      viewedAt: recipient.viewedAt?.toISOString() ?? null,
+    })),
+  };
+}
+
+export async function getMealPlanShareCreationData({
+  familyId,
+  mealPlanId,
+  userId,
+}: MealPlanScopedInput) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await getDraftMealPlanOrThrow({
+    familyId,
+    mealPlanId,
+  });
+
+  const [members, openShares] = await Promise.all([
+    listFamilyMembersForCollaboration(familyId),
+    listOpenSharesForMealPlan(mealPlanId),
+  ]);
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    mealPlan: {
+      id: mealPlan.id,
+      status: mealPlan.status,
+      title: mealPlan.title,
+    },
+    members: members
+      .filter((member) => member.user.id !== userId)
+      .map((member) => ({
+        displayName: member.user.displayName,
+        id: member.user.id,
+        role: member.role,
+      })),
+    openShares: openShares.map(serializeShareWithComments),
+  };
+}
+
+export async function listSharesForMealPlan({
+  familyId,
+  mealPlanId,
+  userId,
+}: MealPlanScopedInput) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  await getMealPlanInFamilyOrThrow({
+    familyId,
+    mealPlanId,
+  });
+
+  const shares = await db.mealPlanShare.findMany({
+    orderBy: [{ createdAt: "desc" }],
+    select: {
+      ...shareSummarySelect,
+      comments: {
+        orderBy: [{ date: "asc" }, { createdAt: "asc" }],
+        select: reviewCommentSelect,
+      },
+      recipients: {
+        select: {
+          status: true,
+          user: {
+            select: {
+              displayName: true,
+              id: true,
+            },
+          },
+        },
+      },
+    },
+    where: {
+      mealPlanId,
+    },
+  });
+
+  return shares.map(serializeShareWithComments);
+}
+
+export async function createMealPlanShare(input: CreateMealPlanShareInput) {
+  await requireFamilyMembership({
+    familyId: input.familyId,
+    userId: input.userId,
+  });
+
+  const mealPlan = await getDraftMealPlanOrThrow({
+    familyId: input.familyId,
+    mealPlanId: input.mealPlanId,
+  });
+
+  const message = input.message?.trim() ?? "";
+  const recipientUserIds = await resolveRecipientUserIds({
+    familyId: input.familyId,
+    recipientUserIds: input.recipientUserIds,
+    sharerUserId: input.userId,
+    wholeFamily: input.wholeFamily,
+  });
+
+  if (recipientUserIds.length === 0) {
+    return {
+      formError: INVALID_RECIPIENT_MESSAGE,
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  const existingOpenShare = await db.mealPlanShare.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      mealPlanId: mealPlan.id,
+      status: SHARE_STATUS_OPEN,
+    },
+  });
+
+  if (existingOpenShare) {
+    return {
+      formError: ALREADY_SHARED_MESSAGE,
+      status: "ALREADY_SHARED" as const,
+    };
+  }
+
+  const share = await db.mealPlanShare.create({
+    data: {
+      mealPlanId: mealPlan.id,
+      message: message || null,
+      recipients: {
+        create: recipientUserIds.map((recipientUserId) => ({
+          userId: recipientUserId,
+        })),
+      },
+      sharedByUserId: input.userId,
+      wholeFamily: input.wholeFamily,
+    },
+    select: shareSummarySelect,
+  });
+
+  return {
+    share: {
+      ...share,
+      closedAt: share.closedAt?.toISOString() ?? null,
+      createdAt: share.createdAt.toISOString(),
+    },
+    status: "CREATED" as const,
+  };
+}
+
+export async function getMealPlanShareReviewData({
+  familyId,
+  mealPlanId,
+  shareId,
+  userId,
+}: MealPlanScopedInput & { shareId: string }) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const share = await getShareForRecipientReviewOrThrow({
+    familyId,
+    mealPlanId,
+    shareId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: {
+      endDate: true,
+      entries: {
+        orderBy: [{ date: "asc" }, { mealType: "asc" }],
+        select: mealPlanReviewEntrySelect,
+        where: {
+          mealType: PLANNING_MEAL_TYPE,
+        },
+      },
+      id: true,
+      startDate: true,
+      status: true,
+      title: true,
+    },
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    throw new Response("Fant ikke ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  const visibleDates = getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate);
+  const dinnerByDate = new Map(
+    mealPlan.entries.map((entry) => [formatDateOnly(entry.date), entry]),
+  );
+  const commentsByDate = new Map(
+    share.comments
+      .filter((comment) => comment.authorUserId === userId)
+      .map((comment) => [formatDateOnly(comment.date), comment]),
+  );
+
+  return {
+    days: visibleDates.map((date) => {
+      const entry = dinnerByDate.get(date);
+      const comment = commentsByDate.get(date);
+
+      return {
+        comment: comment
+          ? {
+              body: comment.body,
+              feedbackLabel: formatMealPlanReviewFeedback(comment),
+              id: comment.id,
+              quickResponse: comment.quickResponse,
+            }
+          : null,
+        date,
+        dinner: entry
+          ? {
+              note: entry.note,
+              recipeId: entry.recipeId,
+              recipeTitle: entry.recipe?.title ?? null,
+            }
+          : null,
+      };
+    }),
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    canApprove:
+      mealPlan.status === MEAL_PLAN_STATUS_DRAFT &&
+      share.status === SHARE_STATUS_OPEN,
+    shareStatus: share.status,
+    mealPlan: {
+      endDate: formatDateOnly(mealPlan.endDate),
+      id: mealPlan.id,
+      startDate: formatDateOnly(mealPlan.startDate),
+      status: mealPlan.status,
+      title: mealPlan.title,
+    },
+    recipientStatus: share.recipient.status,
+    share: {
+      createdAt: share.createdAt.toISOString(),
+      id: share.id,
+      message: share.message,
+      sharedByDisplayName: share.sharedByUser.displayName,
+    },
+  };
+}
+
+export async function approveMealPlanFromShareReview({
+  familyId,
+  mealPlanId,
+  shareId,
+  userId,
+}: MealPlanScopedInput & { shareId: string }) {
+  const recipient = await getShareRecipientOrThrow({
+    familyId,
+    mealPlanId,
+    shareId,
+    userId,
+  });
+
+  if (recipient.share.status !== SHARE_STATUS_OPEN) {
+    return {
+      formError: SHARE_CLOSED_MESSAGE,
+      status: "SHARE_CLOSED" as const,
+    };
+  }
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: {
+      entries: {
+        select: {
+          date: true,
+          mealType: true,
+          updatedAt: true,
+        },
+        where: {
+          mealType: PLANNING_MEAL_TYPE,
+        },
+      },
+      id: true,
+      status: true,
+      updatedAt: true,
+    },
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (mealPlan.status !== MEAL_PLAN_STATUS_DRAFT) {
+    return {
+      formError: SHARE_NOT_DRAFT_MESSAGE,
+      status: "NOT_DRAFT" as const,
+    };
+  }
+
+  const result = await approveMealPlan({
+    entriesSnapshot: buildMealPlanEntriesSnapshot(mealPlan.entries),
+    expectedMealPlanUpdatedAt: mealPlan.updatedAt.toISOString(),
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (result.status === "APPROVED") {
+    await db.mealPlanShareRecipient.update({
+      data: {
+        respondedAt: new Date(),
+        status: RECIPIENT_STATUS_RESPONDED,
+      },
+      where: {
+        id: recipient.id,
+      },
+    });
+  }
+
+  return result;
+}
+
+export async function recordShareViewed({
+  familyId,
+  mealPlanId,
+  shareId,
+  userId,
+}: MealPlanScopedInput & { shareId: string }) {
+  const recipient = await getShareRecipientOrThrow({
+    familyId,
+    mealPlanId,
+    shareId,
+    userId,
+  });
+
+  if (recipient.share.status !== SHARE_STATUS_OPEN) {
+    return { status: "UNCHANGED" as const };
+  }
+
+  if (recipient.status !== RECIPIENT_STATUS_PENDING) {
+    return { status: "UNCHANGED" as const };
+  }
+
+  await db.mealPlanShareRecipient.update({
+    data: {
+      status: RECIPIENT_STATUS_VIEWED,
+      viewedAt: new Date(),
+    },
+    where: {
+      id: recipient.id,
+    },
+  });
+
+  return { status: "VIEWED" as const };
+}
+
+export async function upsertDayReviewComment(input: UpsertDayReviewCommentInput) {
+  const recipient = await getShareRecipientOrThrow({
+    familyId: input.familyId,
+    mealPlanId: input.mealPlanId,
+    shareId: input.shareId,
+    userId: input.userId,
+  });
+
+  if (recipient.share.status !== SHARE_STATUS_OPEN) {
+    return {
+      formError: SHARE_CLOSED_MESSAGE,
+      status: "SHARE_CLOSED" as const,
+    };
+  }
+
+  if (recipient.share.mealPlan.status !== MEAL_PLAN_STATUS_DRAFT) {
+    return {
+      formError: SHARE_NOT_DRAFT_MESSAGE,
+      status: "NOT_DRAFT" as const,
+    };
+  }
+
+  const parsedDate = parseDateOnly(input.date);
+
+  if (!parsedDate) {
+    return {
+      formError: INVALID_DATE_MESSAGE,
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  const visibleDates = getMealPlanDateRange(
+    recipient.share.mealPlan.startDate,
+    recipient.share.mealPlan.endDate,
+  );
+
+  if (!visibleDates.includes(input.date)) {
+    return {
+      formError: INVALID_DATE_MESSAGE,
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  const body = input.body?.trim() ?? "";
+  const quickResponse =
+    input.quickResponse && isMealPlanReviewQuickResponse(input.quickResponse)
+      ? input.quickResponse
+      : null;
+
+  if (!quickResponse && !body) {
+    return {
+      formError: FEEDBACK_REQUIRED_MESSAGE,
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  const comment = await db.mealPlanReviewComment.upsert({
+    create: {
+      authorUserId: input.userId,
+      body: quickResponse ? null : body,
+      date: parsedDate,
+      mealPlanId: input.mealPlanId,
+      quickResponse: quickResponse ?? undefined,
+      shareId: input.shareId,
+    },
+    select: reviewCommentSelect,
+    update: {
+      body: quickResponse ? null : body,
+      quickResponse: quickResponse ?? null,
+    },
+    where: {
+      shareId_authorUserId_date: {
+        authorUserId: input.userId,
+        date: parsedDate,
+        shareId: input.shareId,
+      },
+    },
+  });
+
+  await db.mealPlanShareRecipient.update({
+    data: {
+      respondedAt: new Date(),
+      status: RECIPIENT_STATUS_RESPONDED,
+    },
+    where: {
+      id: recipient.id,
+    },
+  });
+
+  return {
+    comment: serializeReviewComment(comment),
+    status: "SAVED" as const,
+  };
+}
+
+export async function markReviewCommentAddressed({
+  commentId,
+  familyId,
+  mealPlanId,
+  userId,
+}: MealPlanScopedInput & { commentId: string }) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const comment = await db.mealPlanReviewComment.findFirst({
+    select: reviewCommentSelect,
+    where: {
+      id: commentId,
+      mealPlan: {
+        familyId,
+        id: mealPlanId,
+      },
+    },
+  });
+
+  if (!comment) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (comment.addressedAt) {
+    return {
+      comment: serializeReviewComment(comment),
+      status: "ALREADY_ADDRESSED" as const,
+    };
+  }
+
+  const updatedComment = await db.mealPlanReviewComment.update({
+    data: {
+      addressedAt: new Date(),
+      addressedByUserId: userId,
+    },
+    select: reviewCommentSelect,
+    where: {
+      id: commentId,
+    },
+  });
+
+  return {
+    comment: serializeReviewComment(updatedComment),
+    status: "ADDRESSED" as const,
+  };
+}
+
+export async function closeSharesForMealPlan({
+  mealPlanId,
+  tx = db,
+}: {
+  mealPlanId: string;
+  tx?: Prisma.TransactionClient;
+}) {
+  const now = new Date();
+
+  await tx.mealPlanShare.updateMany({
+    data: {
+      closedAt: now,
+      status: SHARE_STATUS_CLOSED,
+    },
+    where: {
+      mealPlanId,
+      status: SHARE_STATUS_OPEN,
+    },
+  });
+}
+
+async function listOpenSharesForMealPlan(mealPlanId: string) {
+  return db.mealPlanShare.findMany({
+    orderBy: [{ createdAt: "desc" }],
+    select: {
+      ...shareSummarySelect,
+      comments: {
+        orderBy: [{ date: "asc" }, { createdAt: "asc" }],
+        select: reviewCommentSelect,
+      },
+      recipients: {
+        select: {
+          status: true,
+          user: {
+            select: {
+              displayName: true,
+              id: true,
+            },
+          },
+        },
+      },
+    },
+    where: {
+      mealPlanId,
+      status: SHARE_STATUS_OPEN,
+    },
+  });
+}
+
+async function getMealPlanInFamilyOrThrow({
+  familyId,
+  mealPlanId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+}) {
+  const mealPlan = await db.mealPlan.findFirst({
+    select: {
+      endDate: true,
+      id: true,
+      startDate: true,
+      status: true,
+      title: true,
+    },
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    throw new Response("Fant ikke ukeplanen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return mealPlan;
+}
+
+async function getDraftMealPlanOrThrow({
+  familyId,
+  mealPlanId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+}) {
+  const mealPlan = await getMealPlanInFamilyOrThrow({
+    familyId,
+    mealPlanId,
+  });
+
+  if (mealPlan.status !== MEAL_PLAN_STATUS_DRAFT) {
+    throw new Response(SHARE_NOT_DRAFT_MESSAGE, {
+      status: 400,
+      statusText: "Bad Request",
+    });
+  }
+
+  return mealPlan;
+}
+
+async function resolveRecipientUserIds({
+  familyId,
+  recipientUserIds,
+  sharerUserId,
+  wholeFamily,
+}: {
+  familyId: string;
+  recipientUserIds: string[];
+  sharerUserId: string;
+  wholeFamily: boolean;
+}) {
+  const members = await listFamilyMembersForCollaboration(familyId);
+  const eligibleUserIds = new Set(
+    members
+      .map((member) => member.user.id)
+      .filter((memberUserId) => memberUserId !== sharerUserId),
+  );
+
+  if (wholeFamily) {
+    return [...eligibleUserIds];
+  }
+
+  return [...new Set(recipientUserIds)].filter((recipientUserId) =>
+    eligibleUserIds.has(recipientUserId),
+  );
+}
+
+async function getShareRecipientOrThrow({
+  familyId,
+  mealPlanId,
+  shareId,
+  userId,
+}: MealPlanScopedInput & { shareId: string }) {
+  const recipient = await db.mealPlanShareRecipient.findFirst({
+    select: {
+      id: true,
+      share: {
+        select: {
+          mealPlan: {
+            select: {
+              endDate: true,
+              id: true,
+              startDate: true,
+              status: true,
+            },
+          },
+          status: true,
+        },
+      },
+      status: true,
+    },
+    where: {
+      share: {
+        id: shareId,
+        mealPlan: {
+          familyId,
+          id: mealPlanId,
+        },
+      },
+      userId,
+    },
+  });
+
+  if (!recipient) {
+    throw new Response(SHARE_NOT_RECIPIENT_MESSAGE, {
+      status: 403,
+      statusText: "Forbidden",
+    });
+  }
+
+  return recipient;
+}
+
+async function getShareForRecipientReviewOrThrow({
+  familyId,
+  mealPlanId,
+  shareId,
+  userId,
+}: MealPlanScopedInput & { shareId: string }) {
+  const recipient = await db.mealPlanShareRecipient.findFirst({
+    select: {
+      id: true,
+      share: {
+        select: {
+          ...shareSummarySelect,
+          comments: {
+            select: {
+              authorUserId: true,
+              body: true,
+              date: true,
+              id: true,
+              quickResponse: true,
+            },
+          },
+          mealPlan: {
+            select: {
+              endDate: true,
+              id: true,
+              startDate: true,
+              status: true,
+            },
+          },
+          status: true,
+        },
+      },
+      status: true,
+    },
+    where: {
+      share: {
+        id: shareId,
+        mealPlan: {
+          familyId,
+          id: mealPlanId,
+        },
+      },
+      userId,
+    },
+  });
+
+  if (!recipient) {
+    throw new Response(SHARE_NOT_RECIPIENT_MESSAGE, {
+      status: 403,
+      statusText: "Forbidden",
+    });
+  }
+
+  return {
+    ...recipient.share,
+    recipient: {
+      id: recipient.id,
+      status: recipient.status,
+    },
+  };
+}
+
+function serializeReviewComment(
+  comment: Prisma.MealPlanReviewCommentGetPayload<{
+    select: typeof reviewCommentSelect;
+  }>,
+) {
+  return {
+    addressedAt: comment.addressedAt?.toISOString() ?? null,
+    addressedByDisplayName: comment.addressedByUser?.displayName ?? null,
+    authorDisplayName: comment.authorUser.displayName,
+    authorUserId: comment.authorUser.id,
+    body: comment.body,
+    createdAt: comment.createdAt.toISOString(),
+    date: formatDateOnly(comment.date),
+    feedbackLabel: formatMealPlanReviewFeedback(comment),
+    id: comment.id,
+    quickResponse: comment.quickResponse,
+    shareId: comment.shareId,
+    updatedAt: comment.updatedAt.toISOString(),
+  };
+}
+
+function serializeShareWithComments(
+  share: Prisma.MealPlanShareGetPayload<{
+    select: typeof shareSummarySelect & {
+      comments: { select: typeof reviewCommentSelect };
+      recipients: {
+        select: {
+          status: true;
+          user: { select: { displayName: true; id: true } };
+        };
+      };
+    };
+  }>,
+) {
+  return {
+    closedAt: share.closedAt?.toISOString() ?? null,
+    comments: share.comments.map(serializeReviewComment),
+    createdAt: share.createdAt.toISOString(),
+    id: share.id,
+    mealPlanId: share.mealPlanId,
+    message: share.message,
+    recipients: share.recipients.map((recipient) => ({
+      displayName: recipient.user.displayName,
+      status: recipient.status,
+      userId: recipient.user.id,
+    })),
+    sharedByDisplayName: share.sharedByUser.displayName,
+    sharedByUserId: share.sharedByUser.id,
+    status: share.status,
+    wholeFamily: share.wholeFamily,
+  };
+}

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -13,6 +13,9 @@ const { dbMock, requireFamilyAdminMock, requireFamilyMembershipMock } = vi.hoist
         update: vi.fn(),
         updateMany: vi.fn(),
       },
+      mealPlanShare: {
+        updateMany: vi.fn(),
+      },
       mealPlanEntry: {
         createMany: vi.fn(),
         deleteMany: vi.fn(),
@@ -87,6 +90,7 @@ describe("meal-plan.server", () => {
     );
     dbMock.mealPlanEntry.findMany.mockResolvedValue([]);
     dbMock.mealPlan.updateMany.mockResolvedValue({ count: 1 });
+    dbMock.mealPlanShare.updateMany.mockResolvedValue({ count: 0 });
     dbMock.mealPlan.findUniqueOrThrow.mockResolvedValue({
       id: "meal-plan-1",
       title: "Langhelg",
@@ -570,6 +574,15 @@ describe("meal-plan.server", () => {
     expect(requireFamilyMembershipMock).toHaveBeenCalledWith({
       familyId: "family-1",
       userId: "user-1",
+    });
+    expect(dbMock.mealPlanShare.updateMany).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        status: "CLOSED",
+      }),
+      where: {
+        mealPlanId: "meal-plan-1",
+        status: "OPEN",
+      },
     });
     expect(dbMock.mealPlan.update).toHaveBeenCalledWith({
       data: expect.objectContaining({

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -11,7 +11,10 @@ import {
 } from "./collaboration.server";
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
-import { logCollaborationFailure, logCollaborationWrite } from "./write-observability.server";
+import {
+  logCollaborationFailure,
+  logCollaborationWrite,
+} from "./write-observability.server";
 
 const MEAL_PLAN_MAX_SPAN_DAYS = 7;
 const MEAL_PLAN_MAX_DAY_OFFSET = MEAL_PLAN_MAX_SPAN_DAYS - 1;
@@ -155,7 +158,8 @@ type AutoFillMealPlanEntriesInput = DeleteMealPlanInput;
 
 type MealPlanApprovalAction = "APPROVE" | "REOPEN";
 
-const AUTO_FILL_NOT_DRAFT_MESSAGE = "Godkjente ukeplaner kan ikke fylles automatisk.";
+const AUTO_FILL_NOT_DRAFT_MESSAGE =
+  "Godkjente ukeplaner kan ikke fylles automatisk.";
 const AUTO_FILL_NO_ELIGIBLE_RECIPES_MESSAGE =
   "Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de to forrige ukeplanene.";
 const AUTO_FILL_REPEAT_WARNING_MESSAGE =
@@ -181,7 +185,10 @@ export function getMealPlanDateRange(startDate: Date, endDate: Date) {
   return dates;
 }
 
-export function validateMealPlanRange(startDate: string, endDate: string): MealPlanValidationResult {
+export function validateMealPlanRange(
+  startDate: string,
+  endDate: string,
+): MealPlanValidationResult {
   const values = {
     endDate: endDate.trim(),
     startDate: startDate.trim(),
@@ -260,7 +267,10 @@ export function validateMealPlanRange(startDate: string, endDate: string): MealP
   };
 }
 
-export async function listMealPlansForFamily({ familyId, userId }: MealPlanListInput) {
+export async function listMealPlansForFamily({
+  familyId,
+  userId,
+}: MealPlanListInput) {
   const membership = await requireFamilyMembership({
     familyId,
     userId,
@@ -284,7 +294,11 @@ export async function listMealPlansForFamily({ familyId, userId }: MealPlanListI
   };
 }
 
-export async function getMealPlanForFamily({ familyId, mealPlanId, userId }: GetMealPlanInput) {
+export async function getMealPlanForFamily({
+  familyId,
+  mealPlanId,
+  userId,
+}: GetMealPlanInput) {
   const membership = await requireFamilyMembership({
     familyId,
     userId,
@@ -344,7 +358,10 @@ export async function getMealPlanPlanningData({
     orderBy: [{ title: "asc" }],
     select: recipeOptionSelect,
     where: {
-      OR: [{ scope: RecipeScope.GLOBAL }, { familyId, scope: RecipeScope.FAMILY }],
+      OR: [
+        { scope: RecipeScope.GLOBAL },
+        { familyId, scope: RecipeScope.FAMILY },
+      ],
     },
   });
 
@@ -460,7 +477,10 @@ export async function copyMealPlan(input: CopyMealPlanInput) {
         return [];
       }
 
-      const dayOffset = differenceInUtcDays(sourceMealPlan.startDate, entry.date);
+      const dayOffset = differenceInUtcDays(
+        sourceMealPlan.startDate,
+        entry.date,
+      );
       const targetDate = addUtcDays(startDate, dayOffset);
 
       if (targetDate.getTime() > endDate.getTime()) {
@@ -537,7 +557,10 @@ export async function updateMealPlan(input: UpdateMealPlanInput) {
   }
 
   if (
-    !matchesExpectedUpdatedAt(input.expectedMealPlanUpdatedAt, existingMealPlan.updatedAt)
+    !matchesExpectedUpdatedAt(
+      input.expectedMealPlanUpdatedAt,
+      existingMealPlan.updatedAt,
+    )
   ) {
     logCollaborationWrite({
       action: "update-meal-plan",
@@ -656,7 +679,11 @@ export async function updateMealPlan(input: UpdateMealPlanInput) {
   }
 }
 
-export async function deleteMealPlan({ familyId, mealPlanId, userId }: DeleteMealPlanInput) {
+export async function deleteMealPlan({
+  familyId,
+  mealPlanId,
+  userId,
+}: DeleteMealPlanInput) {
   await requireFamilyMembership({
     familyId,
     userId,
@@ -764,7 +791,10 @@ export async function autoFillMealPlanEntries({
     };
   }
 
-  const visibleDates = getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate);
+  const visibleDates = getMealPlanDateRange(
+    mealPlan.startDate,
+    mealPlan.endDate,
+  );
   const dinnerEntriesByDate = new Map(
     mealPlan.entries
       .filter((entry) => entry.mealType === PLANNING_MEAL_TYPE)
@@ -789,7 +819,10 @@ export async function autoFillMealPlanEntries({
       id: true,
     },
     where: {
-      OR: [{ scope: RecipeScope.GLOBAL }, { familyId, scope: RecipeScope.FAMILY }],
+      OR: [
+        { scope: RecipeScope.GLOBAL },
+        { familyId, scope: RecipeScope.FAMILY },
+      ],
     },
   });
   const excludedRecipeIds = await getRecentlyUsedRecipeIds({
@@ -895,7 +928,11 @@ export async function saveMealPlanEntries({
   }
 
   const values = entries.map(normalizeMealPlanEntryValues);
-  const validationError = validateMealPlanEntries(values, mealPlan.startDate, mealPlan.endDate);
+  const validationError = validateMealPlanEntries(
+    values,
+    mealPlan.startDate,
+    mealPlan.endDate,
+  );
 
   if (validationError) {
     logCollaborationWrite({
@@ -915,7 +952,9 @@ export async function saveMealPlanEntries({
     };
   }
 
-  const recipeIds = [...new Set(values.map((entry) => entry.recipeId).filter(Boolean))];
+  const recipeIds = [
+    ...new Set(values.map((entry) => entry.recipeId).filter(Boolean)),
+  ];
 
   if (recipeIds.length > 0) {
     const recipes = await db.recipe.findMany({
@@ -926,7 +965,10 @@ export async function saveMealPlanEntries({
         id: {
           in: recipeIds,
         },
-        OR: [{ scope: RecipeScope.GLOBAL }, { familyId, scope: RecipeScope.FAMILY }],
+        OR: [
+          { scope: RecipeScope.GLOBAL },
+          { familyId, scope: RecipeScope.FAMILY },
+        ],
       },
     });
 
@@ -942,14 +984,17 @@ export async function saveMealPlanEntries({
       });
 
       return {
-        formError: "Minst en valgt oppskrift er ikke tilgjengelig for familien.",
+        formError:
+          "Minst en valgt oppskrift er ikke tilgjengelig for familien.",
         status: "VALIDATION_ERROR" as const,
         values,
       };
     }
   }
 
-  const submittedDates = values.map((entry) => parseDateOnly(entry.date)!).filter(Boolean);
+  const submittedDates = values
+    .map((entry) => parseDateOnly(entry.date)!)
+    .filter(Boolean);
   const existingEntries = await db.mealPlanEntry.findMany({
     select: {
       date: true,
@@ -969,7 +1014,12 @@ export async function saveMealPlanEntries({
   const conflictingDates = values.flatMap((entry) => {
     const existingEntry = existingEntryByDate.get(entry.date);
 
-    if (matchesExpectedUpdatedAt(entryVersions[entry.date], existingEntry?.updatedAt)) {
+    if (
+      matchesExpectedUpdatedAt(
+        entryVersions[entry.date],
+        existingEntry?.updatedAt,
+      )
+    ) {
       return [];
     }
 
@@ -1001,7 +1051,9 @@ export async function saveMealPlanEntries({
         const date = parseDateOnly(entry.date);
 
         if (!date) {
-          throw new Error(`Expected validated meal plan date for "${entry.date}".`);
+          throw new Error(
+            `Expected validated meal plan date for "${entry.date}".`,
+          );
         }
 
         if (!entry.note && !entry.recipeId) {
@@ -1077,7 +1129,13 @@ export async function saveMealPlanEntries({
 }
 
 async function updateMealPlanApprovalState(
-  { entriesSnapshot, expectedMealPlanUpdatedAt, familyId, mealPlanId, userId }: MealPlanApprovalInput,
+  {
+    entriesSnapshot,
+    expectedMealPlanUpdatedAt,
+    familyId,
+    mealPlanId,
+    userId,
+  }: MealPlanApprovalInput,
   action: MealPlanApprovalAction,
 ) {
   await requireFamilyMembership({
@@ -1121,10 +1179,15 @@ async function updateMealPlanApprovalState(
   }
 
   if (action === "APPROVE") {
-    const currentEntriesSnapshot = buildMealPlanEntriesSnapshot(mealPlan.entries);
+    const currentEntriesSnapshot = buildMealPlanEntriesSnapshot(
+      mealPlan.entries,
+    );
 
     if (
-      !matchesExpectedUpdatedAt(expectedMealPlanUpdatedAt, mealPlan.updatedAt) ||
+      !matchesExpectedUpdatedAt(
+        expectedMealPlanUpdatedAt,
+        mealPlan.updatedAt,
+      ) ||
       entriesSnapshot.trim() !== currentEntriesSnapshot
     ) {
       logCollaborationWrite({
@@ -1145,28 +1208,48 @@ async function updateMealPlanApprovalState(
     }
   }
 
-  const nextStatus = action === "APPROVE" ? MealPlanStatus.APPROVED : MealPlanStatus.DRAFT;
+  const nextStatus =
+    action === "APPROVE" ? MealPlanStatus.APPROVED : MealPlanStatus.DRAFT;
 
   try {
-    const updatedMealPlan = await db.mealPlan.update({
-      data:
-        nextStatus === MealPlanStatus.APPROVED
-          ? {
-              approvedAt: new Date(),
-              approvedByUserId: userId,
-              status: MealPlanStatus.APPROVED,
-              ...buildActorUpdate(userId),
-            }
-          : {
-              approvedAt: null,
-              approvedByUserId: null,
-              status: MealPlanStatus.DRAFT,
-              ...buildActorUpdate(userId),
-            },
-      select: mealPlanDetailSelect,
-      where: {
-        id: mealPlan.id,
-      },
+    const updatedMealPlan = await db.$transaction(async (tx) => {
+      const result = await tx.mealPlan.update({
+        data:
+          nextStatus === MealPlanStatus.APPROVED
+            ? {
+                approvedAt: new Date(),
+                approvedByUserId: userId,
+                status: MealPlanStatus.APPROVED,
+                ...buildActorUpdate(userId),
+              }
+            : {
+                approvedAt: null,
+                approvedByUserId: null,
+                status: MealPlanStatus.DRAFT,
+                ...buildActorUpdate(userId),
+              },
+        select: mealPlanDetailSelect,
+        where: {
+          id: mealPlan.id,
+        },
+      });
+
+      if (nextStatus === MealPlanStatus.APPROVED) {
+        const closedAt = new Date();
+
+        await tx.mealPlanShare.updateMany({
+          data: {
+            closedAt,
+            status: "CLOSED",
+          },
+          where: {
+            mealPlanId: mealPlan.id,
+            status: "OPEN",
+          },
+        });
+      }
+
+      return result;
     });
 
     logCollaborationWrite({
@@ -1182,7 +1265,8 @@ async function updateMealPlanApprovalState(
 
     return {
       mealPlan: updatedMealPlan,
-      status: action === "APPROVE" ? ("APPROVED" as const) : ("REOPENED" as const),
+      status:
+        action === "APPROVE" ? ("APPROVED" as const) : ("REOPENED" as const),
     };
   } catch (error) {
     logCollaborationFailure({
@@ -1205,7 +1289,10 @@ function validateMealPlanInput({
   endDate,
   startDate,
   title,
-}: Pick<MealPlanMutationInput, "endDate" | "startDate" | "title">): MealPlanValidationResult {
+}: Pick<
+  MealPlanMutationInput,
+  "endDate" | "startDate" | "title"
+>): MealPlanValidationResult {
   const trimmedTitle = title.trim();
   const rangeValidation = validateMealPlanRange(startDate, endDate);
   const values = {
@@ -1239,7 +1326,10 @@ function validateMealPlanInput({
   };
 }
 
-function isMealPlanStatusTransitionAllowed(status: MealPlanStatus, action: MealPlanApprovalAction) {
+function isMealPlanStatusTransitionAllowed(
+  status: MealPlanStatus,
+  action: MealPlanApprovalAction,
+) {
   if (action === "APPROVE") {
     return status === MealPlanStatus.DRAFT;
   }
@@ -1247,7 +1337,10 @@ function isMealPlanStatusTransitionAllowed(status: MealPlanStatus, action: MealP
   return status === MealPlanStatus.APPROVED;
 }
 
-function getMealPlanApprovalTransitionError(action: MealPlanApprovalAction, currentStatus: MealPlanStatus) {
+function getMealPlanApprovalTransitionError(
+  action: MealPlanApprovalAction,
+  currentStatus: MealPlanStatus,
+) {
   if (action === "APPROVE") {
     if (currentStatus === MealPlanStatus.APPROVED) {
       return "Ukeplanen er allerede godkjent.";
@@ -1260,7 +1353,7 @@ function getMealPlanApprovalTransitionError(action: MealPlanApprovalAction, curr
     return "Ukeplanen er allerede et utkast.";
   }
 
-  return "Ukeplanen kan ikke gjenapnes fra gjeldende status.";
+  return "Ukeplanen kan ikke gjenåpnes fra gjeldende status.";
 }
 
 function shuffleRecipeIds(recipeIds: string[]) {
@@ -1310,7 +1403,9 @@ function assignRecipesToDates({
   };
 }
 
-function normalizeMealPlanEntryValues(entry: MealPlanEntryValues): MealPlanEntryValues {
+function normalizeMealPlanEntryValues(
+  entry: MealPlanEntryValues,
+): MealPlanEntryValues {
   return {
     date: entry.date.trim(),
     note: entry.note.trim(),
@@ -1318,7 +1413,11 @@ function normalizeMealPlanEntryValues(entry: MealPlanEntryValues): MealPlanEntry
   };
 }
 
-function validateMealPlanEntries(entries: MealPlanEntryValues[], startDate: Date, endDate: Date) {
+function validateMealPlanEntries(
+  entries: MealPlanEntryValues[],
+  startDate: Date,
+  endDate: Date,
+) {
   const visibleDateSet = new Set(getMealPlanDateRange(startDate, endDate));
 
   if (entries.length !== visibleDateSet.size) {
@@ -1352,7 +1451,7 @@ function validateMealPlanEntries(entries: MealPlanEntryValues[], startDate: Date
   return null;
 }
 
-function parseDateOnly(value: string) {
+export function parseDateOnly(value: string) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     return null;
   }
@@ -1378,11 +1477,19 @@ function parseDateOnly(value: string) {
 function differenceInUtcDays(startDate: Date, endDate: Date) {
   const millisecondsPerDay = 1000 * 60 * 60 * 24;
 
-  return Math.round((endDate.getTime() - startDate.getTime()) / millisecondsPerDay);
+  return Math.round(
+    (endDate.getTime() - startDate.getTime()) / millisecondsPerDay,
+  );
 }
 
 function addUtcDays(date: Date, amount: number) {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + amount));
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate() + amount,
+    ),
+  );
 }
 
 function clampShoppingDateToRange(

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -9,6 +9,11 @@ export default [
     route("app", "routes/app.tsx"),
     route("families/:familyId", "routes/family.tsx"),
     route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
+    route("families/:familyId/meal-plans/reviews", "routes/family-meal-plan-reviews.tsx"),
+    route(
+      "families/:familyId/meal-plans/:mealPlanId/review",
+      "routes/family-meal-plan-review.tsx",
+    ),
     route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
     route(
       "families/:familyId/meal-plans/:mealPlanId/calendar.ics",

--- a/app/routes/app-layout.test.ts
+++ b/app/routes/app-layout.test.ts
@@ -17,8 +17,15 @@ vi.mock("../lib/family.server", () => {
   };
 });
 
+vi.mock("../lib/meal-plan-share.server", () => {
+  return {
+    countPendingReviewsForUser: vi.fn(),
+  };
+});
+
 import { requireUser } from "../lib/auth.server";
 import { getFamilyMembershipsForUser } from "../lib/family.server";
+import { countPendingReviewsForUser } from "../lib/meal-plan-share.server";
 import { loader } from "./app-layout";
 
 const mockUser = {
@@ -39,18 +46,20 @@ describe("app-layout loader", () => {
 
   it("returns familyId from route params on family routes", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(countPendingReviewsForUser).mockResolvedValue(2);
 
     const result = await loader({
       params: { familyId: "family-1" },
       request: buildRequest("http://localhost/families/family-1/stores"),
     } as never);
 
-    expect(result).toEqual({ familyId: "family-1" });
+    expect(result).toEqual({ familyId: "family-1", pendingReviewCount: 2 });
     expect(getFamilyMembershipsForUser).not.toHaveBeenCalled();
   });
 
   it("returns the only family on /app when the user has one membership", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(countPendingReviewsForUser).mockResolvedValue(0);
     vi.mocked(getFamilyMembershipsForUser).mockResolvedValue([
       {
         id: "membership-1",
@@ -64,7 +73,7 @@ describe("app-layout loader", () => {
       request: buildRequest("http://localhost/app"),
     } as never);
 
-    expect(result).toEqual({ familyId: "family-1" });
+    expect(result).toEqual({ familyId: "family-1", pendingReviewCount: 0 });
   });
 
   it("returns null familyId on /app when the user has multiple memberships", async () => {
@@ -87,6 +96,6 @@ describe("app-layout loader", () => {
       request: buildRequest("http://localhost/app"),
     } as never);
 
-    expect(result).toEqual({ familyId: null });
+    expect(result).toEqual({ familyId: null, pendingReviewCount: 0 });
   });
 });

--- a/app/routes/app-layout.tsx
+++ b/app/routes/app-layout.tsx
@@ -3,13 +3,19 @@ import { Outlet } from "react-router";
 import { AppTopNav } from "../components/app-top-nav";
 import { requireUser } from "../lib/auth.server";
 import { getFamilyMembershipsForUser } from "../lib/family.server";
+import { countPendingReviewsForUser } from "../lib/meal-plan-share.server";
 import type { Route } from "./+types/app-layout";
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   const user = await requireUser(request);
 
   if (params.familyId) {
-    return { familyId: params.familyId };
+    const pendingReviewCount = await countPendingReviewsForUser({
+      familyId: params.familyId,
+      userId: user.id,
+    });
+
+    return { familyId: params.familyId, pendingReviewCount };
   }
 
   const url = new URL(request.url);
@@ -18,17 +24,26 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     const memberships = await getFamilyMembershipsForUser(user.id);
 
     if (memberships.length === 1) {
-      return { familyId: memberships[0].family.id };
+      const familyId = memberships[0].family.id;
+      const pendingReviewCount = await countPendingReviewsForUser({
+        familyId,
+        userId: user.id,
+      });
+
+      return { familyId, pendingReviewCount };
     }
   }
 
-  return { familyId: null };
+  return { familyId: null, pendingReviewCount: 0 };
 }
 
 export default function AppLayoutRoute({ loaderData }: Route.ComponentProps) {
   return (
     <>
-      <AppTopNav familyId={loaderData.familyId} />
+      <AppTopNav
+        familyId={loaderData.familyId}
+        pendingReviewCount={loaderData.pendingReviewCount}
+      />
       <Outlet />
     </>
   );

--- a/app/routes/family-meal-plan-review.test.ts
+++ b/app/routes/family-meal-plan-review.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/meal-plan-share.server", () => ({
+  approveMealPlanFromShareReview: vi.fn(),
+  getMealPlanShareReviewData: vi.fn(),
+  recordShareViewed: vi.fn(),
+  upsertDayReviewComment: vi.fn(),
+}));
+
+import { requireUser } from "../lib/auth.server";
+import {
+  approveMealPlanFromShareReview,
+  getMealPlanShareReviewData,
+  recordShareViewed,
+  upsertDayReviewComment,
+} from "../lib/meal-plan-share.server";
+import { action, loader } from "./family-meal-plan-review";
+
+const mockUser = {
+  displayName: "Kari",
+  email: "kari@example.com",
+  id: "user-2",
+  isGlobalAdmin: false,
+};
+
+describe("family meal plan review route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads review data when shareId is provided", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(recordShareViewed).mockResolvedValue({ status: "VIEWED" });
+    vi.mocked(getMealPlanShareReviewData).mockResolvedValue({
+      canApprove: true,
+      days: [],
+      family: { id: "family-1", name: "Solberg" },
+      mealPlan: {
+        endDate: "2026-05-18",
+        id: "meal-plan-1",
+        startDate: "2026-05-15",
+        status: "DRAFT",
+        title: "Uke 20",
+      },
+      recipientStatus: "VIEWED",
+      share: {
+        createdAt: "2026-05-20T10:00:00.000Z",
+        id: "share-1",
+        message: null,
+        sharedByDisplayName: "Ola",
+      },
+      shareStatus: "OPEN",
+    });
+
+    const result = await loader({
+      params: { familyId: "family-1", mealPlanId: "meal-plan-1" },
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/meal-plan-1/review?shareId=share-1",
+      ),
+    } as never);
+
+    expect(result.shareId).toBe("share-1");
+    expect(recordShareViewed).toHaveBeenCalled();
+  });
+
+  it("saves quick-response feedback from the review action", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(upsertDayReviewComment).mockResolvedValue({
+      comment: {
+        addressedAt: null,
+        addressedByDisplayName: null,
+        authorDisplayName: "Kari",
+        authorUserId: "user-2",
+        body: null,
+        createdAt: "2026-05-20T10:00:00.000Z",
+        date: "2026-05-15",
+        feedbackLabel: "Ja!",
+        id: "comment-1",
+        quickResponse: "YES",
+        shareId: "share-1",
+        updatedAt: "2026-05-20T10:00:00.000Z",
+      },
+      status: "SAVED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "save-day-feedback");
+    formData.set("shareId", "share-1");
+    formData.set("date", "2026-05-15");
+    formData.set("quickResponse", "YES");
+
+    const result = await action({
+      params: { familyId: "family-1", mealPlanId: "meal-plan-1" },
+      request: new Request("http://localhost", {
+        body: formData,
+        method: "POST",
+      }),
+    } as never);
+
+    expect(result.ok).toBe(true);
+    expect(upsertDayReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quickResponse: "YES",
+        userId: "user-2",
+      }),
+    );
+  });
+
+  it("approves the meal plan without requiring day feedback", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(approveMealPlanFromShareReview).mockResolvedValue({
+      mealPlan: { id: "meal-plan-1", status: "APPROVED" },
+      status: "APPROVED",
+    } as never);
+
+    const formData = new FormData();
+    formData.set("intent", "approve-meal-plan");
+    formData.set("shareId", "share-1");
+
+    const response = await action({
+      params: { familyId: "family-1", mealPlanId: "meal-plan-1" },
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/meal-plan-1/review?shareId=share-1",
+        {
+          body: formData,
+          method: "POST",
+        },
+      ),
+    } as never);
+
+    expect(approveMealPlanFromShareReview).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      shareId: "share-1",
+      userId: "user-2",
+    });
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+    expect((response as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/reviews?notice=meal-plan-approved",
+    );
+  });
+});

--- a/app/routes/family-meal-plan-review.tsx
+++ b/app/routes/family-meal-plan-review.tsx
@@ -1,0 +1,477 @@
+import { Form, Link, useNavigation, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { getMealPlanReviewQuickResponseOptions } from "../lib/meal-plan-review-presets";
+import {
+  approveMealPlanFromShareReview,
+  getMealPlanShareReviewData,
+  recordShareViewed,
+  upsertDayReviewComment,
+} from "../lib/meal-plan-share.server";
+
+type ReviewIntent = "approve-meal-plan" | "save-day-feedback" | "save-day-note";
+
+interface ReviewActionData {
+  approvalFormError?: string;
+  date?: string;
+  formError?: string;
+  intent?: ReviewIntent;
+  ok?: boolean;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Gjennomgang av ukeplan | Mealplanner" },
+    {
+      name: "description",
+      content: "Gi tilbakemelding på en delt ukeplan.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: { familyId?: string; mealPlanId?: string };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
+  const shareId = new URL(request.url).searchParams.get("shareId");
+
+  if (!shareId) {
+    throw new Response("Fant ikke delingen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  await recordShareViewed({
+    familyId,
+    mealPlanId,
+    shareId,
+    userId: user.id,
+  });
+
+  const data = await getMealPlanShareReviewData({
+    familyId,
+    mealPlanId,
+    shareId,
+    userId: user.id,
+  });
+
+  const url = new URL(request.url);
+  const notice = url.searchParams.get("notice");
+
+  return {
+    ...data,
+    notice:
+      notice === "meal-plan-approved" ? ("meal-plan-approved" as const) : null,
+    quickResponseOptions: getMealPlanReviewQuickResponseOptions(),
+    shareId,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: { familyId?: string; mealPlanId?: string };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+  const shareId = String(formData.get("shareId") ?? "");
+  const date = String(formData.get("date") ?? "");
+
+  if (!shareId) {
+    return {
+      formError: "Fant ikke delingen.",
+      intent: intent as ReviewIntent,
+    } satisfies ReviewActionData;
+  }
+
+  if (intent === "approve-meal-plan") {
+    const result = await approveMealPlanFromShareReview({
+      familyId,
+      mealPlanId,
+      shareId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw new Response("Fant ikke ukeplanen.", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    }
+
+    if (
+      result.status === "CONFLICT" ||
+      result.status === "INVALID_TRANSITION" ||
+      result.status === "NOT_DRAFT" ||
+      result.status === "SHARE_CLOSED"
+    ) {
+      return {
+        approvalFormError: result.formError,
+        intent,
+      } satisfies ReviewActionData;
+    }
+
+    if (result.status === "APPROVED") {
+      const url = new URL(request.url);
+      url.pathname = `/families/${familyId}/meal-plans/reviews`;
+      url.search = "";
+      url.searchParams.set("notice", "meal-plan-approved");
+
+      return Response.redirect(url.toString(), 302);
+    }
+
+    return {
+      approvalFormError: "Kunne ikke godkjenne ukeplanen.",
+      intent,
+    } satisfies ReviewActionData;
+  }
+
+  if (intent === "save-day-feedback" || intent === "save-day-note") {
+    const result = await upsertDayReviewComment({
+      body:
+        intent === "save-day-note"
+          ? String(formData.get("body") ?? "")
+          : undefined,
+      date,
+      familyId,
+      mealPlanId,
+      quickResponse:
+        intent === "save-day-feedback"
+          ? String(formData.get("quickResponse") ?? "")
+          : undefined,
+      shareId,
+      userId: user.id,
+    });
+
+    if (result.status !== "SAVED") {
+      return {
+        date,
+        formError: result.formError,
+        intent: intent as ReviewIntent,
+      } satisfies ReviewActionData;
+    }
+
+    return {
+      date,
+      intent: intent as ReviewIntent,
+      ok: true,
+    } satisfies ReviewActionData;
+  }
+
+  return {
+    formError: "Ugyldig handling.",
+  } satisfies ReviewActionData;
+}
+
+export default function FamilyMealPlanReviewRoute({
+  actionData,
+  loaderData,
+}: {
+  actionData?: ReviewActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}) {
+  const navigation = useNavigation();
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingDate = navigation.formData?.get("date");
+  const isApprovingMealPlan =
+    navigation.state === "submitting" && pendingIntent === "approve-meal-plan";
+  const recipientLabel =
+    loaderData.mealPlan.status === "APPROVED"
+      ? "Godkjent"
+      : loaderData.recipientStatus === "RESPONDED"
+        ? "Du har svart"
+        : "Venter på deg";
+
+  return (
+    <main className="min-h-screen overflow-x-hidden bg-slate-100 px-4 py-6 text-slate-900">
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-4">
+        <section className="sticky top-14 z-40 rounded-[24px] bg-slate-950 px-4 py-4 text-white shadow-lg">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-emerald-200">
+                Gjennomgang
+              </p>
+              <h1 className="mt-1 truncate text-xl font-semibold">
+                {loaderData.mealPlan.title}
+              </h1>
+              <p className="mt-1 text-sm text-slate-300">
+                {formatMealPlanWindow(
+                  loaderData.mealPlan.startDate,
+                  loaderData.mealPlan.endDate,
+                )}
+              </p>
+              <p className="mt-1 text-xs text-slate-400">
+                Delt av {loaderData.share.sharedByDisplayName}
+              </p>
+            </div>
+            <span className="shrink-0 rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-slate-100">
+              {recipientLabel}
+            </span>
+          </div>
+          {loaderData.share.message ? (
+            <p className="mt-3 rounded-2xl bg-white/10 px-3 py-2 text-sm text-slate-200">
+              {loaderData.share.message}
+            </p>
+          ) : null}
+        </section>
+
+        {loaderData.notice === "meal-plan-approved" ? (
+          <section className="rounded-[24px] border border-emerald-200 bg-emerald-50 px-4 py-4 text-emerald-950">
+            <h2 className="text-base font-semibold">Ukeplan godkjent</h2>
+            <p className="mt-1 text-sm leading-6 text-emerald-900">
+              Ukeplanen er godkjent. Tilbakemelding per dag var valgfritt.
+            </p>
+          </section>
+        ) : null}
+
+        {loaderData.canApprove ? (
+          <section className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm mt-15">
+            <h2 className="text-base font-semibold text-slate-950">
+              Godkjenn ukeplanen
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Du trenger ikke legge inn tilbakemelding på hver dag. Godkjenn når
+              planen ser bra ut.
+            </p>
+            <Form className="mt-4" method="post">
+              <input name="intent" type="hidden" value="approve-meal-plan" />
+              <input name="shareId" type="hidden" value={loaderData.shareId} />
+              {actionData?.intent === "approve-meal-plan" &&
+              actionData.approvalFormError ? (
+                <p className="mb-3 rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                  {actionData.approvalFormError}
+                </p>
+              ) : null}
+              <button
+                className="inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-emerald-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-300"
+                disabled={isApprovingMealPlan}
+                type="submit"
+              >
+                {isApprovingMealPlan ? "Godkjenner..." : "Godkjenn ukeplan"}
+              </button>
+            </Form>
+          </section>
+        ) : null}
+
+        <p className="text-sm text-slate-600">
+          Valgfri tilbakemelding per dag:
+        </p>
+
+        <div className="flex flex-col gap-3 pb-8">
+          {loaderData.days.map((day) => {
+            const isSubmittingDay =
+              navigation.state === "submitting" && pendingDate === day.date;
+            const dayError =
+              actionData?.date === day.date ? actionData.formError : undefined;
+            const selectedQuickResponse = day.comment?.quickResponse ?? null;
+
+            return (
+              <article
+                key={day.date}
+                className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm"
+              >
+                <header className="mb-3">
+                  <h2 className="text-base font-semibold text-slate-950">
+                    {formatWeekdayLabel(day.date)}
+                  </h2>
+                  <p className="text-sm text-slate-500">
+                    {formatShortDate(day.date)}
+                  </p>
+                </header>
+
+                {day.dinner?.recipeTitle ? (
+                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 ring-1 ring-emerald-100">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-emerald-800">
+                      Middag
+                    </p>
+                    <p className="mt-2 text-lg font-semibold leading-snug text-slate-950">
+                      {day.dinner.recipeTitle}
+                    </p>
+                    {day.dinner.note ? (
+                      <p className="mt-2 text-sm leading-6 text-slate-600">
+                        {day.dinner.note}
+                      </p>
+                    ) : null}
+                  </div>
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                      Middag
+                    </p>
+                    <p className="mt-2 text-sm text-slate-500">
+                      Ingen middag valgt
+                    </p>
+                  </div>
+                )}
+
+                {loaderData.canApprove ? (
+                  <div className="mt-4 flex flex-col gap-2">
+                    {loaderData.quickResponseOptions.map((option) => {
+                      const isSelected = selectedQuickResponse === option.value;
+                      const isSubmittingChip =
+                        isSubmittingDay &&
+                        pendingIntent === "save-day-feedback" &&
+                        navigation.formData?.get("quickResponse") ===
+                          option.value;
+
+                      return (
+                        <Form
+                          key={option.value}
+                          className="contents"
+                          method="post"
+                        >
+                          <input
+                            name="intent"
+                            type="hidden"
+                            value="save-day-feedback"
+                          />
+                          <input
+                            name="shareId"
+                            type="hidden"
+                            value={loaderData.shareId}
+                          />
+                          <input name="date" type="hidden" value={day.date} />
+                          <input
+                            name="quickResponse"
+                            type="hidden"
+                            value={option.value}
+                          />
+                          <button
+                            className={[
+                              "inline-flex min-h-11 w-full items-center justify-center rounded-2xl px-4 py-3 text-sm font-medium transition disabled:cursor-not-allowed",
+                              isSelected
+                                ? "bg-emerald-600 text-white ring-2 ring-emerald-300"
+                                : "bg-slate-100 text-slate-900 hover:bg-slate-200",
+                            ].join(" ")}
+                            disabled={isSubmittingDay}
+                            type="submit"
+                          >
+                            {isSubmittingChip ? "Lagrer..." : option.label}
+                          </button>
+                        </Form>
+                      );
+                    })}
+                  </div>
+                ) : day.comment ? (
+                  <p className="mt-4 rounded-2xl bg-slate-50 px-3 py-2 text-sm text-slate-700">
+                    {day.comment.feedbackLabel}
+                  </p>
+                ) : null}
+
+                {loaderData.canApprove ? (
+                  <details className="mt-3 group">
+                    <summary className="cursor-pointer list-none text-sm font-medium text-slate-600 marker:content-none [&::-webkit-details-marker]:hidden">
+                      Annet
+                    </summary>
+                    <Form className="mt-3 space-y-2" method="post">
+                      <input
+                        name="intent"
+                        type="hidden"
+                        value="save-day-note"
+                      />
+                      <input
+                        name="shareId"
+                        type="hidden"
+                        value={loaderData.shareId}
+                      />
+                      <input name="date" type="hidden" value={day.date} />
+                      <textarea
+                        className="min-h-20 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900"
+                        defaultValue={day.comment?.body ?? ""}
+                        name="body"
+                        placeholder="Skriv et kort notat..."
+                        rows={3}
+                      />
+                      <button
+                        className="inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                        disabled={
+                          isSubmittingDay && pendingIntent === "save-day-note"
+                        }
+                        type="submit"
+                      >
+                        {isSubmittingDay && pendingIntent === "save-day-note"
+                          ? "Lagrer..."
+                          : "Lagre notat"}
+                      </button>
+                    </Form>
+                  </details>
+                ) : null}
+
+                {day.comment &&
+                !day.comment.quickResponse &&
+                day.comment.body ? (
+                  <p className="mt-2 text-xs text-slate-500">
+                    Lagret: {day.comment.feedbackLabel}
+                  </p>
+                ) : null}
+
+                {dayError ? (
+                  <p className="mt-2 rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+                    {dayError}
+                  </p>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+
+        <Link
+          className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-50"
+          to={`/families/${loaderData.family.id}/meal-plans/reviews`}
+        >
+          Tilbake til gjennomgang
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function requireRouteParam(value: string | undefined, message: string): string {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}
+
+function formatMealPlanWindow(startDate: string, endDate: string) {
+  return `${formatShortDate(startDate)} – ${formatShortDate(endDate)}`;
+}
+
+function formatShortDate(date: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}
+
+function formatWeekdayLabel(date: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    weekday: "long",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}

--- a/app/routes/family-meal-plan-reviews.tsx
+++ b/app/routes/family-meal-plan-reviews.tsx
@@ -1,0 +1,167 @@
+import { Link, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { listPendingReviewsForUser } from "../lib/meal-plan-share.server";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Til gjennomgang | Mealplanner" },
+    {
+      name: "description",
+      content: "Ukeplaner som venter på din tilbakemelding.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: { familyId?: string };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  return {
+    ...(await listPendingReviewsForUser({
+      familyId,
+      userId: user.id,
+    })),
+    notice: notice === "meal-plan-approved" ? ("meal-plan-approved" as const) : null,
+  };
+}
+
+export default function FamilyMealPlanReviewsRoute({
+  loaderData,
+}: {
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}) {
+  const pendingReviews = loaderData.reviews.filter(
+    (review) => review.status === "PENDING" || review.status === "VIEWED",
+  );
+
+  return (
+    <main className="min-h-screen overflow-x-hidden bg-slate-100 px-4 py-6 text-slate-900">
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-6">
+        <section className="rounded-[28px] bg-slate-950 px-5 py-6 text-white shadow-xl">
+          <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+            Gjennomgang
+          </span>
+          <h1 className="mt-4 text-2xl font-semibold tracking-tight">
+            Til gjennomgang
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-slate-300">
+            {loaderData.family.name} — gi tilbakemelding på delte ukeplaner.
+          </p>
+        </section>
+
+        {loaderData.notice === "meal-plan-approved" ? (
+          <section className="rounded-[24px] border border-emerald-200 bg-emerald-50 px-4 py-4 text-emerald-950">
+            <h2 className="text-base font-semibold">Ukeplan godkjent</h2>
+            <p className="mt-1 text-sm leading-6 text-emerald-900">
+              Takk — ukeplanen er godkjent og klar for neste steg.
+            </p>
+          </section>
+        ) : null}
+
+        {loaderData.reviews.length === 0 ? (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <p className="text-sm leading-6 text-slate-600">
+              Ingen ukeplaner venter på deg akkurat nå.
+            </p>
+            <Link
+              className="mt-4 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+              to={`/families/${loaderData.family.id}/meal-plans`}
+            >
+              Til ukeplaner
+            </Link>
+          </section>
+        ) : (
+          <section className="space-y-3">
+            {pendingReviews.length > 0 ? (
+              <p className="text-sm font-medium text-slate-700">
+                {pendingReviews.length}{" "}
+                {pendingReviews.length === 1 ? "plan venter" : "planer venter"}{" "}
+                på deg
+              </p>
+            ) : null}
+
+            {loaderData.reviews.map((review) => {
+              const needsResponse =
+                review.status === "PENDING" || review.status === "VIEWED";
+
+              return (
+                <article
+                  key={review.id}
+                  className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="text-base font-semibold text-slate-950">
+                      {review.mealPlan.title}
+                    </h2>
+                    <span
+                      className={
+                        needsResponse
+                          ? "rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-900"
+                          : "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800"
+                      }
+                    >
+                      {needsResponse ? "Venter på deg" : "Du har svart"}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm text-slate-600">
+                    {formatMealPlanWindow(
+                      review.mealPlan.startDate,
+                      review.mealPlan.endDate,
+                    )}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-500">
+                    Delt av {review.share.sharedByDisplayName}
+                    {review.share.message
+                      ? ` — «${review.share.message}»`
+                      : null}
+                  </p>
+                  <Link
+                    className="mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                    to={`/families/${loaderData.family.id}/meal-plans/${review.mealPlan.id}/review?shareId=${review.share.id}`}
+                  >
+                    {needsResponse ? "Gi tilbakemelding" : "Se tilbakemelding"}
+                  </Link>
+                </article>
+              );
+            })}
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function requireRouteParam(
+  value: string | undefined,
+  message: string,
+): string {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}
+
+function formatMealPlanWindow(startDate: string, endDate: string) {
+  return `${formatShortDate(startDate)} – ${formatShortDate(endDate)}`;
+}
+
+function formatShortDate(date: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -20,6 +20,13 @@ vi.mock("../lib/meal-plan.server", () => {
   };
 });
 
+vi.mock("../lib/meal-plan-share.server", () => ({
+  createMealPlanShare: vi.fn(),
+  getMealPlanShareCreationData: vi.fn(),
+  listSharesForMealPlan: vi.fn(),
+  markReviewCommentAddressed: vi.fn(),
+}));
+
 import { requireUser } from "../lib/auth.server";
 import {
   approveMealPlan,
@@ -28,6 +35,10 @@ import {
   saveMealPlanEntries,
   updateMealPlan,
 } from "../lib/meal-plan.server";
+import {
+  getMealPlanShareCreationData,
+  listSharesForMealPlan,
+} from "../lib/meal-plan-share.server";
 import { action, loader } from "./family-meal-plan";
 
 const mockUser = {
@@ -95,6 +106,13 @@ describe("family meal plan route", () => {
       userRole: "ADMIN",
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
     });
+    vi.mocked(getMealPlanShareCreationData).mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      mealPlan: { id: "meal-plan-1", status: "DRAFT", title: "Langhelg" },
+      members: [{ displayName: "Kari", id: "user-2", role: "MEMBER" }],
+      openShares: [],
+    });
+    vi.mocked(listSharesForMealPlan).mockResolvedValue([]);
 
     const result = await loader({
       params: {
@@ -110,6 +128,7 @@ describe("family meal plan route", () => {
       userId: "user-1",
     });
     expect(result).toEqual({
+      activeOpenShare: null,
       calendarExportDates: [],
       family: {
         id: "family-1",
@@ -131,6 +150,7 @@ describe("family meal plan route", () => {
       },
       entriesSnapshot:
         "2026-05-15T00:00:00.000Z:DINNER:2026-05-01T12:00:00.000Z",
+      feedbackShares: [],
       notice: "meal-plan-created",
       noticeMeta: null,
       recipes: [
@@ -143,6 +163,7 @@ describe("family meal plan route", () => {
           title: "Kyllingtaco",
         },
       ],
+      shareMembers: [{ displayName: "Kari", id: "user-2", role: "MEMBER" }],
       userRole: "ADMIN",
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
       entriesByDate: {

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -12,6 +12,12 @@ import {
   COLLABORATION_CONFLICT_MESSAGE,
 } from "../lib/collaboration.server";
 import {
+  createMealPlanShare,
+  getMealPlanShareCreationData,
+  listSharesForMealPlan,
+  markReviewCommentAddressed,
+} from "../lib/meal-plan-share.server";
+import {
   approveMealPlan,
   autoFillMealPlanEntries,
   formatDateOnly,
@@ -27,13 +33,17 @@ type MealPlanNotice =
   | "meal-plan-auto-filled"
   | "meal-plan-created"
   | "meal-plan-entries-saved"
+  | "meal-plan-feedback-addressed"
   | "meal-plan-reopened"
+  | "meal-plan-shared"
   | "meal-plan-updated";
 type MealPlanIntent =
   | "approve-meal-plan"
   | "auto-fill-meal-plan-entries"
+  | "mark-comment-addressed"
   | "reopen-meal-plan"
   | "save-meal-plan-entries"
+  | "share-meal-plan"
   | "update-meal-plan";
 
 interface MealPlanNoticeMeta {
@@ -51,6 +61,7 @@ interface MealPlanEntryFormState {
 
 interface MealPlanActionData {
   autoFillFormError?: string;
+  commentId?: string;
   entryFormError?: string;
   entryValues?: Record<string, MealPlanEntryFormState>;
   fieldErrors?: {
@@ -60,6 +71,7 @@ interface MealPlanActionData {
   };
   formError?: string;
   intent?: MealPlanIntent;
+  shareFormError?: string;
   statusFormError?: string;
   values?: {
     endDate?: string;
@@ -134,9 +146,27 @@ export async function loader({
     return [formatDateOnly(entry.date)];
   });
 
+  const shareData =
+    result.mealPlan.status === "DRAFT"
+      ? await getMealPlanShareCreationData({
+          familyId,
+          mealPlanId,
+          userId: user.id,
+        })
+      : null;
+  const feedbackShares =
+    result.mealPlan.status === "DRAFT"
+      ? await listSharesForMealPlan({
+          familyId,
+          mealPlanId,
+          userId: user.id,
+        })
+      : [];
+
   return {
     calendarExportDates,
     family: result.family,
+    feedbackShares,
     mealPlan: {
       ...result.mealPlan,
       activeShoppingDate: result.mealPlan.activeShoppingDate
@@ -154,6 +184,8 @@ export async function loader({
     notice: getMealPlanNotice(request),
     noticeMeta: getMealPlanNoticeMeta(request),
     recipes: result.recipes,
+    activeOpenShare: shareData?.openShares[0] ?? null,
+    shareMembers: shareData?.members ?? [],
     userRole: result.userRole,
     visibleDates: result.visibleDates,
     entriesByDate,
@@ -335,6 +367,64 @@ export async function action({
     });
   }
 
+  if (intent === "share-meal-plan") {
+    const wholeFamily = formData.get("wholeFamily") === "on";
+    const recipientUserIds = formData
+      .getAll("recipientUserIds")
+      .map((value) => String(value));
+
+    const result = await createMealPlanShare({
+      familyId,
+      mealPlanId,
+      message: String(formData.get("message") ?? ""),
+      recipientUserIds,
+      userId: user.id,
+      wholeFamily,
+    });
+
+    if (
+      result.status === "VALIDATION_ERROR" ||
+      result.status === "ALREADY_SHARED"
+    ) {
+      return {
+        intent,
+        shareFormError: result.formError,
+      } satisfies MealPlanActionData;
+    }
+
+    return buildMealPlanRedirect({
+      familyId,
+      mealPlanId,
+      notice: "meal-plan-shared",
+      request,
+    });
+  }
+
+  if (intent === "mark-comment-addressed") {
+    const commentId = String(formData.get("commentId") ?? "");
+    const result = await markReviewCommentAddressed({
+      commentId,
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        commentId,
+        intent,
+        shareFormError: "Fant ikke tilbakemeldingen.",
+      } satisfies MealPlanActionData;
+    }
+
+    return buildMealPlanRedirect({
+      familyId,
+      mealPlanId,
+      notice: "meal-plan-feedback-addressed",
+      request,
+    });
+  }
+
   if (intent !== "update-meal-plan") {
     return {
       formError: "Ukjent handling.",
@@ -399,6 +489,17 @@ export default function FamilyMealPlanRoute({
     pendingIntent === "save-meal-plan-entries";
   const isUpdatingMetadata =
     navigation.state === "submitting" && pendingIntent === "update-meal-plan";
+  const isSharingMealPlan =
+    navigation.state === "submitting" && pendingIntent === "share-meal-plan";
+  const isMarkingCommentAddressed =
+    navigation.state === "submitting" &&
+    pendingIntent === "mark-comment-addressed";
+  const openFeedbackShares = loaderData.feedbackShares.filter(
+    (share) => share.status === "OPEN",
+  );
+  const unresolvedComments = openFeedbackShares.flatMap((share) =>
+    share.comments.filter((comment) => !comment.addressedAt),
+  );
   const noticeContent = loaderData.notice
     ? getMealPlanNoticeContent(loaderData.notice, loaderData.noticeMeta)
     : null;
@@ -424,8 +525,8 @@ export default function FamilyMealPlanRoute({
         ? "Godkjenner..."
         : "Godkjenn ukeplan"
       : isReopeningMealPlan
-        ? "Gjenapner..."
-        : "Gjenapne som utkast";
+        ? "Gjenåpner..."
+        : "Gjenåpne som utkast";
   const entryValues =
     actionData?.intent === "save-meal-plan-entries" && actionData.entryValues
       ? actionData.entryValues
@@ -526,6 +627,25 @@ export default function FamilyMealPlanRoute({
             <p className="mt-2 text-sm leading-6 text-emerald-900">
               {noticeContent.description}
             </p>
+          </section>
+        ) : null}
+
+        {loaderData.mealPlan.status === "DRAFT" ? (
+          <section className="grid min-w-0 gap-6 lg:grid-cols-2">
+            <MealPlanShareSection
+              actionData={actionData}
+              activeOpenShare={loaderData.activeOpenShare}
+              familyId={loaderData.family.id}
+              isSharingMealPlan={isSharingMealPlan}
+              members={loaderData.shareMembers}
+            />
+            <MealPlanFeedbackSection
+              actionData={actionData}
+              isMarkingCommentAddressed={isMarkingCommentAddressed}
+              unresolvedCount={unresolvedComments.length}
+              visibleDates={loaderData.visibleDates}
+              shares={openFeedbackShares}
+            />
           </section>
         ) : null}
 
@@ -808,7 +928,9 @@ function getMealPlanNotice(request: Request): MealPlanNotice | null {
     notice === "meal-plan-auto-filled" ||
     notice === "meal-plan-created" ||
     notice === "meal-plan-entries-saved" ||
+    notice === "meal-plan-feedback-addressed" ||
     notice === "meal-plan-reopened" ||
+    notice === "meal-plan-shared" ||
     notice === "meal-plan-updated"
   ) {
     return notice;
@@ -904,11 +1026,21 @@ function getMealPlanNoticeContent(
           "Middagene og notatene ble lagret for den aktive perioden.",
         title: "Middager lagret",
       };
+    case "meal-plan-feedback-addressed":
+      return {
+        description: "Tilbakemeldingen er markert som behandlet.",
+        title: "Tilbakemelding behandlet",
+      };
+    case "meal-plan-shared":
+      return {
+        description: "Familiemedlemmer kan nå gi tilbakemelding på ukeplanen.",
+        title: "Ukeplan delt for gjennomgang",
+      };
     case "meal-plan-reopened":
       return {
         description:
-          "Ukeplanen er gjenapnet som utkast og kan fortsatt redigeres.",
-        title: "Ukeplan gjenapnet",
+          "Ukeplanen er gjenåpnet som utkast og kan fortsatt redigeres.",
+        title: "Ukeplan gjenåpnet",
       };
     case "meal-plan-updated":
       return {
@@ -925,6 +1057,284 @@ interface MealPlanRecipeOption {
   prepMinutes: number | null;
   tags: string[];
   title: string;
+}
+
+interface ShareMemberOption {
+  displayName: string;
+  id: string;
+  role: string;
+}
+
+interface FeedbackShare {
+  comments: Array<{
+    addressedAt: string | null;
+    authorDisplayName: string;
+    date: string;
+    feedbackLabel: string;
+    id: string;
+  }>;
+  createdAt: string;
+  id: string;
+  message: string | null;
+  recipients: Array<{
+    displayName: string;
+    status: string;
+    userId: string;
+  }>;
+  sharedByDisplayName: string;
+  wholeFamily: boolean;
+}
+
+function MealPlanShareSection({
+  actionData,
+  activeOpenShare,
+  familyId,
+  isSharingMealPlan,
+  members,
+}: {
+  actionData?: MealPlanActionData;
+  activeOpenShare: FeedbackShare | null;
+  familyId: string;
+  isSharingMealPlan: boolean;
+  members: ShareMemberOption[];
+}) {
+  if (activeOpenShare) {
+    const recipientNames = activeOpenShare.recipients
+      .map((recipient) => recipient.displayName)
+      .join(", ");
+
+    return (
+      <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
+        <h2 className="text-lg font-semibold text-slate-950">
+          Delt for gjennomgang
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          Ukeplanen venter allerede på tilbakemelding fra{" "}
+          {activeOpenShare.wholeFamily
+            ? "familien"
+            : recipientNames || "mottakerne"}
+          .{activeOpenShare.message ? ` «${activeOpenShare.message}»` : ""}
+        </p>
+        <p className="mt-3 text-sm text-slate-500">
+          Du kan ikke sende en ny gjennomgang før denne er avsluttet (for
+          eksempel når planen godkjennes).
+        </p>
+        <Link
+          className="mt-4 inline-flex text-sm font-medium text-emerald-700 hover:text-emerald-800"
+          to={`/families/${familyId}/meal-plans/reviews`}
+        >
+          Se det du skal gjennomgå
+        </Link>
+      </article>
+    );
+  }
+
+  return (
+    <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
+      <h2 className="text-lg font-semibold text-slate-950">
+        Del for gjennomgang
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-slate-600">
+        Send ukeplanen til familien for enkel tilbakemelding på mobil. Du kan
+        bare ha én aktiv deling om gangen.
+      </p>
+      <Link
+        className="mt-3 inline-flex text-sm font-medium text-emerald-700 hover:text-emerald-800"
+        to={`/families/${familyId}/meal-plans/reviews`}
+      >
+        Se det du skal gjennomgå
+      </Link>
+
+      <Form className="mt-4 space-y-4" method="post">
+        <input name="intent" type="hidden" value="share-meal-plan" />
+
+        <label className="block space-y-2">
+          <span className="text-sm font-medium text-slate-700">
+            Valgfri melding
+          </span>
+          <input
+            className="w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm"
+            name="message"
+            placeholder="F.eks. Sjekk middagene denne uken"
+            type="text"
+          />
+        </label>
+
+        <label className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+          <input className="h-4 w-4" name="wholeFamily" type="checkbox" />
+          <span className="text-sm text-slate-700">Del med hele familien</span>
+        </label>
+
+        {members.length > 0 ? (
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-slate-700">
+              Eller velg medlemmer
+            </legend>
+            <div className="grid gap-2">
+              {members.map((member) => (
+                <label
+                  key={member.id}
+                  className="flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3"
+                >
+                  <input
+                    className="h-4 w-4"
+                    name="recipientUserIds"
+                    type="checkbox"
+                    value={member.id}
+                  />
+                  <span className="text-sm text-slate-800">
+                    {member.displayName}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+        ) : (
+          <p className="text-sm text-slate-500">
+            Ingen andre familiemedlemmer å dele med enn deg.
+          </p>
+        )}
+
+        {actionData?.intent === "share-meal-plan" &&
+        actionData.shareFormError ? (
+          <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            {actionData.shareFormError}
+          </p>
+        ) : null}
+
+        <button
+          className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+          disabled={isSharingMealPlan || members.length === 0}
+          type="submit"
+        >
+          {isSharingMealPlan ? "Deler..." : "Del ukeplan"}
+        </button>
+      </Form>
+    </article>
+  );
+}
+
+function MealPlanFeedbackSection({
+  actionData,
+  isMarkingCommentAddressed,
+  shares,
+  unresolvedCount,
+  visibleDates,
+}: {
+  actionData?: MealPlanActionData;
+  isMarkingCommentAddressed: boolean;
+  shares: FeedbackShare[];
+  unresolvedCount: number;
+  visibleDates: string[];
+}) {
+  if (shares.length === 0) {
+    return (
+      <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
+        <h2 className="text-lg font-semibold text-slate-950">Tilbakemelding</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          Ingen aktiv deling ennå. Når noen svarer, vises tilbakemeldingene her
+          gruppert per dag.
+        </p>
+      </article>
+    );
+  }
+
+  const commentsByDate = new Map<
+    string,
+    Array<FeedbackShare["comments"][number] & { shareId: string }>
+  >();
+
+  for (const share of shares) {
+    for (const comment of share.comments) {
+      const existing = commentsByDate.get(comment.date) ?? [];
+
+      existing.push({ ...comment, shareId: share.id });
+      commentsByDate.set(comment.date, existing);
+    }
+  }
+
+  return (
+    <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
+      <div className="flex flex-wrap items-center gap-2">
+        <h2 className="text-lg font-semibold text-slate-950">Tilbakemelding</h2>
+        {unresolvedCount > 0 ? (
+          <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-900">
+            {unresolvedCount} ubehandlet
+          </span>
+        ) : null}
+      </div>
+
+      {shares.map((share) => (
+        <p key={share.id} className="mt-2 text-sm text-slate-600">
+          Delt av {share.sharedByDisplayName}
+          {share.wholeFamily ? " (hele familien)" : ""}
+          {share.message ? ` — «${share.message}»` : ""}
+        </p>
+      ))}
+
+      <div className="mt-4 space-y-3">
+        {visibleDates.map((date) => {
+          const comments = commentsByDate.get(date) ?? [];
+
+          if (comments.length === 0) {
+            return null;
+          }
+
+          return (
+            <div
+              key={date}
+              className="rounded-2xl border border-slate-200 bg-slate-50 p-4"
+            >
+              <h3 className="text-sm font-semibold text-slate-900">
+                {formatWeekdayLabel(date)}
+              </h3>
+              <ul className="mt-2 space-y-2">
+                {comments.map((comment) => (
+                  <li
+                    key={comment.id}
+                    className="rounded-2xl bg-white px-3 py-3 ring-1 ring-slate-200"
+                  >
+                    <p className="text-sm font-medium text-slate-900">
+                      {comment.authorDisplayName}
+                    </p>
+                    <p className="mt-1 text-sm text-slate-700">
+                      {comment.feedbackLabel}
+                    </p>
+                    {comment.addressedAt ? (
+                      <p className="mt-2 text-xs text-emerald-700">Behandlet</p>
+                    ) : (
+                      <Form className="mt-2" method="post">
+                        <input
+                          name="intent"
+                          type="hidden"
+                          value="mark-comment-addressed"
+                        />
+                        <input
+                          name="commentId"
+                          type="hidden"
+                          value={comment.id}
+                        />
+                        <button
+                          className="inline-flex min-h-10 items-center rounded-2xl bg-slate-950 px-4 py-2 text-xs font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                          disabled={isMarkingCommentAddressed}
+                          type="submit"
+                        >
+                          {isMarkingCommentAddressed &&
+                          actionData?.commentId === comment.id
+                            ? "Lagrer..."
+                            : "Merk som behandlet"}
+                        </button>
+                      </Form>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </article>
+  );
 }
 
 function MealPlanApprovalSection({

--- a/app/routes/family-meal-plans.test.ts
+++ b/app/routes/family-meal-plans.test.ts
@@ -19,7 +19,12 @@ vi.mock("../lib/meal-plan.server", () => {
   };
 });
 
+vi.mock("../lib/meal-plan-share.server", () => ({
+  countPendingReviewsForUser: vi.fn(),
+}));
+
 import { requireUser } from "../lib/auth.server";
+import { countPendingReviewsForUser } from "../lib/meal-plan-share.server";
 import { copyMealPlan, createMealPlan, deleteMealPlan, listMealPlansForFamily } from "../lib/meal-plan.server";
 import { action, loader } from "./family-meal-plans";
 
@@ -63,6 +68,7 @@ describe("family meal plans route", () => {
       ],
       userRole: "ADMIN",
     });
+    vi.mocked(countPendingReviewsForUser).mockResolvedValue(0);
 
     const result = await loader({
       params: {
@@ -93,6 +99,7 @@ describe("family meal plans route", () => {
         },
       ],
       notice: "meal-plan-created",
+      pendingReviewCount: 0,
     });
   });
 

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -1,6 +1,7 @@
 import { Form, Link, useNavigation, type MetaFunction } from "react-router";
 
 import { requireUser } from "../lib/auth.server";
+import { countPendingReviewsForUser } from "../lib/meal-plan-share.server";
 import {
   copyMealPlan,
   createMealPlan,
@@ -57,13 +58,20 @@ export async function loader({
 }) {
   const user = await requireUser(request);
   const familyId = requireFamilyId(params.familyId);
-  const result = await listMealPlansForFamily({
-    familyId,
-    userId: user.id,
-  });
+  const [result, pendingReviewCount] = await Promise.all([
+    listMealPlansForFamily({
+      familyId,
+      userId: user.id,
+    }),
+    countPendingReviewsForUser({
+      familyId,
+      userId: user.id,
+    }),
+  ]);
 
   return {
     family: result.family,
+    pendingReviewCount,
     mealPlans: result.mealPlans.map((mealPlan) => ({
       ...mealPlan,
       activeShoppingDate: mealPlan.activeShoppingDate
@@ -237,6 +245,25 @@ export default function FamilyMealPlansRoute({
           </section>
         ) : null}
 
+        {loaderData.pendingReviewCount > 0 ? (
+          <section className="rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm">
+            <h2 className="text-base font-semibold">
+              {loaderData.pendingReviewCount === 1
+                ? "1 ukeplan venter på deg"
+                : `${loaderData.pendingReviewCount} ukeplaner venter på deg`}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-amber-900">
+              Gi tilbakemelding på delte ukeplaner før de godkjennes.
+            </p>
+            <Link
+              className="mt-4 inline-flex rounded-2xl bg-amber-900 px-5 py-3 text-sm font-medium text-white transition hover:bg-amber-950"
+              to={`/families/${loaderData.family.id}/meal-plans/reviews`}
+            >
+              Åpne gjennomgang
+            </Link>
+          </section>
+        ) : null}
+
         <section className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <div className="flex flex-col gap-2">
@@ -391,7 +418,13 @@ export default function FamilyMealPlansRoute({
                             <h3 className="text-base font-semibold text-slate-950">
                               {mealPlan.title}
                             </h3>
-                            <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
+                            <span
+                              className={
+                                mealPlan.status === "APPROVED"
+                                  ? "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-emerald-800 ring-1 ring-emerald-200"
+                                  : "rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200"
+                              }
+                            >
                               {mealPlan.status === "APPROVED"
                                 ? "Godkjent"
                                 : "Utkast"}

--- a/prisma/migrations/20260522085615_add_meal_plan_share_review/migration.sql
+++ b/prisma/migrations/20260522085615_add_meal_plan_share_review/migration.sql
@@ -1,0 +1,99 @@
+-- CreateEnum
+CREATE TYPE "MealPlanShareStatus" AS ENUM ('OPEN', 'CLOSED');
+
+-- CreateEnum
+CREATE TYPE "MealPlanShareRecipientStatus" AS ENUM ('PENDING', 'VIEWED', 'RESPONDED');
+
+-- CreateEnum
+CREATE TYPE "MealPlanReviewQuickResponse" AS ENUM ('RECENTLY_HAD', 'FISH_AGAIN', 'YES');
+
+-- CreateTable
+CREATE TABLE "MealPlanShare" (
+    "id" TEXT NOT NULL,
+    "mealPlanId" TEXT NOT NULL,
+    "sharedByUserId" TEXT NOT NULL,
+    "message" TEXT,
+    "status" "MealPlanShareStatus" NOT NULL DEFAULT 'OPEN',
+    "wholeFamily" BOOLEAN NOT NULL DEFAULT false,
+    "closedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MealPlanShare_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MealPlanShareRecipient" (
+    "id" TEXT NOT NULL,
+    "shareId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" "MealPlanShareRecipientStatus" NOT NULL DEFAULT 'PENDING',
+    "viewedAt" TIMESTAMP(3),
+    "respondedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MealPlanShareRecipient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MealPlanReviewComment" (
+    "id" TEXT NOT NULL,
+    "shareId" TEXT NOT NULL,
+    "mealPlanId" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "authorUserId" TEXT NOT NULL,
+    "quickResponse" "MealPlanReviewQuickResponse",
+    "body" TEXT,
+    "addressedAt" TIMESTAMP(3),
+    "addressedByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MealPlanReviewComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MealPlanShare_mealPlanId_status_idx" ON "MealPlanShare"("mealPlanId", "status");
+
+-- CreateIndex
+CREATE INDEX "MealPlanShare_sharedByUserId_idx" ON "MealPlanShare"("sharedByUserId");
+
+-- CreateIndex
+CREATE INDEX "MealPlanShareRecipient_userId_status_idx" ON "MealPlanShareRecipient"("userId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MealPlanShareRecipient_shareId_userId_key" ON "MealPlanShareRecipient"("shareId", "userId");
+
+-- CreateIndex
+CREATE INDEX "MealPlanReviewComment_mealPlanId_date_idx" ON "MealPlanReviewComment"("mealPlanId", "date");
+
+-- CreateIndex
+CREATE INDEX "MealPlanReviewComment_shareId_idx" ON "MealPlanReviewComment"("shareId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MealPlanReviewComment_shareId_authorUserId_date_key" ON "MealPlanReviewComment"("shareId", "authorUserId", "date");
+
+-- AddForeignKey
+ALTER TABLE "MealPlanShare" ADD CONSTRAINT "MealPlanShare_mealPlanId_fkey" FOREIGN KEY ("mealPlanId") REFERENCES "MealPlan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPlanShare" ADD CONSTRAINT "MealPlanShare_sharedByUserId_fkey" FOREIGN KEY ("sharedByUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPlanShareRecipient" ADD CONSTRAINT "MealPlanShareRecipient_shareId_fkey" FOREIGN KEY ("shareId") REFERENCES "MealPlanShare"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPlanShareRecipient" ADD CONSTRAINT "MealPlanShareRecipient_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPlanReviewComment" ADD CONSTRAINT "MealPlanReviewComment_shareId_fkey" FOREIGN KEY ("shareId") REFERENCES "MealPlanShare"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPlanReviewComment" ADD CONSTRAINT "MealPlanReviewComment_mealPlanId_fkey" FOREIGN KEY ("mealPlanId") REFERENCES "MealPlan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPlanReviewComment" ADD CONSTRAINT "MealPlanReviewComment_authorUserId_fkey" FOREIGN KEY ("authorUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MealPlanReviewComment" ADD CONSTRAINT "MealPlanReviewComment_addressedByUserId_fkey" FOREIGN KEY ("addressedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,23 @@ enum MealPlanStatus {
   APPROVED
 }
 
+enum MealPlanShareStatus {
+  OPEN
+  CLOSED
+}
+
+enum MealPlanShareRecipientStatus {
+  PENDING
+  VIEWED
+  RESPONDED
+}
+
+enum MealPlanReviewQuickResponse {
+  RECENTLY_HAD
+  FISH_AGAIN
+  YES
+}
+
 enum MealType {
   BREAKFAST
   LUNCH
@@ -52,6 +69,10 @@ model User {
   updatedManualShoppingItems   ManualShoppingItem[]   @relation("ManualShoppingItemUpdatedBy")
   updatedShoppingItemOverrides ShoppingItemOverride[] @relation("ShoppingItemOverrideUpdatedBy")
   storePreferences             UserStorePreference[]
+  sharedMealPlans              MealPlanShare[]        @relation("MealPlanShareSharedBy")
+  mealPlanShareRecipients      MealPlanShareRecipient[]
+  mealPlanReviewComments       MealPlanReviewComment[] @relation("MealPlanReviewCommentAuthor")
+  addressedMealPlanReviewComments MealPlanReviewComment[] @relation("MealPlanReviewCommentAddressedBy")
 
   @@index([displayName])
 }
@@ -209,6 +230,8 @@ model MealPlan {
   entries              MealPlanEntry[]
   manualShoppingItems  ManualShoppingItem[]
   shoppingOverrides    ShoppingItemOverride[]
+  shares               MealPlanShare[]
+  reviewComments       MealPlanReviewComment[]
 
   @@index([familyId, startDate, endDate])
   @@index([approvedByUserId])
@@ -236,6 +259,63 @@ model MealPlanEntry {
   @@index([updatedByUserId])
   @@index([mealPlanId, date])
   @@index([recipeId])
+}
+
+model MealPlanShare {
+  id             String               @id @default(cuid())
+  mealPlanId     String
+  sharedByUserId String
+  message        String?
+  status         MealPlanShareStatus  @default(OPEN)
+  wholeFamily    Boolean              @default(false)
+  closedAt       DateTime?
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
+  mealPlan       MealPlan             @relation(fields: [mealPlanId], references: [id], onDelete: Cascade)
+  sharedByUser   User                 @relation("MealPlanShareSharedBy", fields: [sharedByUserId], references: [id], onDelete: Cascade)
+  recipients     MealPlanShareRecipient[]
+  comments       MealPlanReviewComment[]
+
+  @@index([mealPlanId, status])
+  @@index([sharedByUserId])
+}
+
+model MealPlanShareRecipient {
+  id          String                     @id @default(cuid())
+  shareId     String
+  userId      String
+  status      MealPlanShareRecipientStatus @default(PENDING)
+  viewedAt    DateTime?
+  respondedAt DateTime?
+  createdAt   DateTime                   @default(now())
+  updatedAt   DateTime                   @updatedAt
+  share       MealPlanShare              @relation(fields: [shareId], references: [id], onDelete: Cascade)
+  user        User                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([shareId, userId])
+  @@index([userId, status])
+}
+
+model MealPlanReviewComment {
+  id                String                      @id @default(cuid())
+  shareId           String
+  mealPlanId        String
+  date              DateTime                    @db.Date
+  authorUserId      String
+  quickResponse     MealPlanReviewQuickResponse?
+  body              String?
+  addressedAt       DateTime?
+  addressedByUserId String?
+  createdAt         DateTime                    @default(now())
+  updatedAt         DateTime                    @updatedAt
+  share             MealPlanShare               @relation(fields: [shareId], references: [id], onDelete: Cascade)
+  mealPlan          MealPlan                    @relation(fields: [mealPlanId], references: [id], onDelete: Cascade)
+  authorUser        User                        @relation("MealPlanReviewCommentAuthor", fields: [authorUserId], references: [id], onDelete: Cascade)
+  addressedByUser   User?                       @relation("MealPlanReviewCommentAddressedBy", fields: [addressedByUserId], references: [id], onDelete: SetNull)
+
+  @@unique([shareId, authorUserId, date])
+  @@index([mealPlanId, date])
+  @@index([shareId])
 }
 
 model ManualShoppingItem {


### PR DESCRIPTION
## Summary
- Adds a dedicated share-for-review flow: planners share draft meal plans to specific members or the whole family (one open share per plan).
- Reviewers get a mobile-first per-day view with quick-response chips, optional notes, and can approve without commenting.
- Planners see feedback in the editor and a “Gjennomgang” inbox with nav badge; approving the plan closes open shares.

## Related issue
Closes #70

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Share draft plan to whole family; verify reviewer inbox and per-day chips
- [ ] Approve from review without comments; confirm redirect and no Forbidden
- [ ] Confirm second share blocked while one is open
- [ ] Run migration on deploy: `npx prisma migrate deploy`

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck