### PR TITLE
Let meal-plan sharer use the family review flow

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,34 @@
 
 ## Current Objective
 
-Issue #74 — live client-side search on the family recipes list page; branch `issue/74-recipe-list-search`, PR pending merge.
+Issue #75 — sharer can open the same meal-plan review list and detail view as recipients; branch `issue/75-sharer-review-preview`, ready to merge via PR.
 
 ## Completed
 
-- Added `recipe-list-search` helpers with unit tests (title, description, tags; case-insensitive).
-- Wired search input with clear button on `/families/:familyId/recipes`.
-- Filter both family and global recipe sections as the user types.
-- Distinct empty states for “no recipes yet” vs “no search matches”.
+- Auto-include sharer as `MealPlanShareRecipient` when creating a share (still requires at least one other recipient).
+- Backfill missing sharer recipient rows on open shares when listing or opening review.
+- Exclude self-initiated shares from `countPendingReviewsForUser` nav badge.
+- Initiator-aware copy on reviews list, review detail, and meal plan share links.
+- Unit tests for create, backfill, badge filter, and review route mock.
 
 ## Files To Read First
 
-- `app/routes/family-recipes.tsx` — search UI, filtered lists, empty states
-- `app/lib/recipe-list-search.ts` — filter/match helpers
+- `app/lib/meal-plan-share.server.ts` — recipient logic, backfill, badge filter
+- `app/routes/family-meal-plan-reviews.tsx` — list UI copy for sharer vs recipient
+- `app/routes/family-meal-plan-review.tsx` — detail UI with `isSharedByCurrentUser`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 209 tests passed (39 files)
+- `npm run test:run` — 212 tests passed (39 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke on recipes page: empty search, partial match, no-match messages, clear button.
+- Manual smoke: admin shares plan → sees item on `/meal-plans/reviews` → opens review with full actions; spouse sees incoming badge; admin nav badge unchanged for own share.
 
 ## Next Step
 
-Merge PR when CI is green; closes #74.
+Merge PR when CI is green; closes #75.

--- a/app/lib/meal-plan-share.server.test.ts
+++ b/app/lib/meal-plan-share.server.test.ts
@@ -22,6 +22,7 @@ const { dbMock, listFamilyMembersForCollaborationMock, requireFamilyMembershipMo
         },
         mealPlanShareRecipient: {
           count: vi.fn(),
+          create: vi.fn(),
           findFirst: vi.fn(),
           findMany: vi.fn(),
           update: vi.fn(),
@@ -56,7 +57,9 @@ import { approveMealPlan } from "./meal-plan.server";
 import {
   approveMealPlanFromShareReview,
   closeSharesForMealPlan,
+  countPendingReviewsForUser,
   createMealPlanShare,
+  listPendingReviewsForUser,
   markReviewCommentAddressed,
   upsertDayReviewComment,
 } from "./meal-plan-share.server";
@@ -95,7 +98,7 @@ describe("meal-plan-share.server", () => {
     ]);
   });
 
-  it("creates a whole-family share excluding the sharer", async () => {
+  it("creates a whole-family share including the sharer as recipient", async () => {
     dbMock.mealPlanShare.findFirst.mockResolvedValue(null);
     dbMock.mealPlanShare.create.mockResolvedValue({
       closedAt: null,
@@ -122,9 +125,48 @@ describe("meal-plan-share.server", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           recipients: {
-            create: [{ userId: "user-2" }],
+            create: expect.arrayContaining([
+              { userId: "user-1" },
+              { userId: "user-2" },
+            ]),
           },
           wholeFamily: true,
+        }),
+      }),
+    );
+  });
+
+  it("includes the sharer when sharing with selected members", async () => {
+    dbMock.mealPlanShare.findFirst.mockResolvedValue(null);
+    dbMock.mealPlanShare.create.mockResolvedValue({
+      closedAt: null,
+      createdAt: new Date("2026-05-20T10:00:00.000Z"),
+      id: "share-1",
+      mealPlanId: "meal-plan-1",
+      message: null,
+      sharedByUser: { displayName: "Ola", id: "user-1" },
+      status: "OPEN",
+      wholeFamily: false,
+    });
+
+    const result = await createMealPlanShare({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      recipientUserIds: ["user-2"],
+      userId: "user-1",
+      wholeFamily: false,
+    });
+
+    expect(result.status).toBe("CREATED");
+    expect(dbMock.mealPlanShare.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          recipients: {
+            create: expect.arrayContaining([
+              { userId: "user-1" },
+              { userId: "user-2" },
+            ]),
+          },
         }),
       }),
     );
