### PR TITLE
Store mode shopping list: optional grid view

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,34 @@
 
 ## Current Objective
 
-Issue #78 — store mode optimistic check-off with localStorage sync; branch `issue/78-store-mode-offline-sync`, ready for PR.
+Issue #80 — store mode optional grid view for due shopping items; branch `issue/80-store-mode-grid-view`, ready for PR.
 
 ## Completed
 
-- Client queue module (`shopping-store-mode-client.ts`) with localStorage persistence, merge, reconcile, and progress helpers.
-- `useStoreModeToggleSync` hook: optimistic toggles, serial background sync, delayed sync banner (800ms), stable fetcher refs to avoid request loops.
-- Store mode route uses button toggles (always interactive), merged progress/sections, separate sync vs form error banners.
-- Shared `getToggleExpectedVersion` moved to client module; shopping route imports it.
-- Unit tests for queue client (9 tests).
+- View preference helpers in `shopping-store-mode-client.ts` (`list` | `grid`, localStorage per family/meal plan).
+- `StoreModeShoppingViewToggle` segmented control (Liste / Rutenett) with radiogroup a11y.
+- `StoreModeShoppingItemCard` shared item UI for list and grid layouts.
+- Store mode route: header + toggle above due sections; responsive grid within section groups; preference persists across reload.
+- Unit tests for view storage (13 tests in shopping-store-mode-client suite).
 
 ## Files To Read First
 
