### PR TITLE
Store mode: optimistic check-off with localStorage sync

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,34 @@
 
 ## Current Objective
 
-Issue #75 — sharer can open the same meal-plan review list and detail view as recipients; branch `issue/75-sharer-review-preview`, ready to merge via PR.
+Issue #78 — store mode optimistic check-off with localStorage sync; branch `issue/78-store-mode-offline-sync`, ready for PR.
 
 ## Completed
 
-- Auto-include sharer as `MealPlanShareRecipient` when creating a share (still requires at least one other recipient).
-- Backfill missing sharer recipient rows on open shares when listing or opening review.
-- Exclude self-initiated shares from `countPendingReviewsForUser` nav badge.
-- Initiator-aware copy on reviews list, review detail, and meal plan share links.
-- Unit tests for create, backfill, badge filter, and review route mock.
+- Client queue module (`shopping-store-mode-client.ts`) with localStorage persistence, merge, reconcile, and progress helpers.
+- `useStoreModeToggleSync` hook: optimistic toggles, serial background sync, delayed sync banner (800ms), stable fetcher refs to avoid request loops.
+- Store mode route uses button toggles (always interactive), merged progress/sections, separate sync vs form error banners.
+- Shared `getToggleExpectedVersion` moved to client module; shopping route imports it.
+- Unit tests for queue client (9 tests).
 
 ## Files To Read First
 
