### PR TITLE
Compact mobile layout for meal plan shopping list rows

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,34 @@
 
 ## Current Objective
 
-Issue #70 — share meal plan for family review shipped on branch `issue/70-share-meal-plan-review`; PR ready for review.
+Issue #72 — compact mobile shopping list shipped on branch `issue/72-compact-shopping-mobile`; PR opened.
 
 ## Completed
 
-- Added Prisma models and migration for meal plan shares, recipients, and per-day review comments with quick-response presets.
-- Implemented `meal-plan-share.server.ts`: share creation (one open share per plan), mobile review flow, approve-from-review, feedback inbox.
-- Added review routes (`family-meal-plan-reviews`, `family-meal-plan-review`) with one-tap chips (Dette hadde vi for litt siden / Fisk igjen...? / Ja!).
-- Integrated share + feedback panels on meal plan editor; nav badge for pending reviews.
-- Fixed post-approve redirect (no Forbidden), single-share guard, emerald Godkjent badge on meal plans list.
+- Added `formatCompactShoppingSourceLine` in `app/lib/shopping-display.ts` with unit tests.
+- Extracted `ShoppingListItemExpanded` component with shared date input styling.
+- Refactored shopping list item cards: compact header + source on mobile, `<details>` for actions; desktop layout unchanged at `xl+`.
+- Auto-open details when update returns field errors for that row.
+- Fixed date input overflow on narrow viewports.
 
 ## Files To Read First
 