-- `app/lib/use-store-mode-toggle-sync.ts` — queue drain, revalidate when queue empty, loop fixes
-- `app/lib/shopping-store-mode-client.ts` — storage key, reconcile, merge
-- `app/routes/family-meal-plan-store-mode.tsx` — UI wiring and banners
+- `app/routes/family-meal-plan-store-mode.tsx` — view state, section layouts, toggle placement
+- `app/components/store-mode-shopping-item-card.tsx` — list vs grid card markup
+- `app/lib/shopping-store-mode-client.ts` — view storage key read/write
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 221 tests passed (40 files)
+- `npm run test:run` — 225 tests passed (40 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke: fast connection (no sync banner flash), offline tick + reload + reconnect, stale localStorage queue clears after sync.
+- Manual smoke: toggle list/grid, reload persistence, check-off in grid, empty due list hides toggle, narrow viewport tap targets.
 
 ## Next Step
 
-Merge PR when CI is green; closes #78.
+Merge PR when CI is green; closes #80.

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -1,0 +1,187 @@
+import {
+  formatGeneratedOccurrenceAttribution,
+  formatGeneratedQuantityBadge,
+} from "../lib/shopping-display";
+import type { StoreModeShoppingView } from "../lib/shopping-store-mode-client";
+
+interface StoreModeShoppingItemCardBase {
+  checked: boolean;
+  name: string;
+  note: string | null;
+  preferredStore: {
+    id: string;
+    name: string;
+  } | null;
+  quantityLabel: string | null;
+  sourceKey: string;
+}
+
+interface StoreModeShoppingItemCardGenerated
+  extends StoreModeShoppingItemCardBase {
+  lastDate: string;
+  occurrenceCount: number;
+  occurrences: Array<{ date: string; recipeTitle: string }>;
+  postponedUntilDate: string | null;
+  preferredStoreConflict: boolean;
+  sourceType: "GENERATED";
+}
+
+interface StoreModeShoppingItemCardManual extends StoreModeShoppingItemCardBase {
+  buyOnDate: string | null;
+  sourceType: "MANUAL";
+}
+
+export type StoreModeShoppingItemCardItem =
+  | StoreModeShoppingItemCardGenerated
+  | StoreModeShoppingItemCardManual;
+
+interface StoreModeShoppingItemCardProps {
+  item: StoreModeShoppingItemCardItem;
+  layout: StoreModeShoppingView;
+  onToggle: () => void;
+  selectedStoreId: string | undefined;
+}
+
+export function StoreModeShoppingItemCard({
+  item,
+  layout,
+  onToggle,
+  selectedStoreId,
+}: StoreModeShoppingItemCardProps) {
+  const quantityBadge = formatGeneratedQuantityBadge(item);
+  const recipeAttribution =
+    item.sourceType === "GENERATED"
+      ? item.occurrenceCount === 1
+        ? (item.occurrences[0]?.recipeTitle ?? null)
+        : formatGeneratedOccurrenceAttribution(item.occurrences)
+      : null;
+  const isGrid = layout === "grid";
+
+  const checkedButtonClass = item.checked
+    ? isGrid
+      ? "flex h-full min-h-[44px] w-full cursor-pointer touch-manipulation flex-col gap-3 rounded-[20px] border border-emerald-200 bg-emerald-50 p-3 text-left transition hover:bg-emerald-100 active:bg-emerald-200"
+      : "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-emerald-200 bg-emerald-50 p-4 text-left transition hover:bg-emerald-100 active:bg-emerald-200"
+    : isGrid
+      ? "flex h-full min-h-[44px] w-full cursor-pointer touch-manipulation flex-col gap-3 rounded-[20px] border border-slate-200 bg-slate-50 p-3 text-left transition hover:bg-slate-100 active:bg-slate-200"
+      : "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-slate-200 bg-slate-50 p-4 text-left transition hover:bg-slate-100 active:bg-slate-200";
+
+  const checkIndicatorClass = item.checked
+    ? isGrid
+      ? "flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-base font-semibold text-white"
+      : "flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-lg font-semibold text-white"
+    : isGrid
+      ? "flex h-10 w-10 shrink-0 items-center justify-center rounded-full border-2 border-slate-300 bg-white text-base font-semibold text-slate-400"
+      : "flex h-12 w-12 shrink-0 items-center justify-center rounded-full border-2 border-slate-300 bg-white text-lg font-semibold text-slate-400";
+
+  const details = (
+    <span className="min-w-0 flex-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <span
+            className={
+              isGrid
+                ? "text-sm font-semibold text-slate-950"
+                : "text-base font-semibold text-slate-950"
+            }
+          >
+            {item.name}
+          </span>
+          {quantityBadge ? (
+            <span
+              className={
+                item.sourceType === "GENERATED" &&
+                !item.quantityLabel &&
+                item.occurrenceCount > 1
+                  ? "rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800"
+                  : "rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+              }
+            >
+              {quantityBadge}
+            </span>
+          ) : null}
+          {item.sourceType === "MANUAL" ? (
+            <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">
+              Manuell
+            </span>
+          ) : null}
+          {item.sourceType === "GENERATED" && item.preferredStoreConflict ? (
+            <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+              Ulike foretrukne butikker
+            </span>
+          ) : null}
+          {item.preferredStore && item.preferredStore.id !== selectedStoreId ? (
+            <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
+              Foretrekker {item.preferredStore.name}
+            </span>
+          ) : null}
+        </span>
+
+        <span
+          className={
+            isGrid
+              ? "mt-2 block text-xs leading-5 text-slate-600"
+              : "mt-2 block text-sm leading-6 text-slate-600"
+          }
+        >
+          {item.sourceType === "GENERATED"
+            ? item.occurrenceCount === 1
+              ? `Fra ${recipeAttribution} fram til ${formatDateLabel(item.lastDate)}.`
+              : `Brukt i ${recipeAttribution}.`
+            : item.buyOnDate
+              ? `Manuell vare planlagt for ${formatDateLabel(item.buyOnDate)}.`
+              : "Manuell vare uten spesifikk handledato."}
+        </span>
+
+        {item.note ? (
+          <span
+            className={
+              isGrid
+                ? "mt-2 block text-xs leading-5 text-slate-700"
+                : "mt-2 block text-sm leading-6 text-slate-700"
+            }
+          >
+            Notat: {item.note}
+          </span>
+        ) : null}
+        {item.sourceType === "GENERATED" && item.postponedUntilDate ? (
+          <span
+            className={
+              isGrid
+                ? "mt-2 block text-xs leading-5 text-amber-800"
+                : "mt-2 block text-sm leading-6 text-amber-800"
+            }
+          >
+            Utsatt til {formatDateLabel(item.postponedUntilDate)}.
+          </span>
+        ) : null}
+    </span>
+  );
+
+  return (
+    <div className="block h-full">
+      <button
+        aria-label={
+          item.checked
+            ? `Marker ${item.name} som ikke handlet`
+            : `Marker ${item.name} som handlet`
+        }
+        aria-pressed={item.checked}
+        className={checkedButtonClass}
+        onClick={onToggle}
+        type="button"
+      >
+        <span aria-hidden="true" className={checkIndicatorClass}>
+          {item.checked ? "✓" : ""}
+        </span>
+        {details}
+      </button>
+    </div>
+  );
+}
+
+function formatDateLabel(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00.000Z`));
+}

--- a/app/components/store-mode-shopping-view-toggle.tsx
+++ b/app/components/store-mode-shopping-view-toggle.tsx
@@ -1,0 +1,46 @@
+import type { StoreModeShoppingView } from "../lib/shopping-store-mode-client";
+
+interface StoreModeShoppingViewToggleProps {
+  onChange: (view: StoreModeShoppingView) => void;
+  view: StoreModeShoppingView;
+}
+
+export function StoreModeShoppingViewToggle({
+  onChange,
+  view,
+}: StoreModeShoppingViewToggleProps) {
+  return (
+    <div
+      aria-label="Visning av handleliste"
+      className="inline-flex rounded-2xl bg-slate-100 p-1 ring-1 ring-slate-200"
+      role="radiogroup"
+    >
+      <button
+        aria-checked={view === "list"}
+        className={
+          view === "list"
+            ? "rounded-xl bg-white px-4 py-2 text-sm font-medium text-slate-950 shadow-sm ring-1 ring-slate-200"
+            : "rounded-xl px-4 py-2 text-sm font-medium text-slate-600 transition hover:text-slate-950"
+        }
+        onClick={() => onChange("list")}
+        role="radio"
+        type="button"
+      >
+        Liste
+      </button>
+      <button
+        aria-checked={view === "grid"}
+        className={
+          view === "grid"
+            ? "rounded-xl bg-white px-4 py-2 text-sm font-medium text-slate-950 shadow-sm ring-1 ring-slate-200"
+            : "rounded-xl px-4 py-2 text-sm font-medium text-slate-600 transition hover:text-slate-950"
+        }
+        onClick={() => onChange("grid")}
+        role="radio"
+        type="button"
+      >
+        Rutenett
+      </button>
+    </div>
+  );
+}

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -7,11 +7,14 @@ import {
   applyToggleOpsToItems,
   areToggleQueuesEqual,
   buildStoreModeQueueStorageKey,
+  buildStoreModeViewStorageKey,
   computeStoreModeProgress,
+  readStoreModeShoppingView,
   readStoreModeToggleQueue,
   reconcileToggleQueue,
   removeToggleOp,
   upsertToggleOp,
+  writeStoreModeShoppingView,
   writeStoreModeToggleQueue,
 } from "./shopping-store-mode-client";
 
@@ -175,5 +178,50 @@ describe("shopping-store-mode-client", () => {
     window.localStorage.setItem(storageKey, "{not-an-array");
 
     expect(readStoreModeToggleQueue(storageKey)).toEqual([]);
+  });
+
+  it("builds isolated view storage keys per meal plan", () => {
+    expect(
+      buildStoreModeViewStorageKey({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      }),
+    ).not.toBe(
+      buildStoreModeViewStorageKey({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-2",
+      }),
+    );
+  });
+
+  it("defaults shopping view to list", () => {
+    const viewStorageKey = buildStoreModeViewStorageKey({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+    });
+
+    expect(readStoreModeShoppingView(viewStorageKey)).toBe("list");
+  });
+
+  it("persists and reads shopping view preference", () => {
+    const viewStorageKey = buildStoreModeViewStorageKey({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+    });
+
+    writeStoreModeShoppingView(viewStorageKey, "grid");
+
+    expect(readStoreModeShoppingView(viewStorageKey)).toBe("grid");
+  });
+
+  it("falls back to list for invalid stored shopping views", () => {
+    const viewStorageKey = buildStoreModeViewStorageKey({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+    });
+
+    window.localStorage.setItem(viewStorageKey, "table");
+
+    expect(readStoreModeShoppingView(viewStorageKey)).toBe("list");
   });
 });

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -20,7 +20,55 @@ export interface StoreModeProgress {
   totalCount: number;
 }
 
+export type StoreModeShoppingView = "list" | "grid";
+
 const STORE_MODE_QUEUE_KEY_PREFIX = "mealplanner:store-mode-queue:v1";
+const STORE_MODE_VIEW_KEY_PREFIX = "mealplanner:store-mode-view:v1";
+
+export function buildStoreModeViewStorageKey({
+  familyId,
+  mealPlanId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+}) {
+  return `${STORE_MODE_VIEW_KEY_PREFIX}:${familyId}:${mealPlanId}`;
+}
+
+export function readStoreModeShoppingView(
+  storageKey: string,
+): StoreModeShoppingView {
+  if (typeof window === "undefined") {
+    return "list";
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+
+    if (raw === "grid" || raw === "list") {
+      return raw;
+    }
+
+    return "list";
+  } catch {
+    return "list";
+  }
+}
+
+export function writeStoreModeShoppingView(
+  storageKey: string,
+  view: StoreModeShoppingView,
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(storageKey, view);
+  } catch {
+    // Private mode or quota exceeded — in-session state still works.
+  }
+}
 
 export function buildStoreModeQueueStorageKey({
   activeShoppingDate,

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1,6 +1,6 @@
 import { ShoppingItemSource } from "@prisma/client";
 import type { ChangeEvent } from "react";
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Form,
   Link,
@@ -12,12 +12,16 @@ import {
   type MetaFunction,
 } from "react-router";
 
+import { StoreModeShoppingItemCard } from "../components/store-mode-shopping-item-card";
+import { StoreModeShoppingViewToggle } from "../components/store-mode-shopping-view-toggle";
 import { requireUser } from "../lib/auth.server";
 import {
-  formatGeneratedOccurrenceAttribution,
-  formatGeneratedQuantityBadge,
-} from "../lib/shopping-display";
-import { computeStoreModeProgress } from "../lib/shopping-store-mode-client";
+  buildStoreModeViewStorageKey,
+  computeStoreModeProgress,
+  readStoreModeShoppingView,
+  type StoreModeShoppingView,
+  writeStoreModeShoppingView,
+} from "../lib/shopping-store-mode-client";
 import { getMealPlanStoreModeData } from "../lib/shopping.server";
 import {
   toggleShoppingItemChecked,
@@ -298,6 +302,27 @@ export default function FamilyMealPlanStoreModeRoute({
       })),
     [displayItemsBySourceKey, loaderData.dueSectionGroups],
   );
+  const viewStorageKey = useMemo(
+    () =>
+      buildStoreModeViewStorageKey({
+        familyId: loaderData.family.id,
+        mealPlanId: loaderData.mealPlan.id,
+      }),
+    [loaderData.family.id, loaderData.mealPlan.id],
+  );
+  const [shoppingView, setShoppingView] = useState<StoreModeShoppingView>(
+    () => readStoreModeShoppingView(viewStorageKey),
+  );
+  const handleShoppingViewChange = useCallback(
+    (nextView: StoreModeShoppingView) => {
+      setShoppingView(nextView);
+      writeStoreModeShoppingView(viewStorageKey, nextView);
+    },
+    [viewStorageKey],
+  );
+  useEffect(() => {
+    setShoppingView(readStoreModeShoppingView(viewStorageKey));
+  }, [viewStorageKey]);
   const noticeContent = loaderData.notice
     ? getStoreModeNoticeContent(loaderData.notice)
     : null;
@@ -502,6 +527,15 @@ export default function FamilyMealPlanStoreModeRoute({
 
         {displaySectionGroups.length > 0 ? (
           <section className="grid gap-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-lg font-semibold text-slate-950">
+                Varer å handle
+              </h2>
+              <StoreModeShoppingViewToggle
+                onChange={handleShoppingViewChange}
+                view={shoppingView}
+              />
+            </div>
             {displaySectionGroups.map((section) => (
               <article
                 key={`${loaderData.selectedStore?.id ?? "no-store"}:${section.category.id}`}
@@ -516,111 +550,22 @@ export default function FamilyMealPlanStoreModeRoute({
                   </span>
                 </div>
 
-                <div className="mt-4 grid gap-3">
-                  {section.items.map((item) => {
-                    const quantityBadge = formatGeneratedQuantityBadge(item);
-                    const recipeAttribution =
-                      item.sourceType === "GENERATED"
-                        ? item.occurrenceCount === 1
-                          ? (item.occurrences[0]?.recipeTitle ?? null)
-                          : formatGeneratedOccurrenceAttribution(
-                              item.occurrences,
-                            )
-                        : null;
-
-                    return (
-                      <div key={item.sourceKey} className="block">
-                        <button
-                          aria-label={
-                            item.checked
-                              ? `Marker ${item.name} som ikke handlet`
-                              : `Marker ${item.name} som handlet`
-                          }
-                          aria-pressed={item.checked}
-                          className={
-                            item.checked
-                              ? "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-emerald-200 bg-emerald-50 p-4 text-left transition hover:bg-emerald-100 active:bg-emerald-200"
-                              : "flex w-full cursor-pointer touch-manipulation items-start gap-4 rounded-[24px] border border-slate-200 bg-slate-50 p-4 text-left transition hover:bg-slate-100 active:bg-slate-200"
-                          }
-                          onClick={() => handleToggle(item)}
-                          type="button"
-                        >
-                          <span
-                            aria-hidden="true"
-                            className={
-                              item.checked
-                                ? "flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-emerald-500 text-lg font-semibold text-white"
-                                : "flex h-12 w-12 shrink-0 items-center justify-center rounded-full border-2 border-slate-300 bg-white text-lg font-semibold text-slate-400"
-                            }
-                          >
-                            {item.checked ? "✓" : ""}
-                          </span>
-
-                          <span className="min-w-0 flex-1">
-                            <span className="flex flex-wrap items-center gap-2">
-                              <span className="text-base font-semibold text-slate-950">
-                                {item.name}
-                              </span>
-                              {quantityBadge ? (
-                                <span
-                                  className={
-                                    item.sourceType === "GENERATED" &&
-                                    !item.quantityLabel &&
-                                    item.occurrenceCount > 1
-                                      ? "rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800"
-                                      : "rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
-                                  }
-                                >
-                                  {quantityBadge}
-                                </span>
-                              ) : null}
-                              {item.sourceType === "MANUAL" ? (
-                                <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700">
-                                  Manuell
-                                </span>
-                              ) : null}
-                              {item.sourceType === "GENERATED" &&
-                              item.preferredStoreConflict ? (
-                                <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
-                                  Ulike foretrukne butikker
-                                </span>
-                              ) : null}
-                              {item.preferredStore &&
-                              item.preferredStore.id !==
-                                loaderData.selectedStore?.id ? (
-                                <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
-                                  Foretrekker {item.preferredStore.name}
-                                </span>
-                              ) : null}
-                            </span>
-
-                            <span className="mt-2 block text-sm leading-6 text-slate-600">
-                              {item.sourceType === "GENERATED"
-                                ? item.occurrenceCount === 1
-                                  ? `Fra ${recipeAttribution} fram til ${formatDateLabel(item.lastDate)}.`
-                                  : `Brukt i ${recipeAttribution}.`
-                                : item.buyOnDate
-                                  ? `Manuell vare planlagt for ${formatDateLabel(item.buyOnDate)}.`
-                                  : "Manuell vare uten spesifikk handledato."}
-                            </span>
-
-                            {item.note ? (
-                              <span className="mt-2 block text-sm leading-6 text-slate-700">
-                                Notat: {item.note}
-                              </span>
-                            ) : null}
-                            {item.sourceType === "GENERATED" &&
-                            item.postponedUntilDate ? (
-                              <span className="mt-2 block text-sm leading-6 text-amber-800">
-                                Utsatt til{" "}
-                                {formatDateLabel(item.postponedUntilDate)}.
-                              </span>
-                            ) : null}
-                          </span>
-                        </button>
-                      </div>
-                    );
-                  })}
+                <div
+                  className={
+                    shoppingView === "grid"
+                      ? "mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4"
+                      : "mt-4 flex flex-col gap-3"
+                  }
+                >
+                  {section.items.map((item) => (
+                    <StoreModeShoppingItemCard
+                      key={item.sourceKey}
+                      item={item}
+                      layout={shoppingView}
+                      onToggle={() => handleToggle(item)}
+                      selectedStoreId={loaderData.selectedStore?.id}
+                    />
+                  ))}
                 </div>
               </article>
             ))}


### PR DESCRIPTION
## Summary
- Add a Liste / Rutenett toggle on the store mode due-items list so shoppers can switch between the existing list layout and a denser multi-column grid within each store section.
- Persist view preference in localStorage per family and meal plan; extract shared item card and view toggle components.

## Related issue
Closes #80

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: toggle list ↔ grid and reload to confirm persistence
- [ ] Manual: check/uncheck items in grid view; progress and sync banner unchanged
- [ ] Manual: empty due list hides toggle; narrow viewport keeps tappable cards

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (225 tests)
- npm run typecheck