-- `app/lib/meal-plan-share.server.ts` — recipient logic, backfill, badge filter
-- `app/routes/family-meal-plan-reviews.tsx` — list UI copy for sharer vs recipient
-- `app/routes/family-meal-plan-review.tsx` — detail UI with `isSharedByCurrentUser`
+- `app/lib/use-store-mode-toggle-sync.ts` — queue drain, revalidate when queue empty, loop fixes
+- `app/lib/shopping-store-mode-client.ts` — storage key, reconcile, merge
+- `app/routes/family-meal-plan-store-mode.tsx` — UI wiring and banners
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 212 tests passed (39 files)
+- `npm run test:run` — 221 tests passed (40 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke: admin shares plan → sees item on `/meal-plans/reviews` → opens review with full actions; spouse sees incoming badge; admin nav badge unchanged for own share.
+- Manual smoke: fast connection (no sync banner flash), offline tick + reload + reconnect, stale localStorage queue clears after sync.
 
 ## Next Step
 
-Merge PR when CI is green; closes #75.
+Merge PR when CI is green; closes #78.

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { ShoppingItemSource } from "@prisma/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applyToggleOpsToItems,
+  areToggleQueuesEqual,
+  buildStoreModeQueueStorageKey,
+  computeStoreModeProgress,
+  readStoreModeToggleQueue,
+  reconcileToggleQueue,
+  removeToggleOp,
+  upsertToggleOp,
+  writeStoreModeToggleQueue,
+} from "./shopping-store-mode-client";
+
+const storageKey = buildStoreModeQueueStorageKey({
+  activeShoppingDate: "2026-05-16",
+  familyId: "family-1",
+  mealPlanId: "meal-plan-1",
+});
+
+const sampleItem = {
+  checked: false,
+  collaborationVersion: "2026-05-01T12:00:00.000Z",
+  sourceKey: "entry-1:ingredient-1",
+  sourceType: ShoppingItemSource.GENERATED,
+} as const;
+
+describe("shopping-store-mode-client", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("builds isolated storage keys per shopping context", () => {
+    expect(
+      buildStoreModeQueueStorageKey({
+        activeShoppingDate: "2026-05-16",
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      }),
+    ).not.toBe(
+      buildStoreModeQueueStorageKey({
+        activeShoppingDate: "2026-05-17",
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      }),
+    );
+  });
+
+  it("upserts toggle ops by sourceKey", () => {
+    const queue = upsertToggleOp([], {
+      checked: true,
+      expectedUpdatedAt: "v1",
+      sourceKey: "a",
+      sourceType: ShoppingItemSource.GENERATED,
+    });
+
+    const updated = upsertToggleOp(queue, {
+      checked: false,
+      expectedUpdatedAt: "v2",
+      sourceKey: "a",
+      sourceType: ShoppingItemSource.GENERATED,
+    });
+
+    expect(updated).toEqual([
+      {
+        checked: false,
+        expectedUpdatedAt: "v2",
+        sourceKey: "a",
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+    ]);
+  });
+
+  it("merges queued checked state onto loader items", () => {
+    const merged = applyToggleOpsToItems([sampleItem], [
+      {
+        checked: true,
+        expectedUpdatedAt: "",
+        sourceKey: sampleItem.sourceKey,
+        sourceType: sampleItem.sourceType,
+      },
+    ]);
+
+    expect(merged[0]?.checked).toBe(true);
+  });
+
+  it("computes progress from merged items", () => {
+    expect(
+      computeStoreModeProgress([
+        { checked: true },
+        { checked: false },
+        { checked: true },
+      ]),
+    ).toEqual({
+      checkedCount: 2,
+      totalCount: 3,
+    });
+  });
+
+  it("removes queue entries that already match loader state", () => {
+    expect(
+      reconcileToggleQueue({
+        loaderItems: [{ ...sampleItem, checked: true }],
+        queue: [
+          {
+            checked: true,
+            expectedUpdatedAt: "",
+            sourceKey: sampleItem.sourceKey,
+            sourceType: sampleItem.sourceType,
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps queue entries when loader still disagrees", () => {
+    const queue = [
+      {
+        checked: true,
+        expectedUpdatedAt: "",
+        sourceKey: sampleItem.sourceKey,
+        sourceType: sampleItem.sourceType,
+      },
+    ];
+
+    expect(
+      reconcileToggleQueue({
+        loaderItems: [sampleItem],
+        queue,
+      }),
+    ).toEqual(queue);
+  });
+
+  it("persists and reads queue entries from localStorage", () => {
+    const queue = [
+      {
+        checked: true,
+        expectedUpdatedAt: "v1",
+        sourceKey: "a",
+        sourceType: ShoppingItemSource.MANUAL,
+      },
+    ];
+
+    writeStoreModeToggleQueue(storageKey, queue);
+
+    expect(readStoreModeToggleQueue(storageKey)).toEqual(queue);
+    expect(removeToggleOp(queue, "a")).toEqual([]);
+  });
+
+  it("compares toggle queues by op fields", () => {
+    const queue = [
+      {
+        checked: true,
+        expectedUpdatedAt: "v1",
+        sourceKey: "a",
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+    ];
+
+    expect(areToggleQueuesEqual(queue, [...queue])).toBe(true);
+    expect(
+      areToggleQueuesEqual(queue, [
+        {
+          ...queue[0]!,
+          checked: false,
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns an empty queue for corrupt storage payloads", () => {
+    window.localStorage.setItem(storageKey, "{not-an-array");
+
+    expect(readStoreModeToggleQueue(storageKey)).toEqual([]);
+  });
+});

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -1,0 +1,199 @@
+import { ShoppingItemSource } from "@prisma/client";
+
+export interface StoreModeToggleOp {
+  checked: boolean;
+  expectedUpdatedAt: string;
+  sourceKey: string;
+  sourceType: ShoppingItemSource;
+}
+
+export interface StoreModeToggleItem {
+  checked: boolean;
+  collaborationVersion: string;
+  overrideVersion?: string;
+  sourceKey: string;
+  sourceType: ShoppingItemSource;
+}
+
+export interface StoreModeProgress {
+  checkedCount: number;
+  totalCount: number;
+}
+
+const STORE_MODE_QUEUE_KEY_PREFIX = "mealplanner:store-mode-queue:v1";
+
+export function buildStoreModeQueueStorageKey({
+  activeShoppingDate,
+  familyId,
+  mealPlanId,
+}: {
+  activeShoppingDate: string;
+  familyId: string;
+  mealPlanId: string;
+}) {
+  return `${STORE_MODE_QUEUE_KEY_PREFIX}:${familyId}:${mealPlanId}:${activeShoppingDate}`;
+}
+
+export function readStoreModeToggleQueue(storageKey: string): StoreModeToggleOp[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isStoreModeToggleOp);
+  } catch {
+    return [];
+  }
+}
+
+export function writeStoreModeToggleQueue(
+  storageKey: string,
+  queue: StoreModeToggleOp[],
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (queue.length === 0) {
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+
+    window.localStorage.setItem(storageKey, JSON.stringify(queue));
+  } catch {
+    // Private mode or quota exceeded — in-session optimistic state still works.
+  }
+}
+
+export function upsertToggleOp(
+  queue: StoreModeToggleOp[],
+  op: StoreModeToggleOp,
+): StoreModeToggleOp[] {
+  const withoutExisting = queue.filter((entry) => entry.sourceKey !== op.sourceKey);
+  return [...withoutExisting, op];
+}
+
+export function removeToggleOp(queue: StoreModeToggleOp[], sourceKey: string) {
+  return queue.filter((entry) => entry.sourceKey !== sourceKey);
+}
+
+export function applyToggleOpsToItems<T extends StoreModeToggleItem>(
+  items: T[],
+  ops: StoreModeToggleOp[],
+): T[] {
+  if (ops.length === 0) {
+    return items;
+  }
+
+  const opBySourceKey = new Map(ops.map((op) => [op.sourceKey, op]));
+
+  return items.map((item) => {
+    const op = opBySourceKey.get(item.sourceKey);
+
+    if (!op) {
+      return item;
+    }
+
+    return {
+      ...item,
+      checked: op.checked,
+    };
+  });
+}
+
+export function computeStoreModeProgress(
+  items: Pick<StoreModeToggleItem, "checked">[],
+): StoreModeProgress {
+  return {
+    checkedCount: items.filter((item) => item.checked).length,
+    totalCount: items.length,
+  };
+}
+
+export function areToggleQueuesEqual(
+  left: StoreModeToggleOp[],
+  right: StoreModeToggleOp[],
+) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((op, index) => {
+    const other = right[index];
+
+    return (
+      op.sourceKey === other.sourceKey &&
+      op.sourceType === other.sourceType &&
+      op.checked === other.checked &&
+      op.expectedUpdatedAt === other.expectedUpdatedAt
+    );
+  });
+}
+
+export function reconcileToggleQueue({
+  loaderItems,
+  queue,
+}: {
+  loaderItems: StoreModeToggleItem[];
+  queue: StoreModeToggleOp[];
+}): StoreModeToggleOp[] {
+  if (queue.length === 0) {
+    return queue;
+  }
+
+  const loaderBySourceKey = new Map(
+    loaderItems.map((item) => [item.sourceKey, item]),
+  );
+
+  return queue.filter((op) => {
+    const loaderItem = loaderBySourceKey.get(op.sourceKey);
+
+    if (!loaderItem) {
+      return true;
+    }
+
+    return loaderItem.checked !== op.checked;
+  });
+}
+
+export function getToggleExpectedVersion(item: {
+  collaborationVersion: string;
+  overrideVersion?: string;
+  sourceType: ShoppingItemSource;
+}) {
+  if (item.sourceType === ShoppingItemSource.MANUAL) {
+    return item.overrideVersion ?? "";
+  }
+
+  return item.collaborationVersion;
+}
+
+function isStoreModeToggleOp(value: unknown): value is StoreModeToggleOp {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const op = value as Partial<StoreModeToggleOp>;
+
+  return (
+    typeof op.sourceKey === "string" &&
+    op.sourceKey.length > 0 &&
+    (op.sourceType === ShoppingItemSource.GENERATED ||
+      op.sourceType === ShoppingItemSource.MANUAL) &&
+    typeof op.checked === "boolean" &&
+    typeof op.expectedUpdatedAt === "string"
+  );
+}

--- a/app/lib/use-store-mode-toggle-sync.ts
+++ b/app/lib/use-store-mode-toggle-sync.ts
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FetcherWithComponents } from "react-router";
+
+import {
+  applyToggleOpsToItems,
+  areToggleQueuesEqual,
+  buildStoreModeQueueStorageKey,
+  getToggleExpectedVersion,
+  readStoreModeToggleQueue,
+  reconcileToggleQueue,
+  removeToggleOp,
+  type StoreModeToggleItem,
+  type StoreModeToggleOp,
+  upsertToggleOp,
+  writeStoreModeToggleQueue,
+} from "./shopping-store-mode-client";
+
+const SYNC_RETRY_DELAY_MS = 2000;
+const SYNC_BANNER_DELAY_MS = 800;
+
+export const STORE_MODE_SYNC_PROGRESS_MESSAGE = "Synkroniserer avkryssinger…";
+
+interface StoreModeToggleActionData {
+  formError?: string;
+  intent?: string;
+  ok?: boolean;
+}
+
+interface UseStoreModeToggleSyncOptions<T extends StoreModeToggleItem> {
+  activeShoppingDate: string;
+  familyId: string;
+  loaderItems: T[];
+  mealPlanId: string;
+  revalidate: () => void;
+  toggleFetcher: FetcherWithComponents<StoreModeToggleActionData>;
+}
+
+export function useStoreModeToggleSync<T extends StoreModeToggleItem>({
+  activeShoppingDate,
+  familyId,
+  loaderItems,
+  mealPlanId,
+  revalidate,
+  toggleFetcher,
+}: UseStoreModeToggleSyncOptions<T>) {
+  const storageKey = useMemo(
+    () =>
+      buildStoreModeQueueStorageKey({
+        activeShoppingDate,
+        familyId,
+        mealPlanId,
+      }),
+    [activeShoppingDate, familyId, mealPlanId],
+  );
+  const [queue, setQueue] = useState<StoreModeToggleOp[]>([]);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [showSyncProgressBanner, setShowSyncProgressBanner] = useState(false);
+  const queueRef = useRef(queue);
+  const inFlightSourceKeyRef = useRef<string | null>(null);
+  const retryTimeoutRef = useRef<number | null>(null);
+  const lastProcessedFetcherStateRef = useRef(toggleFetcher.state);
+  const toggleFetcherRef = useRef(toggleFetcher);
+  const revalidateRef = useRef(revalidate);
+  const storageKeyRef = useRef(storageKey);
+  const loaderItemsRef = useRef(loaderItems);
+
+  toggleFetcherRef.current = toggleFetcher;
+  revalidateRef.current = revalidate;
+  storageKeyRef.current = storageKey;
+  loaderItemsRef.current = loaderItems;
+  queueRef.current = queue;
+
+  const persistQueue = useCallback((nextQueue: StoreModeToggleOp[]) => {
+    queueRef.current = nextQueue;
+    setQueue(nextQueue);
+    writeStoreModeToggleQueue(storageKeyRef.current, nextQueue);
+  }, []);
+
+  const submitNextOp = useCallback(() => {
+    const fetcher = toggleFetcherRef.current;
+
+    if (fetcher.state !== "idle" || queueRef.current.length === 0) {
+      return;
+    }
+
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      return;
+    }
+
+    const [nextOp] = queueRef.current;
+    inFlightSourceKeyRef.current = nextOp.sourceKey;
+    const formData = new FormData();
+    formData.set("intent", "toggle-shopping-item-checked");
+    formData.set("sourceKey", nextOp.sourceKey);
+    formData.set("sourceType", nextOp.sourceType);
+    formData.set("checked", nextOp.checked ? "true" : "false");
+    formData.set("expectedUpdatedAt", nextOp.expectedUpdatedAt);
+    fetcher.submit(formData, { method: "post" });
+  }, []);
+
+  const scheduleRetry = useCallback(() => {
+    if (retryTimeoutRef.current !== null) {
+      window.clearTimeout(retryTimeoutRef.current);
+    }
+
+    retryTimeoutRef.current = window.setTimeout(() => {
+      retryTimeoutRef.current = null;
+      submitNextOp();
+    }, SYNC_RETRY_DELAY_MS);
+  }, [submitNextOp]);
+
+  const applyReconciledQueue = useCallback(
+    (reconciledQueue: StoreModeToggleOp[]) => {
+      if (areToggleQueuesEqual(reconciledQueue, queueRef.current)) {
+        return;
+      }
+
+      persistQueue(reconciledQueue);
+    },
+    [persistQueue],
+  );
+
+  useEffect(() => {
+    const storedQueue = readStoreModeToggleQueue(storageKey);
+    const reconciledQueue = reconcileToggleQueue({
+      loaderItems: loaderItemsRef.current,
+      queue: storedQueue,
+    });
+    queueRef.current = reconciledQueue;
+    setQueue(reconciledQueue);
+    writeStoreModeToggleQueue(storageKey, reconciledQueue);
+    setSyncError(null);
+  }, [storageKey]);
+
+  useEffect(() => {
+    const reconciledQueue = reconcileToggleQueue({
+      loaderItems,
+      queue: queueRef.current,
+    });
+    applyReconciledQueue(reconciledQueue);
+  }, [applyReconciledQueue, loaderItems]);
+
+  const displayItems = useMemo(
+    () => applyToggleOpsToItems(loaderItems, queue),
+    [loaderItems, queue],
+  );
+
+  const displayItemsBySourceKey = useMemo(
+    () => new Map(displayItems.map((item) => [item.sourceKey, item])),
+    [displayItems],
+  );
+
+  useEffect(() => {
+    submitNextOp();
+  }, [queue, submitNextOp]);
+
+  useEffect(() => {
+    const previousState = lastProcessedFetcherStateRef.current;
+    lastProcessedFetcherStateRef.current = toggleFetcher.state;
+
+    if (previousState === "submitting" && toggleFetcher.state === "idle") {
+      const submittedSourceKeyValue = inFlightSourceKeyRef.current;
+      inFlightSourceKeyRef.current = null;
+
+      if (toggleFetcher.data?.ok) {
+        const nextQueue = submittedSourceKeyValue
+          ? removeToggleOp(queueRef.current, submittedSourceKeyValue)
+          : queueRef.current.slice(1);
+        persistQueue(nextQueue);
+        setSyncError(null);
+
+        if (nextQueue.length === 0) {
+          revalidateRef.current();
+        } else {
+          submitNextOp();
+        }
+
+        return;
+      }
+
+      if (toggleFetcher.data?.formError) {
+        const nextQueue = submittedSourceKeyValue
+          ? removeToggleOp(queueRef.current, submittedSourceKeyValue)
+          : queueRef.current.slice(1);
+        persistQueue(nextQueue);
+        setSyncError(toggleFetcher.data.formError);
+        revalidateRef.current();
+        scheduleRetry();
+        return;
+      }
+
+      if (submittedSourceKeyValue) {
+        const nextQueue = removeToggleOp(queueRef.current, submittedSourceKeyValue);
+        persistQueue(nextQueue);
+        setSyncError(
+          "Kunne ikke synkronisere. Prøver igjen når nettet er tilbake.",
+        );
+        scheduleRetry();
+      }
+    }
+  }, [
+    persistQueue,
+    scheduleRetry,
+    submitNextOp,
+    toggleFetcher.data,
+    toggleFetcher.state,
+  ]);
+
+  useEffect(() => {
+    function handleConnectivityChange() {
+      if (navigator.onLine) {
+        setSyncError(null);
+        submitNextOp();
+      }
+    }
+
+    window.addEventListener("online", handleConnectivityChange);
+    window.addEventListener("offline", handleConnectivityChange);
+    window.addEventListener("visibilitychange", handleConnectivityChange);
+
+    return () => {
+      window.removeEventListener("online", handleConnectivityChange);
+      window.removeEventListener("offline", handleConnectivityChange);
+      window.removeEventListener("visibilitychange", handleConnectivityChange);
+
+      if (retryTimeoutRef.current !== null) {
+        window.clearTimeout(retryTimeoutRef.current);
+      }
+    };
+  }, [submitNextOp]);
+
+  const handleToggle = useCallback(
+    (item: T) => {
+      const displayItem = displayItemsBySourceKey.get(item.sourceKey) ?? item;
+      const checked = !displayItem.checked;
+      const op: StoreModeToggleOp = {
+        checked,
+        expectedUpdatedAt: getToggleExpectedVersion(displayItem),
+        sourceKey: item.sourceKey,
+        sourceType: item.sourceType,
+      };
+      const nextQueue = upsertToggleOp(queueRef.current, op);
+      persistQueue(nextQueue);
+      setSyncError(null);
+      submitNextOp();
+    },
+    [displayItemsBySourceKey, persistQueue, submitNextOp],
+  );
+
+  const isSyncing = queue.length > 0;
+
+  useEffect(() => {
+    if (syncError || !isSyncing) {
+      setShowSyncProgressBanner(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShowSyncProgressBanner(true);
+    }, SYNC_BANNER_DELAY_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isSyncing, syncError]);
+
+  const syncBannerMessage =
+    syncError ??
+    (showSyncProgressBanner ? STORE_MODE_SYNC_PROGRESS_MESSAGE : null);
+
+  return {
+    displayItems,
+    displayItemsBySourceKey,
+    handleToggle,
+    isSyncing,
+    queue,
+    syncBannerMessage,
+    syncError,
+  };
+}

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -18,6 +18,7 @@ import {
   ShoppingListItemExpanded,
   shoppingDateInputClassName,
 } from "../components/shopping-list-item-expanded";
+import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
   getMealPlanShoppingData,
   listRecentManualShoppingItemsForFamily,
@@ -1330,18 +1331,6 @@ function serializeProjectedShoppingItem(
 
 function parseExpectedUpdatedAt(formData: FormData) {
   return String(formData.get("expectedUpdatedAt") ?? "");
-}
-
-function getToggleExpectedVersion(item: {
-  collaborationVersion: string;
-  overrideVersion?: string;
-  sourceType: ShoppingItemSource;
-}) {
-  if (item.sourceType === ShoppingItemSource.MANUAL) {
-    return item.overrideVersion ?? "";
-  }
-
-  return item.collaborationVersion;
 }
 
 function shouldAutoOpenShoppingItemDetails(

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1,11 +1,13 @@
 import { ShoppingItemSource } from "@prisma/client";
 import type { ChangeEvent } from "react";
+import { useMemo } from "react";
 import {
   Form,
   Link,
   isRouteErrorResponse,
   useFetcher,
   useNavigation,
+  useRevalidator,
   useSubmit,
   type MetaFunction,
 } from "react-router";
@@ -15,12 +17,17 @@ import {
   formatGeneratedOccurrenceAttribution,
   formatGeneratedQuantityBadge,
 } from "../lib/shopping-display";
+import { computeStoreModeProgress } from "../lib/shopping-store-mode-client";
 import { getMealPlanStoreModeData } from "../lib/shopping.server";
 import {
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
 } from "../lib/shopping-write.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
+import {
+  STORE_MODE_SYNC_PROGRESS_MESSAGE,
+  useStoreModeToggleSync,
+} from "../lib/use-store-mode-toggle-sync";
 
 type StoreModeNotice =
   | "active-shopping-date-updated"
@@ -245,6 +252,7 @@ export default function FamilyMealPlanStoreModeRoute({
 }: FamilyMealPlanStoreModeRouteProps) {
   const navigation = useNavigation();
   const submit = useSubmit();
+  const revalidator = useRevalidator();
   const toggleFetcher = useFetcher<StoreModeActionData>();
   const pendingIntent = navigation.formData?.get("intent");
   const isSavingStore =
@@ -253,12 +261,43 @@ export default function FamilyMealPlanStoreModeRoute({
   const isSavingShoppingDate =
     navigation.state === "submitting" &&
     pendingIntent === "update-active-shopping-date";
-  const pendingSourceKey = getPendingSourceKey(toggleFetcher.formData);
-  const toggleFormError =
-    toggleFetcher.data?.intent === "toggle-shopping-item-checked" &&
-    toggleFetcher.data.formError
-      ? toggleFetcher.data.formError
-      : null;
+  const loaderDueItems = useMemo(
+    () => loaderData.dueSectionGroups.flatMap((section) => section.items),
+    [loaderData.dueSectionGroups],
+  );
+  const {
+    displayItemsBySourceKey,
+    handleToggle,
+    syncBannerMessage,
+  } = useStoreModeToggleSync({
+    activeShoppingDate: loaderData.activeShoppingDate,
+    familyId: loaderData.family.id,
+    loaderItems: loaderDueItems,
+    mealPlanId: loaderData.mealPlan.id,
+    revalidate: revalidator.revalidate,
+    toggleFetcher,
+  });
+  const displayDueItems = useMemo(
+    () =>
+      loaderDueItems.map(
+        (item) => displayItemsBySourceKey.get(item.sourceKey) ?? item,
+      ),
+    [displayItemsBySourceKey, loaderDueItems],
+  );
+  const displayProgress = useMemo(
+    () => computeStoreModeProgress(displayDueItems),
+    [displayDueItems],
+  );
+  const displaySectionGroups = useMemo(
+    () =>
+      loaderData.dueSectionGroups.map((section) => ({
+        ...section,
+        items: section.items.map(
+          (item) => displayItemsBySourceKey.get(item.sourceKey) ?? item,
+        ),
+      })),
+    [displayItemsBySourceKey, loaderData.dueSectionGroups],
+  );
   const noticeContent = loaderData.notice
     ? getStoreModeNoticeContent(loaderData.notice)
     : null;
@@ -323,8 +362,8 @@ export default function FamilyMealPlanStoreModeRoute({
               <div className="rounded-[24px] bg-emerald-500/20 p-4 ring-1 ring-emerald-400/30">
                 <p className="text-sm text-emerald-100">Fremdrift</p>
                 <p className="mt-1 text-lg font-semibold">
-                  {loaderData.progress.checkedCount}/
-                  {loaderData.progress.totalCount} varer krysset av
+                  {displayProgress.checkedCount}/{displayProgress.totalCount}{" "}
+                  varer krysset av
                 </p>
               </div>
             </div>
@@ -340,14 +379,29 @@ export default function FamilyMealPlanStoreModeRoute({
           </section>
         ) : null}
 
-        {actionData?.formError || toggleFormError ? (
+        {syncBannerMessage ? (
+          <section
+            className={
+              syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
+                ? "rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm"
+                : "rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm"
+            }
+          >
+            <h2 className="text-base font-semibold">
+              {syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
+                ? "Synkroniserer"
+                : "Kunne ikke synkronisere"}
+            </h2>
+            <p className="mt-2 text-sm leading-6">{syncBannerMessage}</p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
           <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
             <h2 className="text-base font-semibold">
               Kunne ikke oppdatere butikkmodus
             </h2>
-            <p className="mt-2 text-sm leading-6">
-              {actionData?.formError ?? toggleFormError}
-            </p>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
           </section>
         ) : null}
 
@@ -446,9 +500,9 @@ export default function FamilyMealPlanStoreModeRoute({
           </article>
         </section>
 
-        {loaderData.dueSectionGroups.length > 0 ? (
+        {displaySectionGroups.length > 0 ? (
           <section className="grid gap-4">
-            {loaderData.dueSectionGroups.map((section) => (
+            {displaySectionGroups.map((section) => (
               <article
                 key={`${loaderData.selectedStore?.id ?? "no-store"}:${section.category.id}`}
                 className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
@@ -464,11 +518,6 @@ export default function FamilyMealPlanStoreModeRoute({
 
                 <div className="mt-4 grid gap-3">
                   {section.items.map((item) => {
-                    const isPendingToggle =
-                      toggleFetcher.state !== "idle" &&
-                      toggleFetcher.formData?.get("intent") ===
-                        "toggle-shopping-item-checked" &&
-                      pendingSourceKey === item.sourceKey;
                     const quantityBadge = formatGeneratedQuantityBadge(item);
                     const recipeAttribution =
                       item.sourceType === "GENERATED"
@@ -480,37 +529,7 @@ export default function FamilyMealPlanStoreModeRoute({
                         : null;
 
                     return (
-                      <toggleFetcher.Form
-                        key={item.sourceKey}
-                        className="block"
-                        method="post"
-                        preventScrollReset
-                      >
-                        <input
-                          name="intent"
-                          type="hidden"
-                          value="toggle-shopping-item-checked"
-                        />
-                        <input
-                          name="sourceKey"
-                          type="hidden"
-                          value={item.sourceKey}
-                        />
-                        <input
-                          name="sourceType"
-                          type="hidden"
-                          value={item.sourceType}
-                        />
-                        <input
-                          name="checked"
-                          type="hidden"
-                          value={item.checked ? "false" : "true"}
-                        />
-                        <input
-                          name="expectedUpdatedAt"
-                          type="hidden"
-                          value={getToggleExpectedVersion(item)}
-                        />
+                      <div key={item.sourceKey} className="block">
                         <button
                           aria-label={
                             item.checked
@@ -520,11 +539,11 @@ export default function FamilyMealPlanStoreModeRoute({
                           aria-pressed={item.checked}
                           className={
                             item.checked
-                              ? "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-emerald-200 bg-emerald-50 p-4 text-left transition hover:bg-emerald-100 active:bg-emerald-200 disabled:cursor-not-allowed disabled:opacity-70"
-                              : "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-slate-200 bg-slate-50 p-4 text-left transition hover:bg-slate-100 active:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-70"
+                              ? "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-emerald-200 bg-emerald-50 p-4 text-left transition hover:bg-emerald-100 active:bg-emerald-200"
+                              : "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-slate-200 bg-slate-50 p-4 text-left transition hover:bg-slate-100 active:bg-slate-200"
                           }
-                          disabled={isPendingToggle}
-                          type="submit"
+                          onClick={() => handleToggle(item)}
+                          type="button"
                         >
                           <span
                             aria-hidden="true"
@@ -599,7 +618,7 @@ export default function FamilyMealPlanStoreModeRoute({
                             ) : null}
                           </span>
                         </button>
-                      </toggleFetcher.Form>
+                      </div>
                     );
                   })}
                 </div>
@@ -789,20 +808,6 @@ function parseShoppingItemSource(value: FormDataEntryValue | null) {
   return null;
 }
 
-function getPendingSourceKey(formData: FormData | undefined) {
-  if (!formData) {
-    return null;
-  }
-
-  const sourceKey = formData.get("sourceKey");
-
-  if (typeof sourceKey === "string" && sourceKey.trim()) {
-    return sourceKey;
-  }
-
-  return null;
-}
-
 function buildMealPlanNotFoundResponse() {
   return new Response("Fant ikke ukeplanen.", {
     status: 404,
@@ -819,18 +824,6 @@ function requireRouteParam(value: string | undefined, message: string) {
   }
 
   return value;
-}
-
-function getToggleExpectedVersion(item: {
-  collaborationVersion: string;
-  overrideVersion?: string;
-  sourceType: ShoppingItemSource;
-}) {
-  if (item.sourceType === ShoppingItemSource.MANUAL) {
-    return item.overrideVersion ?? "";
-  }
-
-  return item.collaborationVersion;
 }
 
 function formatDateOnly(date: Date) {


### PR DESCRIPTION
## Summary
- Store mode check/uncheck updates immediately and persists a per-trip queue in `localStorage` (scoped by family, meal plan, and active shopping date).
- Background sync drains the queue via the existing `toggle-shopping-item-checked` action; loader revalidates when the queue is empty.
- Sync banner appears only after 800ms so fast connections stay quiet; fixed unstable fetcher deps that caused POST/GET loops on page load.

## Related issue
Closes #78

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual: tick items on fast Wi‑Fi (no banner flash), throttle/offline tick + reload + reconnect, confirm server state matches

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (221 tests)
- npm run typecheck