### PR TITLE
Add live search filter on recipes list page

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,32 @@
 
 ## Current Objective
 
-Issue #72 — compact mobile shopping list shipped on branch `issue/72-compact-shopping-mobile`; PR opened.
+Issue #74 — live client-side search on the family recipes list page; branch `issue/74-recipe-list-search`, PR pending merge.
 
 ## Completed
 
-- Added `formatCompactShoppingSourceLine` in `app/lib/shopping-display.ts` with unit tests.
-- Extracted `ShoppingListItemExpanded` component with shared date input styling.
-- Refactored shopping list item cards: compact header + source on mobile, `<details>` for actions; desktop layout unchanged at `xl+`.
-- Auto-open details when update returns field errors for that row.
-- Fixed date input overflow on narrow viewports.
+- Added `recipe-list-search` helpers with unit tests (title, description, tags; case-insensitive).
+- Wired search input with clear button on `/families/:familyId/recipes`.
+- Filter both family and global recipe sections as the user types.
+- Distinct empty states for “no recipes yet” vs “no search matches”.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-shopping.tsx` — mobile/desktop item card structure
-- `app/components/shopping-list-item-expanded.tsx` — forms and Kilder panel
-- `app/lib/shopping-display.ts` — compact source line formatter
+- `app/routes/family-recipes.tsx` — search UI, filtered lists, empty states
+- `app/lib/recipe-list-search.ts` — filter/match helpers
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 204 tests passed (38 files)
+- `npm run test:run` — 209 tests passed (39 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke on 320px / 390px / 1280px+ before merge if not done in review.
+- Manual smoke on recipes page: empty search, partial match, no-match messages, clear button.
 
 ## Next Step
 
-Merge PR when CI is green; closes #72.
+Merge PR when CI is green; closes #74.

--- a/app/lib/recipe-list-search.test.ts
+++ b/app/lib/recipe-list-search.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterRecipeList,
+  hasActiveRecipeSearch,
+  normalizeRecipeSearchQuery,
+  recipeMatchesSearch,
+} from "./recipe-list-search";
+
+const sampleRecipe = {
+  description: "En varm suppe med tomater",
+  tags: ["middag", "suppe"],
+  title: "Tomatsuppe",
+};
+
+describe("recipe list search", () => {
+  it("normalizes whitespace-only queries to empty", () => {
+    expect(normalizeRecipeSearchQuery("   ")).toBe("");
+    expect(hasActiveRecipeSearch("   ")).toBe(false);
+  });
+
+  it("matches all recipes when the query is empty", () => {
+    expect(recipeMatchesSearch(sampleRecipe, "")).toBe(true);
+    expect(recipeMatchesSearch(sampleRecipe, "   ")).toBe(true);
+    expect(filterRecipeList([sampleRecipe], "")).toEqual([sampleRecipe]);
+  });
+
+  it("matches titles case-insensitively", () => {
+    expect(recipeMatchesSearch(sampleRecipe, "tomat")).toBe(true);
+    expect(recipeMatchesSearch(sampleRecipe, "SUPPE")).toBe(true);
+  });
+
+  it("matches descriptions and tags", () => {
+    expect(recipeMatchesSearch(sampleRecipe, "varm")).toBe(true);
+    expect(recipeMatchesSearch(sampleRecipe, "middag")).toBe(true);
+  });
+
+  it("returns no matches when the query is absent from all fields", () => {
+    expect(recipeMatchesSearch(sampleRecipe, "pizza")).toBe(false);
+    expect(filterRecipeList([sampleRecipe], "pizza")).toEqual([]);
+  });
+});

--- a/app/lib/recipe-list-search.ts
+++ b/app/lib/recipe-list-search.ts
@@ -1,0 +1,40 @@
+export type RecipeSearchFields = {
+  description: string | null;
+  tags: string[];
+  title: string;
+};
+
+export function normalizeRecipeSearchQuery(query: string): string {
+  return query.trim();
+}
+
+export function recipeMatchesSearch(
+  recipe: RecipeSearchFields,
+  query: string,
+): boolean {
+  const normalizedQuery = normalizeRecipeSearchQuery(query);
+
+  if (normalizedQuery.length === 0) {
+    return true;
+  }
+
+  const needle = normalizedQuery.toLowerCase();
+  const haystacks = [
+    recipe.title,
+    recipe.description ?? "",
+    ...recipe.tags,
+  ];
+
+  return haystacks.some((value) => value.toLowerCase().includes(needle));
+}
+
+export function filterRecipeList<T extends RecipeSearchFields>(
+  recipes: T[],
+  query: string,
+): T[] {
+  return recipes.filter((recipe) => recipeMatchesSearch(recipe, query));
+}
+
+export function hasActiveRecipeSearch(query: string): boolean {
+  return normalizeRecipeSearchQuery(query).length > 0;
+}

--- a/app/routes/family-recipes.tsx
+++ b/app/routes/family-recipes.tsx
@@ -1,6 +1,11 @@
+import { useMemo, useState } from "react";
 import { Form, Link, isRouteErrorResponse, useNavigation } from "react-router";
 
 import { requireUser } from "../lib/auth.server";
+import {
+  filterRecipeList,
+  hasActiveRecipeSearch,
+} from "../lib/recipe-list-search";
 import { getRecipeManagementData } from "../lib/recipe.server";
 import {
   createFamilyRecipe,
@@ -110,11 +115,21 @@ export default function FamilyRecipesRoute({
   loaderData,
 }: FamilyRecipesRouteProps) {
   const navigation = useNavigation();
+  const [searchQuery, setSearchQuery] = useState("");
   const noticeContent = loaderData.notice
     ? getRecipesNoticeContent(loaderData.notice)
     : null;
   const pendingIntent = navigation.formData?.get("intent");
   const canManageRecipes = loaderData.userRole === "ADMIN";
+  const isSearchActive = hasActiveRecipeSearch(searchQuery);
+  const filteredFamilyRecipes = useMemo(
+    () => filterRecipeList(loaderData.familyRecipes, searchQuery),
+    [loaderData.familyRecipes, searchQuery],
+  );
+  const filteredGlobalRecipes = useMemo(
+    () => filterRecipeList(loaderData.globalRecipes, searchQuery),
+    [loaderData.globalRecipes, searchQuery],
+  );
   const createValues =
     actionData?.intent === "create-recipe" && actionData.createValues
       ? actionData.createValues
@@ -290,6 +305,35 @@ export default function FamilyRecipesRoute({
           </section>
         ) : null}
 
+        <section className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm">
+          <label
+            className="block text-sm font-medium text-slate-700"
+            htmlFor="recipe-search"
+          >
+            Søk oppskrifter
+            <div className="mt-2 flex gap-2">
+              <input
+                autoComplete="off"
+                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                id="recipe-search"
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="For eksempel tomatsuppe"
+                type="search"
+                value={searchQuery}
+              />
+              {isSearchActive ? (
+                <button
+                  className="shrink-0 rounded-2xl border border-slate-300 px-4 py-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+                  onClick={() => setSearchQuery("")}
+                  type="button"
+                >
+                  Nullstill
+                </button>
+              ) : null}
+            </div>
+          </label>
+        </section>
+
         <section className="rounded-[28px] border-2 border-emerald-200 bg-white p-6 shadow-sm">
           <div className="flex flex-col gap-2">
             <span className="inline-flex w-fit rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
@@ -298,12 +342,6 @@ export default function FamilyRecipesRoute({
             <h2 className="text-xl font-semibold text-slate-950">
               Familieoppskrifter
             </h2>
-            <p className="text-sm leading-6 text-slate-600">
-              Oppskrifter som tilhører {loaderData.family.name}.{" "}
-              {canManageRecipes
-                ? "Som administrator kan du opprette, redigere og slette disse."
-                : "Du kan apne og lese oppskriftene, men ikke endre dem."}
-            </p>
           </div>
 
           {loaderData.familyRecipes.length === 0 ? (
@@ -312,9 +350,13 @@ export default function FamilyRecipesRoute({
                 ? "Ingen familieoppskrifter ennå. Opprett den første oppskriften over."
                 : "Familien har ingen egne oppskrifter ennå."}
             </p>
+          ) : filteredFamilyRecipes.length === 0 && isSearchActive ? (
+            <p className="mt-6 rounded-[24px] border border-dashed border-emerald-200 bg-emerald-50/50 px-5 py-8 text-center text-sm leading-6 text-slate-600">
+              Ingen familieoppskrifter matcher søket.
+            </p>
           ) : (
             <div className="mt-6 grid gap-3">
-              {loaderData.familyRecipes.map((recipe) => (
+              {filteredFamilyRecipes.map((recipe) => (
                 <RecipeListCard
                   key={recipe.id}
                   recipe={recipe}
@@ -341,17 +383,24 @@ export default function FamilyRecipesRoute({
             </p>
           </div>
 
-          <div className="mt-6 grid gap-3">
-            {loaderData.globalRecipes.map((recipe) => (
-              <RecipeListCard
-                key={recipe.id}
-                readOnly
-                recipe={recipe}
-                scopeLabel="Standard"
-                scopeTone="global"
-              />
-            ))}
-          </div>
+          {loaderData.globalRecipes.length ===
+          0 ? null : filteredGlobalRecipes.length === 0 && isSearchActive ? (
+            <p className="mt-6 rounded-[24px] border border-dashed border-slate-200 bg-white px-5 py-8 text-center text-sm leading-6 text-slate-600">
+              Ingen standardoppskrifter matcher søket.
+            </p>
+          ) : (
+            <div className="mt-6 grid gap-3">
+              {filteredGlobalRecipes.map((recipe) => (
+                <RecipeListCard
+                  key={recipe.id}
+                  readOnly
+                  recipe={recipe}
+                  scopeLabel="Standard"
+                  scopeTone="global"
+                />
+              ))}
+            </div>
+          )}
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Add client-side search on `/families/:familyId/recipes` that filters family and standard recipe lists as the user types
- Match title, description, and tags (case-insensitive); empty search shows all recipes
- Show per-section “matcher søket” empty states distinct from “no recipes yet”

## Related issue
Closes #74

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: empty search shows full lists; typing filters both sections; no-match messages; Nullstill clears search; create-recipe form still works

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (209 tests)
- npm run typecheck