@@ -274,6 +316,79 @@ describe("meal-plan-share.server", () => {
     expect(result.status).toBe("APPROVED");
     expect(approveMealPlan).toHaveBeenCalled();
     expect(dbMock.mealPlanShareRecipient.update).toHaveBeenCalled();
+  });
+
+  it("excludes self-initiated shares from pending review count", async () => {
+    dbMock.mealPlanShareRecipient.count.mockResolvedValue(1);
+
+    await countPendingReviewsForUser({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.mealPlanShareRecipient.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          share: expect.objectContaining({
+            sharedByUserId: {
+              not: "user-1",
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("backfills sharer recipient rows when listing reviews", async () => {
+    dbMock.mealPlanShare.findMany.mockResolvedValue([{ id: "share-1" }]);
+    dbMock.mealPlanShareRecipient.findFirst.mockResolvedValue(null);
+    dbMock.mealPlanShare.findFirst.mockResolvedValue({
+      id: "share-1",
+      sharedByUserId: "user-1",
+      status: "OPEN",
+    });
+    dbMock.mealPlanShareRecipient.create.mockResolvedValue({ id: "recipient-1" });
+    dbMock.mealPlanShareRecipient.findMany.mockResolvedValue([
+      {
+        id: "recipient-1",
+        respondedAt: null,
+        share: {
+          closedAt: null,
+          createdAt: new Date("2026-05-20T10:00:00.000Z"),
+          id: "share-1",
+          mealPlan: {
+            endDate: draftMealPlan.endDate,
+            id: "meal-plan-1",
+            startDate: draftMealPlan.startDate,
+            title: "Uke 20",
+          },
+          mealPlanId: "meal-plan-1",
+          message: "Sjekk middagene",
+          sharedByUser: { displayName: "Ola", id: "user-1" },
+          status: "OPEN",
+          wholeFamily: true,
+        },
+        status: "PENDING",
+        viewedAt: null,
+      },
+    ]);
+
+    const result = await listPendingReviewsForUser({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.mealPlanShareRecipient.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          shareId: "share-1",
+          status: "PENDING",
+          userId: "user-1",
+        },
+      }),
+    );
+    expect(result.reviews).toHaveLength(1);
+    expect(result.reviews[0]?.isSharedByCurrentUser).toBe(true);
   });
 
   it("closes open shares for a meal plan", async () => {

--- a/app/lib/meal-plan-share.server.ts
+++ b/app/lib/meal-plan-share.server.ts
@@ -138,6 +138,9 @@ export async function countPendingReviewsForUser({
           familyId,
           status: MEAL_PLAN_STATUS_DRAFT,
         },
+        sharedByUserId: {
+          not: userId,
+        },
         status: SHARE_STATUS_OPEN,
       },
       userId,
@@ -150,6 +153,11 @@ export async function listPendingReviewsForUser({
   userId,
 }: FamilyScopedInput) {
   const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  await backfillSharerRecipientsForUser({
     familyId,
     userId,
   });
@@ -201,6 +209,7 @@ export async function listPendingReviewsForUser({
     },
     reviews: recipients.map((recipient) => ({
       id: recipient.id,
+      isSharedByCurrentUser: recipient.share.sharedByUser.id === userId,
       mealPlan: {
         endDate: formatDateOnly(recipient.share.mealPlan.endDate),
         id: recipient.share.mealPlan.id,
@@ -213,6 +222,7 @@ export async function listPendingReviewsForUser({
         id: recipient.share.id,
         message: recipient.share.message,
         sharedByDisplayName: recipient.share.sharedByUser.displayName,
+        sharedByUserId: recipient.share.sharedByUser.id,
         wholeFamily: recipient.share.wholeFamily,
       },
       status: recipient.status,
@@ -317,19 +327,24 @@ export async function createMealPlanShare(input: CreateMealPlanShareInput) {
   });
 
   const message = input.message?.trim() ?? "";
-  const recipientUserIds = await resolveRecipientUserIds({
+  const resolvedRecipientUserIds = await resolveRecipientUserIds({
     familyId: input.familyId,
     recipientUserIds: input.recipientUserIds,
     sharerUserId: input.userId,
     wholeFamily: input.wholeFamily,
   });
 
-  if (recipientUserIds.length === 0) {
+  if (resolvedRecipientUserIds.length === 0) {
     return {
       formError: INVALID_RECIPIENT_MESSAGE,
       status: "VALIDATION_ERROR" as const,
     };
   }
+
+  const recipientUserIds = withSharerAsRecipient(
+    resolvedRecipientUserIds,
+    input.userId,
+  );
 
   const existingOpenShare = await db.mealPlanShare.findFirst({
     select: {
@@ -468,6 +483,7 @@ export async function getMealPlanShareReviewData({
       status: mealPlan.status,
       title: mealPlan.title,
     },
+    isSharedByCurrentUser: share.sharedByUser.id === userId,
     recipientStatus: share.recipient.status,
     share: {
       createdAt: share.createdAt.toISOString(),
@@ -839,6 +855,93 @@ async function getDraftMealPlanOrThrow({
   return mealPlan;
 }
 
+function withSharerAsRecipient(recipientUserIds: string[], sharerUserId: string) {
+  return [...new Set([...recipientUserIds, sharerUserId])];
+}
+
+async function backfillSharerRecipientsForUser({
+  familyId,
+  userId,
+}: FamilyScopedInput) {
+  const sharesMissingSharerRecipient = await db.mealPlanShare.findMany({
+    select: {
+      id: true,
+    },
+    where: {
+      mealPlan: {
+        familyId,
+        status: MEAL_PLAN_STATUS_DRAFT,
+      },
+      recipients: {
+        none: {
+          userId,
+        },
+      },
+      sharedByUserId: userId,
+      status: SHARE_STATUS_OPEN,
+    },
+  });
+
+  await Promise.all(
+    sharesMissingSharerRecipient.map((share) =>
+      ensureSharerRecipientForOpenShare({
+        shareId: share.id,
+        sharerUserId: userId,
+      }),
+    ),
+  );
+}
+
+async function ensureSharerRecipientForOpenShare({
+  shareId,
+  sharerUserId,
+}: {
+  shareId: string;
+  sharerUserId: string;
+}) {
+  const existingRecipient = await db.mealPlanShareRecipient.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      shareId,
+      userId: sharerUserId,
+    },
+  });
+
+  if (existingRecipient) {
+    return existingRecipient;
+  }
+
+  const share = await db.mealPlanShare.findFirst({
+    select: {
+      id: true,
+      sharedByUserId: true,
+      status: true,
+    },
+    where: {
+      id: shareId,
+      sharedByUserId: sharerUserId,
+      status: SHARE_STATUS_OPEN,
+    },
+  });
+
+  if (!share) {
+    return null;
+  }
+
+  return db.mealPlanShareRecipient.create({
+    data: {
+      shareId: share.id,
+      status: RECIPIENT_STATUS_PENDING,
+      userId: sharerUserId,
+    },
+    select: {
+      id: true,
+    },
+  });
+}
+
 async function resolveRecipientUserIds({
   familyId,
   recipientUserIds,
@@ -959,6 +1062,37 @@ async function getShareForRecipientReviewOrThrow({
   });
 
   if (!recipient) {
+    const share = await db.mealPlanShare.findFirst({
+      select: {
+        id: true,
+        sharedByUserId: true,
+        status: true,
+      },
+      where: {
+        id: shareId,
+        mealPlan: {
+          familyId,
+          id: mealPlanId,
+        },
+        sharedByUserId: userId,
+        status: SHARE_STATUS_OPEN,
+      },
+    });
+
+    if (share) {
+      await ensureSharerRecipientForOpenShare({
+        shareId: share.id,
+        sharerUserId: userId,
+      });
+
+      return getShareForRecipientReviewOrThrow({
+        familyId,
+        mealPlanId,
+        shareId,
+        userId,
+      });
+    }
+
     throw new Response(SHARE_NOT_RECIPIENT_MESSAGE, {
       status: 403,
       statusText: "Forbidden",

--- a/app/routes/family-meal-plan-review.test.ts
+++ b/app/routes/family-meal-plan-review.test.ts
@@ -46,6 +46,7 @@ describe("family meal plan review route", () => {
       canApprove: true,
       days: [],
       family: { id: "family-1", name: "Solberg" },
+      isSharedByCurrentUser: false,
       mealPlan: {
         endDate: "2026-05-18",
         id: "meal-plan-1",

--- a/app/routes/family-meal-plan-review.tsx
+++ b/app/routes/family-meal-plan-review.tsx
@@ -198,7 +198,9 @@ export default function FamilyMealPlanReviewRoute({
       ? "Godkjent"
       : loaderData.recipientStatus === "RESPONDED"
         ? "Du har svart"
-        : "Venter på deg";
+        : loaderData.isSharedByCurrentUser
+          ? "Delt av deg"
+          : "Venter på deg";
 
   return (
     <main className="min-h-screen overflow-x-hidden bg-slate-100 px-4 py-6 text-slate-900">
@@ -219,7 +221,9 @@ export default function FamilyMealPlanReviewRoute({
                 )}
               </p>
               <p className="mt-1 text-xs text-slate-400">
-                Delt av {loaderData.share.sharedByDisplayName}
+                {loaderData.isSharedByCurrentUser
+                  ? "Delt av deg"
+                  : `Delt av ${loaderData.share.sharedByDisplayName}`}
               </p>
             </div>
             <span className="shrink-0 rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-slate-100">
@@ -229,6 +233,12 @@ export default function FamilyMealPlanReviewRoute({
           {loaderData.share.message ? (
             <p className="mt-3 rounded-2xl bg-white/10 px-3 py-2 text-sm text-slate-200">
               {loaderData.share.message}
+            </p>
+          ) : null}
+          {loaderData.isSharedByCurrentUser && loaderData.canApprove ? (
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              Familien kan gi tilbakemelding. Du kan også godkjenne her når
+              planen er klar.
             </p>
           ) : null}
         </section>

--- a/app/routes/family-meal-plan-reviews.tsx
+++ b/app/routes/family-meal-plan-reviews.tsx
@@ -92,6 +92,13 @@ export default function FamilyMealPlanReviewsRoute({
             {loaderData.reviews.map((review) => {
               const needsResponse =
                 review.status === "PENDING" || review.status === "VIEWED";
+              const statusLabel = review.isSharedByCurrentUser
+                ? needsResponse
+                  ? "Venter på familien"
+                  : "Du har svart"
+                : needsResponse
+                  ? "Venter på deg"
+                  : "Du har svart";
 
               return (
                 <article
@@ -109,7 +116,7 @@ export default function FamilyMealPlanReviewsRoute({
                           : "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800"
                       }
                     >
-                      {needsResponse ? "Venter på deg" : "Du har svart"}
+                      {statusLabel}
                     </span>
                   </div>
                   <p className="mt-2 text-sm text-slate-600">
@@ -119,7 +126,9 @@ export default function FamilyMealPlanReviewsRoute({
                     )}
                   </p>
                   <p className="mt-1 text-sm text-slate-500">
-                    Delt av {review.share.sharedByDisplayName}
+                    {review.isSharedByCurrentUser
+                      ? "Delt av deg"
+                      : `Delt av ${review.share.sharedByDisplayName}`}
                     {review.share.message
                       ? ` — «${review.share.message}»`
                       : null}
@@ -128,7 +137,13 @@ export default function FamilyMealPlanReviewsRoute({
                     className="mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
                     to={`/families/${loaderData.family.id}/meal-plans/${review.mealPlan.id}/review?shareId=${review.share.id}`}
                   >
-                    {needsResponse ? "Gi tilbakemelding" : "Se tilbakemelding"}
+                    {review.isSharedByCurrentUser
+                      ? needsResponse
+                        ? "Se delt ukeplan"
+                        : "Se tilbakemelding"
+                      : needsResponse
+                        ? "Gi tilbakemelding"
+                        : "Se tilbakemelding"}
                   </Link>
                 </article>
               );

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -1123,7 +1123,7 @@ function MealPlanShareSection({
           className="mt-4 inline-flex text-sm font-medium text-emerald-700 hover:text-emerald-800"
           to={`/families/${familyId}/meal-plans/reviews`}
         >
-          Se det du skal gjennomgå
+          Se delt ukeplan
         </Link>
       </article>
     );
@@ -1142,7 +1142,7 @@ function MealPlanShareSection({
         className="mt-3 inline-flex text-sm font-medium text-emerald-700 hover:text-emerald-800"
         to={`/families/${familyId}/meal-plans/reviews`}
       >
-        Se det du skal gjennomgå
+        Til gjennomgang
       </Link>
 
       <Form className="mt-4 space-y-4" method="post">


### PR DESCRIPTION
## Summary
- Add the sharer as a share recipient when sending a plan for review, with idempotent backfill for existing open shares
- Sharer sees the same review list and detail UI (approve + day feedback); nav badge only counts incoming reviews from others
- Norwegian copy distinguishes plans you shared (“Delt av deg”, “Se delt ukeplan”) from plans waiting on you

## Related issue
Closes #75

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Admin shares draft with whole family → plan appears on `/meal-plans/reviews` → open review → approve/feedback works
- [ ] Family member sees pending review and nav badge increments
- [ ] Sharer nav badge does not increment for their own outbound share

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (212 tests)
- npm run typecheck