-- `app/lib/meal-plan-share.server.ts` — share/review/approve domain logic
-- `app/routes/family-meal-plan-review.tsx` — mobile-first reviewer UI
-- `app/routes/family-meal-plan.tsx` — planner share + feedback panels
+- `app/routes/family-meal-plan-shopping.tsx` — mobile/desktop item card structure
+- `app/components/shopping-list-item-expanded.tsx` — forms and Kilder panel
+- `app/lib/shopping-display.ts` — compact source line formatter
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 201 tests passed (38 files)
+- `npm run test:run` — 204 tests passed (38 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Run migration on deploy: `npx prisma migrate deploy`.
-- Manual smoke: share whole family, review on mobile width, approve without comments, verify no second share while open.
+- Manual smoke on 320px / 390px / 1280px+ before merge if not done in review.
 
 ## Next Step
 
-Merge PR when CI is green.
+Merge PR when CI is green; closes #72.

--- a/app/components/shopping-list-item-expanded.tsx
+++ b/app/components/shopping-list-item-expanded.tsx
@@ -1,0 +1,394 @@
+import { Form } from "react-router";
+
+import { formatOccurrenceSourceLine } from "../lib/shopping-display";
+import type {
+  GeneratedShoppingItemOverrideFieldErrors,
+  GeneratedShoppingItemOverrideValues,
+  ManualShoppingItemFieldErrors,
+  ManualShoppingItemValues,
+} from "../lib/shopping-write.server";
+
+export const shoppingDateInputClassName =
+  "mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100";
+
+type ShoppingListItemExpandedProps = {
+  actionData?: {
+    generatedOverrideFieldErrors?: GeneratedShoppingItemOverrideFieldErrors;
+    intent?: string;
+    itemTarget?: { sourceKey: string };
+    manualFieldErrors?: ManualShoppingItemFieldErrors;
+  };
+  categories: Array<{ displayName: string; id: string }>;
+  isPendingCheckToggle: boolean;
+  isPendingGeneratedExclude: boolean;
+  isPendingGeneratedSave: boolean;
+  isPendingManualDelete: boolean;
+  isPendingManualSave: boolean;
+  item: {
+    buyOnDate?: string | null;
+    checked: boolean;
+    collaborationVersion: string;
+    name: string;
+    note: string | null;
+    occurrences?: Array<{
+      date: string;
+      mealPlanEntryId: string;
+      quantityLabel: string | null;
+      recipeIngredientId: string;
+      recipeTitle: string;
+    }>;
+    sourceKey: string;
+    sourceType: "GENERATED" | "MANUAL";
+  };
+  manualValues: ManualShoppingItemValues | null;
+  mealPlanEndDate: string;
+  mealPlanStartDate: string;
+  overrideValues: GeneratedShoppingItemOverrideValues | null;
+  stores: Array<{ id: string; name: string }>;
+  toggleExpectedVersion: string;
+};
+
+export function ShoppingListItemExpanded({
+  actionData,
+  categories,
+  isPendingCheckToggle,
+  isPendingGeneratedExclude,
+  isPendingGeneratedSave,
+  isPendingManualDelete,
+  isPendingManualSave,
+  item,
+  manualValues,
+  mealPlanEndDate,
+  mealPlanStartDate,
+  overrideValues,
+  stores,
+  toggleExpectedVersion,
+}: ShoppingListItemExpandedProps) {
+  return (
+    <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+      <div className="min-w-0 rounded-[20px] bg-white p-4 ring-1 ring-slate-200">
+        {item.sourceType === "GENERATED" ? (
+          <>
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+              Kilder
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
+              {(item.occurrences ?? []).map((occurrence) => (
+                <li
+                  key={`${occurrence.mealPlanEntryId}:${occurrence.recipeIngredientId}`}
+                >
+                  {formatOccurrenceSourceLine(occurrence)}
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <>
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+              Manuell rad
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-700">
+              Denne varelinjen kommer ikke fra en oppskrift og kan redigeres
+              eller slettes direkte her.
+            </p>
+          </>
+        )}
+      </div>
+
+      <div className="grid min-w-0 gap-3">
+        <Form method="post">
+          <input
+            name="intent"
+            type="hidden"
+            value="toggle-shopping-item-checked"
+          />
+          <input name="sourceKey" type="hidden" value={item.sourceKey} />
+          <input name="sourceType" type="hidden" value={item.sourceType} />
+          <input
+            name="checked"
+            type="hidden"
+            value={item.checked ? "false" : "true"}
+          />
+          <input
+            name="expectedUpdatedAt"
+            type="hidden"
+            value={toggleExpectedVersion}
+          />
+          <button
+            className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+            disabled={isPendingCheckToggle}
+            type="submit"
+          >
+            {isPendingCheckToggle
+              ? item.checked
+                ? "Oppdaterer..."
+                : "Krysser av..."
+              : item.checked
+                ? "Fjern avkryssing"
+                : "Marker som kjøpt"}
+          </button>
+        </Form>
+
+        {item.sourceType === "GENERATED" && overrideValues ? (
+          <Form className="grid min-w-0 gap-3" method="post">
+            <input
+              name="intent"
+              type="hidden"
+              value="update-generated-shopping-item"
+            />
+            <input name="sourceKey" type="hidden" value={item.sourceKey} />
+            <input
+              name="expectedUpdatedAt"
+              type="hidden"
+              value={item.collaborationVersion}
+            />
+
+            <label className="block min-w-0 text-sm font-medium text-slate-700">
+              Foretrukket butikk
+              <select
+                className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={overrideValues.preferredStoreId}
+                name="preferredStoreId"
+              >
+                <option value="">Ingen valgt butikk</option>
+                {stores.map((store) => (
+                  <option key={store.id} value={store.id}>
+                    {store.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block min-w-0 text-sm font-medium text-slate-700">
+              Utsatt til
+              <input
+                className={shoppingDateInputClassName}
+                defaultValue={overrideValues.postponedUntilDate}
+                max={mealPlanEndDate}
+                min={mealPlanStartDate}
+                name="postponedUntilDate"
+                type="date"
+              />
+            </label>
+
+            <label className="block min-w-0 text-sm font-medium text-slate-700">
+              Notat
+              <textarea
+                className="mt-2 box-border min-h-24 w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={overrideValues.note}
+                name="note"
+              />
+            </label>
+
+            {actionData?.intent === "update-generated-shopping-item" &&
+            actionData.itemTarget?.sourceKey === item.sourceKey &&
+            actionData.generatedOverrideFieldErrors?.preferredStoreId ? (
+              <p className="text-sm text-rose-600">
+                {actionData.generatedOverrideFieldErrors.preferredStoreId}
+              </p>
+            ) : null}
+            {actionData?.intent === "update-generated-shopping-item" &&
+            actionData.itemTarget?.sourceKey === item.sourceKey &&
+            actionData.generatedOverrideFieldErrors?.postponedUntilDate ? (
+              <p className="text-sm text-rose-600">
+                {actionData.generatedOverrideFieldErrors.postponedUntilDate}
+              </p>
+            ) : null}
+
+            <button
+              className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+              disabled={isPendingGeneratedSave || isPendingGeneratedExclude}
+              type="submit"
+            >
+              {isPendingGeneratedSave
+                ? "Lagrer tilpasninger..."
+                : "Lagre tilpasninger"}
+            </button>
+          </Form>
+        ) : null}
+
+        {item.sourceType === "GENERATED" ? (
+          <Form method="post">
+            <input
+              name="intent"
+              type="hidden"
+              value="exclude-generated-shopping-item"
+            />
+            <input name="sourceKey" type="hidden" value={item.sourceKey} />
+            <input
+              name="expectedUpdatedAt"
+              type="hidden"
+              value={item.collaborationVersion}
+            />
+            <button
+              className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
+              disabled={isPendingGeneratedExclude || isPendingGeneratedSave}
+              type="submit"
+            >
+              {isPendingGeneratedExclude
+                ? "Fjerner varelinje..."
+                : "Fjern fra handlelisten"}
+            </button>
+          </Form>
+        ) : null}
+
+        {item.sourceType === "MANUAL" && manualValues ? (
+          <>
+            <Form className="grid min-w-0 gap-3" method="post">
+              <input
+                name="intent"
+                type="hidden"
+                value="update-manual-shopping-item"
+              />
+              <input name="manualItemId" type="hidden" value={item.sourceKey} />
+              <input
+                name="expectedUpdatedAt"
+                type="hidden"
+                value={item.collaborationVersion}
+              />
+
+              <label className="block min-w-0 text-sm font-medium text-slate-700">
+                Varenavn
+                <input
+                  className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={manualValues.name}
+                  name="name"
+                  type="text"
+                />
+              </label>
+
+              <div className="grid min-w-0 gap-3 sm:grid-cols-2">
+                <label className="block min-w-0 text-sm font-medium text-slate-700">
+                  Mengde
+                  <input
+                    className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={manualValues.quantity}
+                    name="quantity"
+                    type="text"
+                  />
+                </label>
+
+                <label className="block min-w-0 text-sm font-medium text-slate-700">
+                  Handledato
+                  <input
+                    className={shoppingDateInputClassName}
+                    defaultValue={manualValues.buyOnDate}
+                    max={mealPlanEndDate}
+                    min={mealPlanStartDate}
+                    name="buyOnDate"
+                    type="date"
+                  />
+                </label>
+              </div>
+
+              <div className="grid min-w-0 gap-3 sm:grid-cols-2">
+                <label className="block min-w-0 text-sm font-medium text-slate-700">
+                  Kategori
+                  <select
+                    className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={manualValues.categoryId}
+                    name="categoryId"
+                  >
+                    <option value="">Velg kategori</option>
+                    {categories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block min-w-0 text-sm font-medium text-slate-700">
+                  Foretrukket butikk
+                  <select
+                    className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={manualValues.preferredStoreId}
+                    name="preferredStoreId"
+                  >
+                    <option value="">Ingen valgt butikk</option>
+                    {stores.map((store) => (
+                      <option key={store.id} value={store.id}>
+                        {store.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <label className="block min-w-0 text-sm font-medium text-slate-700">
+                Notat
+                <textarea
+                  className="mt-2 box-border min-h-24 w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={manualValues.note}
+                  name="note"
+                />
+              </label>
+
+              {actionData?.intent === "update-manual-shopping-item" &&
+              actionData.itemTarget?.sourceKey === item.sourceKey &&
+              actionData.manualFieldErrors?.name ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.name}
+                </p>
+              ) : null}
+              {actionData?.intent === "update-manual-shopping-item" &&
+              actionData.itemTarget?.sourceKey === item.sourceKey &&
+              actionData.manualFieldErrors?.categoryId ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.categoryId}
+                </p>
+              ) : null}
+              {actionData?.intent === "update-manual-shopping-item" &&
+              actionData.itemTarget?.sourceKey === item.sourceKey &&
+              actionData.manualFieldErrors?.preferredStoreId ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.preferredStoreId}
+                </p>
+              ) : null}
+              {actionData?.intent === "update-manual-shopping-item" &&
+              actionData.itemTarget?.sourceKey === item.sourceKey &&
+              actionData.manualFieldErrors?.buyOnDate ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.manualFieldErrors.buyOnDate}
+                </p>
+              ) : null}
+
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+                disabled={isPendingManualSave}
+                type="submit"
+              >
+                {isPendingManualSave
+                  ? "Lagrer varelinje..."
+                  : "Lagre varelinje"}
+              </button>
+            </Form>
+
+            <Form method="post">
+              <input
+                name="intent"
+                type="hidden"
+                value="delete-manual-shopping-item"
+              />
+              <input name="manualItemId" type="hidden" value={item.sourceKey} />
+              <input
+                name="expectedUpdatedAt"
+                type="hidden"
+                value={item.collaborationVersion}
+              />
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
+                disabled={isPendingManualDelete}
+                type="submit"
+              >
+                {isPendingManualDelete
+                  ? "Sletter varelinje..."
+                  : "Slett varelinje"}
+              </button>
+            </Form>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/lib/shopping-display.test.ts
+++ b/app/lib/shopping-display.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { formatGeneratedOccurrenceAttribution } from "./shopping-display";
+import {
+  formatCompactShoppingSourceLine,
+  formatGeneratedOccurrenceAttribution,
+} from "./shopping-display";
 
 describe("shopping-display", () => {
   it("lists every planned occurrence including repeated recipes on different days", () => {
@@ -19,5 +22,46 @@ describe("shopping-display", () => {
         { date: "2026-05-12", recipeTitle: "Salat" },
       ]),
     ).toBe("Taco mandag 11. mai og Salat tirsdag 12. mai");
+  });
+
+  it("formats a single generated occurrence compactly", () => {
+    expect(
+      formatCompactShoppingSourceLine({
+        occurrenceCount: 1,
+        occurrences: [{ date: "2026-05-11", recipeTitle: "Lasagne" }],
+        sourceType: "GENERATED",
+      }),
+    ).toBe("Fra Lasagne");
+  });
+
+  it("formats multiple generated occurrences compactly", () => {
+    expect(
+      formatCompactShoppingSourceLine({
+        occurrenceCount: 2,
+        occurrences: [
+          { date: "2026-05-11", recipeTitle: "Taco" },
+          { date: "2026-05-12", recipeTitle: "Salat" },
+        ],
+        sourceType: "GENERATED",
+      }),
+    ).toBe("Brukt i Taco mandag 11. mai og Salat tirsdag 12. mai");
+  });
+
+  it("formats manual items with and without buy dates", () => {
+    expect(
+      formatCompactShoppingSourceLine({
+        buyOnDate: "2026-05-11",
+        occurrences: [],
+        sourceType: "MANUAL",
+      }),
+    ).toBe("Manuell · Kjøpes 11. mai");
+
+    expect(
+      formatCompactShoppingSourceLine({
+        buyOnDate: null,
+        occurrences: [],
+        sourceType: "MANUAL",
+      }),
+    ).toBe("Manuell");
   });
 });

--- a/app/lib/shopping-display.ts
+++ b/app/lib/shopping-display.ts
@@ -85,6 +85,41 @@ export function formatOccurrenceSourceLine(occurrence: {
     : base;
 }
 
+export function formatCompactShoppingSourceLine(item: {
+  buyOnDate?: string | null;
+  occurrenceCount?: number;
+  occurrences?: Array<{ date: string; recipeTitle: string }>;
+  sourceType: string;
+}) {
+  if (item.sourceType === "GENERATED") {
+    const occurrences = item.occurrences ?? [];
+
+    if (item.occurrenceCount === 1) {
+      const recipeTitle = occurrences[0]?.recipeTitle;
+      return recipeTitle ? `Fra ${recipeTitle}` : null;
+    }
+
+    const occurrenceAttribution =
+      formatGeneratedOccurrenceAttribution(occurrences);
+
+    return occurrenceAttribution ? `Brukt i ${occurrenceAttribution}` : null;
+  }
+
+  if (item.buyOnDate) {
+    return `Manuell · Kjøpes ${formatCompactDateLabel(item.buyOnDate)}`;
+  }
+
+  return "Manuell";
+}
+
+function formatCompactDateLabel(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00.000Z`));
+}
+
 function formatDateLabelInSummary(value: string) {
   return new Intl.DateTimeFormat("nb-NO", {
     weekday: "long",

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -9,11 +9,15 @@ import {
 
 import { requireUser } from "../lib/auth.server";
 import {
+  formatCompactShoppingSourceLine,
   formatGeneratedItemSummary,
   formatGeneratedQuantityBadge,
-  formatOccurrenceSourceLine,
 } from "../lib/shopping-display";
 import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
+import {
+  ShoppingListItemExpanded,
+  shoppingDateInputClassName,
+} from "../components/shopping-list-item-expanded";
 import {
   getMealPlanShoppingData,
   listRecentManualShoppingItemsForFamily,
@@ -907,8 +911,8 @@ export default function FamilyMealPlanShoppingRoute({
                   </p>
                 ) : null}
 
-                <div className="grid gap-4 sm:grid-cols-3">
-                  <label className="block text-sm font-medium text-slate-700">
+                <div className="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-3">
+                  <label className="block min-w-0 text-sm font-medium text-slate-700">
                     Kategori
                     <select
                       className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
@@ -924,10 +928,10 @@ export default function FamilyMealPlanShoppingRoute({
                     </select>
                   </label>
 
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label className="block min-w-0 text-sm font-medium text-slate-700">
                     Foretrukket butikk
                     <select
-                      className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                      className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
                       defaultValue={addManualValues.preferredStoreId}
                       name="preferredStoreId"
                     >
@@ -940,10 +944,10 @@ export default function FamilyMealPlanShoppingRoute({
                     </select>
                   </label>
 
-                  <label className="block text-sm font-medium text-slate-700">
+                  <label className="block min-w-0 text-sm font-medium text-slate-700">
                     Handledato
                     <input
-                      className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                      className={shoppingDateInputClassName}
                       defaultValue={addManualValues.buyOnDate}
                       max={loaderData.mealPlan.endDate}
                       min={loaderData.mealPlan.startDate}
@@ -1027,7 +1031,7 @@ export default function FamilyMealPlanShoppingRoute({
                         {section.displayName}
                       </h3>
 
-                      <div className="mt-3 grid gap-3">
+                      <div className="mt-3 grid gap-2 xl:gap-3">
                         {section.items.map((item) => {
                           const isPendingCheckToggle =
                             navigation.state === "submitting" &&
@@ -1087,11 +1091,35 @@ export default function FamilyMealPlanShoppingRoute({
                                 : null;
                           const quantityBadge =
                             formatGeneratedQuantityBadge(item);
+                          const compactSourceLine =
+                            formatCompactShoppingSourceLine(item);
+                          const shouldAutoOpenDetails =
+                            shouldAutoOpenShoppingItemDetails(
+                              actionData,
+                              item.sourceKey,
+                            );
+                          const expandedProps = {
+                            actionData,
+                            categories: loaderData.categories,
+                            isPendingCheckToggle,
+                            isPendingGeneratedExclude,
+                            isPendingGeneratedSave,
+                            isPendingManualDelete,
+                            isPendingManualSave,
+                            item,
+                            manualValues,
+                            mealPlanEndDate: loaderData.mealPlan.endDate,
+                            mealPlanStartDate: loaderData.mealPlan.startDate,
+                            overrideValues,
+                            stores: loaderData.stores,
+                            toggleExpectedVersion:
+                              getToggleExpectedVersion(item),
+                          };
 
                           return (
                             <article
                               key={item.sourceKey}
-                              className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                              className="min-w-0 max-w-full overflow-hidden rounded-[24px] border border-slate-200 bg-slate-50 p-3 xl:p-5"
                             >
                               <div className="flex flex-wrap items-center gap-2">
                                 <h4 className="text-base font-semibold text-slate-950">
@@ -1139,449 +1167,64 @@ export default function FamilyMealPlanShoppingRoute({
                                     Kjøpes {formatDateLabel(item.buyOnDate)}
                                   </span>
                                 ) : null}
+                                {item.note ? (
+                                  <span className="rounded-full bg-slate-200 px-3 py-1 text-xs font-medium text-slate-700">
+                                    Har notat
+                                  </span>
+                                ) : null}
                               </div>
 
-                              <p className="mt-3 text-sm leading-6 text-slate-600">
-                                {item.sourceType === "GENERATED"
-                                  ? formatGeneratedItemSummary(item)
-                                  : item.buyOnDate
-                                    ? `Lagt til manuelt og planlagt for ${formatDateLabel(item.buyOnDate)}.`
-                                    : "Lagt til manuelt uten spesifikk handledato."}
-                              </p>
-                              {item.note ? (
-                                <p className="mt-2 text-sm leading-6 text-slate-700">
-                                  Notat: {item.note}
+                              {compactSourceLine ? (
+                                <p className="mt-1 line-clamp-2 text-sm leading-5 text-slate-600 xl:hidden">
+                                  {compactSourceLine}
                                 </p>
                               ) : null}
 
-                              <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-                                <div className="rounded-[20px] bg-white p-4 ring-1 ring-slate-200">
-                                  {item.sourceType === "GENERATED" ? (
-                                    <>
-                                      <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
-                                        Kilder
-                                      </p>
-                                      <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
-                                        {item.occurrences.map((occurrence) => (
-                                          <li
-                                            key={`${occurrence.mealPlanEntryId}:${occurrence.recipeIngredientId}`}
-                                          >
-                                            {formatOccurrenceSourceLine(
-                                              occurrence,
-                                            )}
-                                          </li>
-                                        ))}
-                                      </ul>
-                                    </>
-                                  ) : (
-                                    <>
-                                      <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
-                                        Manuell rad
-                                      </p>
-                                      <p className="mt-3 text-sm leading-6 text-slate-700">
-                                        Denne varelinjen kommer ikke fra en
-                                        oppskrift og kan redigeres eller slettes
-                                        direkte her.
-                                      </p>
-                                    </>
-                                  )}
+                              <details
+                                className="group mt-2 min-w-0 xl:hidden"
+                                open={shouldAutoOpenDetails}
+                              >
+                                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-emerald-500 [&::-webkit-details-marker]:hidden">
+                                  <span>Detaljer</span>
+                                  <span className="text-xs text-slate-400 group-open:hidden">
+                                    Åpne
+                                  </span>
+                                  <span className="hidden text-xs text-slate-400 group-open:inline">
+                                    Lukk
+                                  </span>
+                                </summary>
+                                <div className="mt-3 min-w-0 space-y-3 border-t border-slate-200 pt-3">
+                                  <p className="text-sm leading-6 text-slate-600">
+                                    {item.sourceType === "GENERATED"
+                                      ? formatGeneratedItemSummary(item)
+                                      : item.buyOnDate
+                                        ? `Lagt til manuelt og planlagt for ${formatDateLabel(item.buyOnDate)}.`
+                                        : "Lagt til manuelt uten spesifikk handledato."}
+                                  </p>
+                                  {item.note ? (
+                                    <p className="text-sm leading-6 text-slate-700">
+                                      Notat: {item.note}
+                                    </p>
+                                  ) : null}
+                                  <ShoppingListItemExpanded {...expandedProps} />
                                 </div>
+                              </details>
 
-                                <div className="grid gap-3">
-                                  <Form method="post">
-                                    <input
-                                      name="intent"
-                                      type="hidden"
-                                      value="toggle-shopping-item-checked"
-                                    />
-                                    <input
-                                      name="sourceKey"
-                                      type="hidden"
-                                      value={item.sourceKey}
-                                    />
-                                    <input
-                                      name="sourceType"
-                                      type="hidden"
-                                      value={item.sourceType}
-                                    />
-                                    <input
-                                      name="checked"
-                                      type="hidden"
-                                      value={item.checked ? "false" : "true"}
-                                    />
-                                    <input
-                                      name="expectedUpdatedAt"
-                                      type="hidden"
-                                      value={getToggleExpectedVersion(item)}
-                                    />
-                                    <button
-                                      className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                                      disabled={isPendingCheckToggle}
-                                      type="submit"
-                                    >
-                                      {isPendingCheckToggle
-                                        ? item.checked
-                                          ? "Oppdaterer..."
-                                          : "Krysser av..."
-                                        : item.checked
-                                          ? "Fjern avkryssing"
-                                          : "Marker som kjøpt"}
-                                    </button>
-                                  </Form>
-
-                                  {item.sourceType === "GENERATED" &&
-                                  overrideValues ? (
-                                    <Form className="grid gap-3" method="post">
-                                      <input
-                                        name="intent"
-                                        type="hidden"
-                                        value="update-generated-shopping-item"
-                                      />
-                                      <input
-                                        name="sourceKey"
-                                        type="hidden"
-                                        value={item.sourceKey}
-                                      />
-                                      <input
-                                        name="expectedUpdatedAt"
-                                        type="hidden"
-                                        value={item.collaborationVersion}
-                                      />
-
-                                      <label className="block text-sm font-medium text-slate-700">
-                                        Foretrukket butikk
-                                        <select
-                                          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                          defaultValue={
-                                            overrideValues.preferredStoreId
-                                          }
-                                          name="preferredStoreId"
-                                        >
-                                          <option value="">
-                                            Ingen valgt butikk
-                                          </option>
-                                          {loaderData.stores.map((store) => (
-                                            <option
-                                              key={store.id}
-                                              value={store.id}
-                                            >
-                                              {store.name}
-                                            </option>
-                                          ))}
-                                        </select>
-                                      </label>
-
-                                      <label className="block text-sm font-medium text-slate-700">
-                                        Utsatt til
-                                        <input
-                                          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                          defaultValue={
-                                            overrideValues.postponedUntilDate
-                                          }
-                                          max={loaderData.mealPlan.endDate}
-                                          min={loaderData.mealPlan.startDate}
-                                          name="postponedUntilDate"
-                                          type="date"
-                                        />
-                                      </label>
-
-                                      <label className="block text-sm font-medium text-slate-700">
-                                        Notat
-                                        <textarea
-                                          className="mt-2 min-h-24 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                          defaultValue={overrideValues.note}
-                                          name="note"
-                                        />
-                                      </label>
-
-                                      {actionData?.intent ===
-                                        "update-generated-shopping-item" &&
-                                      actionData.itemTarget?.sourceKey ===
-                                        item.sourceKey &&
-                                      actionData.generatedOverrideFieldErrors
-                                        ?.preferredStoreId ? (
-                                        <p className="text-sm text-rose-600">
-                                          {
-                                            actionData
-                                              .generatedOverrideFieldErrors
-                                              .preferredStoreId
-                                          }
-                                        </p>
-                                      ) : null}
-                                      {actionData?.intent ===
-                                        "update-generated-shopping-item" &&
-                                      actionData.itemTarget?.sourceKey ===
-                                        item.sourceKey &&
-                                      actionData.generatedOverrideFieldErrors
-                                        ?.postponedUntilDate ? (
-                                        <p className="text-sm text-rose-600">
-                                          {
-                                            actionData
-                                              .generatedOverrideFieldErrors
-                                              .postponedUntilDate
-                                          }
-                                        </p>
-                                      ) : null}
-
-                                      <button
-                                        className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
-                                        disabled={
-                                          isPendingGeneratedSave ||
-                                          isPendingGeneratedExclude
-                                        }
-                                        type="submit"
-                                      >
-                                        {isPendingGeneratedSave
-                                          ? "Lagrer tilpasninger..."
-                                          : "Lagre tilpasninger"}
-                                      </button>
-                                    </Form>
-                                  ) : null}
-
-                                  {item.sourceType === "GENERATED" ? (
-                                    <Form method="post">
-                                      <input
-                                        name="intent"
-                                        type="hidden"
-                                        value="exclude-generated-shopping-item"
-                                      />
-                                      <input
-                                        name="sourceKey"
-                                        type="hidden"
-                                        value={item.sourceKey}
-                                      />
-                                      <input
-                                        name="expectedUpdatedAt"
-                                        type="hidden"
-                                        value={item.collaborationVersion}
-                                      />
-                                      <button
-                                        className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
-                                        disabled={
-                                          isPendingGeneratedExclude ||
-                                          isPendingGeneratedSave
-                                        }
-                                        type="submit"
-                                      >
-                                        {isPendingGeneratedExclude
-                                          ? "Fjerner varelinje..."
-                                          : "Fjern fra handlelisten"}
-                                      </button>
-                                    </Form>
-                                  ) : null}
-
-                                  {item.sourceType === "MANUAL" &&
-                                  manualValues ? (
-                                    <>
-                                      <Form
-                                        className="grid gap-3"
-                                        method="post"
-                                      >
-                                        <input
-                                          name="intent"
-                                          type="hidden"
-                                          value="update-manual-shopping-item"
-                                        />
-                                        <input
-                                          name="manualItemId"
-                                          type="hidden"
-                                          value={item.sourceKey}
-                                        />
-                                        <input
-                                          name="expectedUpdatedAt"
-                                          type="hidden"
-                                          value={item.collaborationVersion}
-                                        />
-
-                                        <label className="block text-sm font-medium text-slate-700">
-                                          Varenavn
-                                          <input
-                                            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                            defaultValue={manualValues.name}
-                                            name="name"
-                                            type="text"
-                                          />
-                                        </label>
-
-                                        <div className="grid gap-3 sm:grid-cols-2">
-                                          <label className="block text-sm font-medium text-slate-700">
-                                            Mengde
-                                            <input
-                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={
-                                                manualValues.quantity
-                                              }
-                                              name="quantity"
-                                              type="text"
-                                            />
-                                          </label>
-
-                                          <label className="block text-sm font-medium text-slate-700">
-                                            Handledato
-                                            <input
-                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={
-                                                manualValues.buyOnDate
-                                              }
-                                              max={loaderData.mealPlan.endDate}
-                                              min={
-                                                loaderData.mealPlan.startDate
-                                              }
-                                              name="buyOnDate"
-                                              type="date"
-                                            />
-                                          </label>
-                                        </div>
-
-                                        <div className="grid gap-3 sm:grid-cols-2">
-                                          <label className="block text-sm font-medium text-slate-700">
-                                            Kategori
-                                            <select
-                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={
-                                                manualValues.categoryId
-                                              }
-                                              name="categoryId"
-                                            >
-                                              <option value="">
-                                                Velg kategori
-                                              </option>
-                                              {loaderData.categories.map(
-                                                (category) => (
-                                                  <option
-                                                    key={category.id}
-                                                    value={category.id}
-                                                  >
-                                                    {category.displayName}
-                                                  </option>
-                                                ),
-                                              )}
-                                            </select>
-                                          </label>
-
-                                          <label className="block text-sm font-medium text-slate-700">
-                                            Foretrukket butikk
-                                            <select
-                                              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                              defaultValue={
-                                                manualValues.preferredStoreId
-                                              }
-                                              name="preferredStoreId"
-                                            >
-                                              <option value="">
-                                                Ingen valgt butikk
-                                              </option>
-                                              {loaderData.stores.map(
-                                                (store) => (
-                                                  <option
-                                                    key={store.id}
-                                                    value={store.id}
-                                                  >
-                                                    {store.name}
-                                                  </option>
-                                                ),
-                                              )}
-                                            </select>
-                                          </label>
-                                        </div>
-
-                                        <label className="block text-sm font-medium text-slate-700">
-                                          Notat
-                                          <textarea
-                                            className="mt-2 min-h-24 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                                            defaultValue={manualValues.note}
-                                            name="note"
-                                          />
-                                        </label>
-
-                                        {actionData?.intent ===
-                                          "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey ===
-                                          item.sourceKey &&
-                                        actionData.manualFieldErrors?.name ? (
-                                          <p className="text-sm text-rose-600">
-                                            {actionData.manualFieldErrors.name}
-                                          </p>
-                                        ) : null}
-                                        {actionData?.intent ===
-                                          "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey ===
-                                          item.sourceKey &&
-                                        actionData.manualFieldErrors
-                                          ?.categoryId ? (
-                                          <p className="text-sm text-rose-600">
-                                            {
-                                              actionData.manualFieldErrors
-                                                .categoryId
-                                            }
-                                          </p>
-                                        ) : null}
-                                        {actionData?.intent ===
-                                          "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey ===
-                                          item.sourceKey &&
-                                        actionData.manualFieldErrors
-                                          ?.preferredStoreId ? (
-                                          <p className="text-sm text-rose-600">
-                                            {
-                                              actionData.manualFieldErrors
-                                                .preferredStoreId
-                                            }
-                                          </p>
-                                        ) : null}
-                                        {actionData?.intent ===
-                                          "update-manual-shopping-item" &&
-                                        actionData.itemTarget?.sourceKey ===
-                                          item.sourceKey &&
-                                        actionData.manualFieldErrors
-                                          ?.buyOnDate ? (
-                                          <p className="text-sm text-rose-600">
-                                            {
-                                              actionData.manualFieldErrors
-                                                .buyOnDate
-                                            }
-                                          </p>
-                                        ) : null}
-
-                                        <button
-                                          className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
-                                          disabled={isPendingManualSave}
-                                          type="submit"
-                                        >
-                                          {isPendingManualSave
-                                            ? "Lagrer varelinje..."
-                                            : "Lagre varelinje"}
-                                        </button>
-                                      </Form>
-
-                                      <Form method="post">
-                                        <input
-                                          name="intent"
-                                          type="hidden"
-                                          value="delete-manual-shopping-item"
-                                        />
-                                        <input
-                                          name="manualItemId"
-                                          type="hidden"
-                                          value={item.sourceKey}
-                                        />
-                                        <input
-                                          name="expectedUpdatedAt"
-                                          type="hidden"
-                                          value={item.collaborationVersion}
-                                        />
-                                        <button
-                                          className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
-                                          disabled={isPendingManualDelete}
-                                          type="submit"
-                                        >
-                                          {isPendingManualDelete
-                                            ? "Sletter varelinje..."
-                                            : "Slett varelinje"}
-                                        </button>
-                                      </Form>
-                                    </>
-                                  ) : null}
+                              <div className="mt-4 hidden xl:block">
+                                <p className="text-sm leading-6 text-slate-600">
+                                  {item.sourceType === "GENERATED"
+                                    ? formatGeneratedItemSummary(item)
+                                    : item.buyOnDate
+                                      ? `Lagt til manuelt og planlagt for ${formatDateLabel(item.buyOnDate)}.`
+                                      : "Lagt til manuelt uten spesifikk handledato."}
+                                </p>
+                                {item.note ? (
+                                  <p className="mt-2 text-sm leading-6 text-slate-700">
+                                    Notat: {item.note}
+                                  </p>
+                                ) : null}
+                                <div className="mt-4">
+                                  <ShoppingListItemExpanded {...expandedProps} />
                                 </div>
                               </div>
                             </article>
@@ -1699,6 +1342,31 @@ function getToggleExpectedVersion(item: {
   }
 
   return item.collaborationVersion;
+}
+
+function shouldAutoOpenShoppingItemDetails(
+  actionData: ShoppingActionData | undefined,
+  sourceKey: string,
+) {
+  if (!actionData?.itemTarget || actionData.itemTarget.sourceKey !== sourceKey) {
+    return false;
+  }
+
+  if (actionData.intent === "update-manual-shopping-item") {
+    return Boolean(
+      actionData.manualFieldErrors &&
+        Object.values(actionData.manualFieldErrors).some(Boolean),
+    );
+  }
+
+  if (actionData.intent === "update-generated-shopping-item") {
+    return Boolean(
+      actionData.generatedOverrideFieldErrors &&
+        Object.values(actionData.generatedOverrideFieldErrors).some(Boolean),
+    );
+  }
+
+  return false;
 }
 
 function parseQuickAddManualShoppingItemInput(formData: FormData) {


### PR DESCRIPTION
## Summary
- Show a compact shopping row on viewports below `xl` (name, quantity, badges, recipe/source) so the list is easier to scan in the store.
- Move check-off, overrides, manual edit, and full Kilder list into per-row **Detaljer** `<details>` on mobile; desktop layout at `xl+` is unchanged.
- Fix `Handledato` / `Utsatt til` date inputs overflowing cards on narrow screens.

## Related issue
Closes #72

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: 320px / 390px — scan list, expand row, toggle checked, save override/manual item
- [ ] Manual: date fields stay inside card on mobile
- [ ] Manual: 1280px+ — full two-column layout without extra tap

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (204 tests)
- npm run typecheck