### PR TITLE
Store mode: move bought items to bottom section

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,34 @@
 
 ## Current Objective
 
-Issue #82 — compact store mode shopping cards with collapsible attribution; branch `issue/82-compact-store-mode-details`, ready for PR.
+Issue #84 — store mode preference to move checked items to a bottom **Kjøpt** section; branch `issue/84-deprioritize-bought-items`, ready for PR.
 
 ## Completed
 
-- Restructured `StoreModeShoppingItemCard`: whole-card tap toggles handled state (no checkbox); red tint + strikethrough when checked.
-- Attribution, notes, and postponed copy behind `<details>` with bottom-left info icon (opens panel upward).
-- Removed «Manuell» badge; tightened padding, typography, badges, and list/grid gaps for denser cards.
-- Store mode route: item list/grid gap `gap-3` → `gap-2`.
+- Added `partitionStoreModeSections` and localStorage preference (`read`/`write` deprioritize bought) in `shopping-store-mode-client.ts`.
+- New `StoreModeDeprioritizeBoughtToggle` (“Flytt kjøpte varer til bunnen”) beside list/grid controls in store mode.
+- Route partitions active aisle sections vs flat **Kjøpt** block; empty-state when all items checked with preference on.
+- Narrowed store mode card `<details>` to `w-fit` so the info control does not span full card width.
 
 ## Files To Read First
 
-- `app/components/store-mode-shopping-item-card.tsx` — card layout, toggle overlay, details disclosure
-- `app/routes/family-meal-plan-store-mode.tsx` — grid/list gap between cards
+- `app/lib/shopping-store-mode-client.ts` — preference storage and section partitioning
+- `app/routes/family-meal-plan-store-mode.tsx` — UI wiring, `StoreModeItemGrid`
+- `app/components/store-mode-deprioritize-bought-toggle.tsx` — preference toggle
+- `app/components/store-mode-shopping-item-card.tsx` — card layout and details width
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 225 tests passed (40 files)
+- `npm run test:run` — 231 tests passed (40 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke: tap card to check/uncheck; info icon does not toggle; details auto-open for note/postpone/conflict; list + grid on narrow viewport.
+- Manual smoke: toggle preference persists; check/uncheck moves items between aisles and **Kjøpt**; list + grid layouts.
 
 ## Next Step
 
-Merge PR when CI is green; closes #82.
+Merge PR when CI is green; closes #84.

--- a/app/components/store-mode-deprioritize-bought-toggle.tsx
+++ b/app/components/store-mode-deprioritize-bought-toggle.tsx
@@ -1,0 +1,24 @@
+interface StoreModeDeprioritizeBoughtToggleProps {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}
+
+export function StoreModeDeprioritizeBoughtToggle({
+  enabled,
+  onChange,
+}: StoreModeDeprioritizeBoughtToggleProps) {
+  return (
+    <button
+      aria-pressed={enabled}
+      className={
+        enabled
+          ? "rounded-2xl bg-white px-4 py-2 text-sm font-medium text-slate-950 shadow-sm ring-1 ring-slate-200"
+          : "rounded-2xl bg-slate-100 px-4 py-2 text-sm font-medium text-slate-600 ring-1 ring-slate-200 transition hover:text-slate-950"
+      }
+      onClick={() => onChange(!enabled)}
+      type="button"
+    >
+      Flytt kjøpte varer til bunnen
+    </button>
+  );
+}

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -41,8 +41,7 @@ interface StoreModeShoppingItemCardProps {
   selectedStoreId: string | undefined;
 }
 
-const badgeClass =
-  "rounded-full px-2 py-0.5 text-[11px] font-medium leading-4";
+const badgeClass = "rounded-full px-2 py-0.5 text-[11px] font-medium leading-4";
 
 export function StoreModeShoppingItemCard({
   item,
@@ -111,7 +110,7 @@ export function StoreModeShoppingItemCard({
         </div>
 
         <details
-          className="group mt-auto flex shrink-0 flex-col-reverse items-start pointer-events-auto"
+          className="group mt-auto w-fit self-start flex flex-col-reverse items-start pointer-events-auto"
           open={shouldAutoOpenDetails}
         >
           <summary
@@ -122,7 +121,7 @@ export function StoreModeShoppingItemCard({
             <span className="sr-only">Vis informasjon</span>
           </summary>
           <div
-            className="mb-1 w-full space-y-1 border-b border-slate-200 pb-1.5 pointer-events-auto"
+            className="mb-1 w-max max-w-full space-y-1 border-b border-slate-200 pb-1.5 pointer-events-auto"
             onClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => event.stopPropagation()}
           >

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -6,14 +6,18 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   applyToggleOpsToItems,
   areToggleQueuesEqual,
+  buildStoreModeDeprioritizeBoughtStorageKey,
   buildStoreModeQueueStorageKey,
   buildStoreModeViewStorageKey,
   computeStoreModeProgress,
+  partitionStoreModeSections,
+  readStoreModeDeprioritizeBought,
   readStoreModeShoppingView,
   readStoreModeToggleQueue,
   reconcileToggleQueue,
   removeToggleOp,
   upsertToggleOp,
+  writeStoreModeDeprioritizeBought,
   writeStoreModeShoppingView,
   writeStoreModeToggleQueue,
 } from "./shopping-store-mode-client";
@@ -223,5 +227,96 @@ describe("shopping-store-mode-client", () => {
     window.localStorage.setItem(viewStorageKey, "table");
 
     expect(readStoreModeShoppingView(viewStorageKey)).toBe("list");
+  });
+
+  it("builds isolated deprioritize-bought storage keys per meal plan", () => {
+    expect(
+      buildStoreModeDeprioritizeBoughtStorageKey({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      }),
+    ).not.toBe(
+      buildStoreModeDeprioritizeBoughtStorageKey({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-2",
+      }),
+    );
+  });
+
+  it("defaults deprioritize-bought preference to false", () => {
+    const storageKey = buildStoreModeDeprioritizeBoughtStorageKey({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+    });
+
+    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(false);
+  });
+
+  it("persists and reads deprioritize-bought preference", () => {
+    const storageKey = buildStoreModeDeprioritizeBoughtStorageKey({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+    });
+
+    writeStoreModeDeprioritizeBought(storageKey, true);
+
+    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(true);
+  });
+
+  it("falls back to false for invalid stored deprioritize-bought values", () => {
+    const storageKey = buildStoreModeDeprioritizeBoughtStorageKey({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+    });
+
+    window.localStorage.setItem(storageKey, "yes");
+
+    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(false);
+  });
+
+  it("returns sections unchanged when deprioritize-bought is off", () => {
+    const sections = [
+      {
+        displayName: "Produce",
+        items: [
+          { checked: true, id: "a" },
+          { checked: false, id: "b" },
+        ],
+      },
+    ];
+
+    expect(partitionStoreModeSections(sections, false)).toEqual({
+      activeSections: sections,
+      boughtItems: [],
+    });
+  });
+
+  it("partitions unchecked into active sections and checked into bought items", () => {
+    const sections = [
+      {
+        displayName: "Produce",
+        items: [
+          { checked: true, id: "a" },
+          { checked: false, id: "b" },
+        ],
+      },
+      {
+        displayName: "Dairy",
+        items: [{ checked: true, id: "c" }],
+      },
+    ];
+
+    expect(partitionStoreModeSections(sections, true)).toEqual({
+      activeSections: [
+        {
+          displayName: "Produce",
+          items: [{ checked: false, id: "b" }],
+        },
+      ],
+      boughtItems: [
+        { checked: true, id: "a" },
+        { checked: true, id: "c" },
+      ],
+    });
   });
 });

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -24,6 +24,8 @@ export type StoreModeShoppingView = "list" | "grid";
 
 const STORE_MODE_QUEUE_KEY_PREFIX = "mealplanner:store-mode-queue:v1";
 const STORE_MODE_VIEW_KEY_PREFIX = "mealplanner:store-mode-view:v1";
+const STORE_MODE_DEPRIORITIZE_BOUGHT_KEY_PREFIX =
+  "mealplanner:store-mode-deprioritize-bought:v1";
 
 export function buildStoreModeViewStorageKey({
   familyId,
@@ -68,6 +70,94 @@ export function writeStoreModeShoppingView(
   } catch {
     // Private mode or quota exceeded — in-session state still works.
   }
+}
+
+export function buildStoreModeDeprioritizeBoughtStorageKey({
+  familyId,
+  mealPlanId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+}) {
+  return `${STORE_MODE_DEPRIORITIZE_BOUGHT_KEY_PREFIX}:${familyId}:${mealPlanId}`;
+}
+
+export function readStoreModeDeprioritizeBought(storageKey: string): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+
+    if (raw === "true") {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function writeStoreModeDeprioritizeBought(
+  storageKey: string,
+  enabled: boolean,
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(storageKey, enabled ? "true" : "false");
+  } catch {
+    // Private mode or quota exceeded — in-session state still works.
+  }
+}
+
+export function partitionStoreModeSections<
+  TItem extends { checked: boolean },
+  TSection extends { items: TItem[] },
+>(
+  sections: TSection[],
+  deprioritizeBought: boolean,
+): { activeSections: TSection[]; boughtItems: TItem[] } {
+  if (!deprioritizeBought) {
+    return {
+      activeSections: sections,
+      boughtItems: [],
+    };
+  }
+
+  const activeSections: TSection[] = [];
+  const boughtItems: TItem[] = [];
+
+  for (const section of sections) {
+    const uncheckedItems: TItem[] = [];
+    const checkedItems: TItem[] = [];
+
+    for (const item of section.items) {
+      if (item.checked) {
+        checkedItems.push(item);
+      } else {
+        uncheckedItems.push(item);
+      }
+    }
+
+    if (uncheckedItems.length > 0) {
+      activeSections.push({
+        ...section,
+        items: uncheckedItems,
+      });
+    }
+
+    boughtItems.push(...checkedItems);
+  }
+
+  return {
+    activeSections,
+    boughtItems,
+  };
 }
 
 export function buildStoreModeQueueStorageKey({

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1,5 +1,5 @@
 import { ShoppingItemSource } from "@prisma/client";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, ComponentProps } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Form,
@@ -12,14 +12,19 @@ import {
   type MetaFunction,
 } from "react-router";
 
+import { StoreModeDeprioritizeBoughtToggle } from "../components/store-mode-deprioritize-bought-toggle";
 import { StoreModeShoppingItemCard } from "../components/store-mode-shopping-item-card";
 import { StoreModeShoppingViewToggle } from "../components/store-mode-shopping-view-toggle";
 import { requireUser } from "../lib/auth.server";
 import {
+  buildStoreModeDeprioritizeBoughtStorageKey,
   buildStoreModeViewStorageKey,
   computeStoreModeProgress,
+  partitionStoreModeSections,
+  readStoreModeDeprioritizeBought,
   readStoreModeShoppingView,
   type StoreModeShoppingView,
+  writeStoreModeDeprioritizeBought,
   writeStoreModeShoppingView,
 } from "../lib/shopping-store-mode-client";
 import { getMealPlanStoreModeData } from "../lib/shopping.server";
@@ -310,8 +315,19 @@ export default function FamilyMealPlanStoreModeRoute({
       }),
     [loaderData.family.id, loaderData.mealPlan.id],
   );
+  const deprioritizeBoughtStorageKey = useMemo(
+    () =>
+      buildStoreModeDeprioritizeBoughtStorageKey({
+        familyId: loaderData.family.id,
+        mealPlanId: loaderData.mealPlan.id,
+      }),
+    [loaderData.family.id, loaderData.mealPlan.id],
+  );
   const [shoppingView, setShoppingView] = useState<StoreModeShoppingView>(
     () => readStoreModeShoppingView(viewStorageKey),
+  );
+  const [deprioritizeBought, setDeprioritizeBought] = useState(() =>
+    readStoreModeDeprioritizeBought(deprioritizeBoughtStorageKey),
   );
   const handleShoppingViewChange = useCallback(
     (nextView: StoreModeShoppingView) => {
@@ -320,9 +336,30 @@ export default function FamilyMealPlanStoreModeRoute({
     },
     [viewStorageKey],
   );
+  const handleDeprioritizeBoughtChange = useCallback(
+    (enabled: boolean) => {
+      setDeprioritizeBought(enabled);
+      writeStoreModeDeprioritizeBought(deprioritizeBoughtStorageKey, enabled);
+    },
+    [deprioritizeBoughtStorageKey],
+  );
   useEffect(() => {
     setShoppingView(readStoreModeShoppingView(viewStorageKey));
   }, [viewStorageKey]);
+  useEffect(() => {
+    setDeprioritizeBought(
+      readStoreModeDeprioritizeBought(deprioritizeBoughtStorageKey),
+    );
+  }, [deprioritizeBoughtStorageKey]);
+  type StoreModeDisplayItem = (typeof displayDueItems)[number];
+  type StoreModeDisplaySection = (typeof displaySectionGroups)[number];
+  const { activeSections, boughtItems } = useMemo((): {
+    activeSections: StoreModeDisplaySection[];
+    boughtItems: StoreModeDisplayItem[];
+  } => partitionStoreModeSections(displaySectionGroups, deprioritizeBought), [
+    deprioritizeBought,
+    displaySectionGroups,
+  ]);
   const noticeContent = loaderData.notice
     ? getStoreModeNoticeContent(loaderData.notice)
     : null;
@@ -531,44 +568,68 @@ export default function FamilyMealPlanStoreModeRoute({
               <h2 className="text-lg font-semibold text-slate-950">
                 Varer å handle
               </h2>
-              <StoreModeShoppingViewToggle
-                onChange={handleShoppingViewChange}
-                view={shoppingView}
-              />
+              <div className="flex flex-wrap items-center gap-2">
+                <StoreModeDeprioritizeBoughtToggle
+                  enabled={deprioritizeBought}
+                  onChange={handleDeprioritizeBoughtChange}
+                />
+                <StoreModeShoppingViewToggle
+                  onChange={handleShoppingViewChange}
+                  view={shoppingView}
+                />
+              </div>
             </div>
-            {displaySectionGroups.map((section) => (
-              <article
-                key={`${loaderData.selectedStore?.id ?? "no-store"}:${section.category.id}`}
-                className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
-              >
+            {activeSections.length > 0 ? (
+              activeSections.map((section) => (
+                <article
+                  key={`${loaderData.selectedStore?.id ?? "no-store"}:${section.category.id}`}
+                  className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      {section.displayName}
+                    </h2>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                      {section.items.length} varer
+                    </span>
+                  </div>
+
+                  <StoreModeItemGrid
+                    items={section.items}
+                    layout={shoppingView}
+                    onToggleItem={handleToggle}
+                    selectedStoreId={loaderData.selectedStore?.id}
+                  />
+                </article>
+              ))
+            ) : deprioritizeBought ? (
+              <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+                <h3 className="text-base font-semibold text-slate-950">
+                  Alt er krysset av
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-slate-600">
+                  Du har handlet alle varene for denne turen. Kjøpte varer ligger
+                  nedenfor hvis du vil se eller endre dem.
+                </p>
+              </article>
+            ) : null}
+            {deprioritizeBought && boughtItems.length > 0 ? (
+              <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
                 <div className="flex items-center justify-between gap-3">
-                  <h2 className="text-lg font-semibold text-slate-950">
-                    {section.displayName}
-                  </h2>
+                  <h2 className="text-lg font-semibold text-slate-950">Kjøpt</h2>
                   <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
-                    {section.items.length} varer
+                    {boughtItems.length} varer
                   </span>
                 </div>
 
-                <div
-                  className={
-                    shoppingView === "grid"
-                      ? "mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4"
-                      : "mt-4 flex flex-col gap-2"
-                  }
-                >
-                  {section.items.map((item) => (
-                    <StoreModeShoppingItemCard
-                      key={item.sourceKey}
-                      item={item}
-                      layout={shoppingView}
-                      onToggle={() => handleToggle(item)}
-                      selectedStoreId={loaderData.selectedStore?.id}
-                    />
-                  ))}
-                </div>
+                <StoreModeItemGrid
+                  items={boughtItems}
+                  layout={shoppingView}
+                  onToggleItem={handleToggle}
+                  selectedStoreId={loaderData.selectedStore?.id}
+                />
               </article>
-            ))}
+            ) : null}
           </section>
         ) : (
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
@@ -722,6 +783,38 @@ function buildStoreModeRedirect({
   url.searchParams.set("notice", notice);
 
   return Response.redirect(url, 302);
+}
+
+function StoreModeItemGrid<TItem extends ComponentProps<typeof StoreModeShoppingItemCard>["item"]>({
+  items,
+  layout,
+  onToggleItem,
+  selectedStoreId,
+}: {
+  items: TItem[];
+  layout: StoreModeShoppingView;
+  onToggleItem: (item: TItem) => void;
+  selectedStoreId?: string;
+}) {
+  return (
+    <div
+      className={
+        layout === "grid"
+          ? "mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4"
+          : "mt-4 flex flex-col gap-2"
+      }
+    >
+      {items.map((item) => (
+        <StoreModeShoppingItemCard
+          key={item.sourceKey}
+          item={item}
+          layout={layout}
+          onToggle={() => onToggleItem(item)}
+          selectedStoreId={selectedStoreId}
+        />
+      ))}
+    </div>
+  );
 }
 
 function submitSelectForm(


### PR DESCRIPTION
## Summary
- Adds an optional **Flytt kjøpte varer til bunnen** preference in store mode (persisted per meal plan in localStorage).
- When enabled, unchecked items stay in aisle sections; checked items move to a **Kjøpt** block at the bottom and remain toggleable.
- Narrows the item card info `<details>` to content width so it no longer spans the full card.

## Related issue
Closes #84

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Enable preference, check items across sections → they appear in **Kjøpt**
- [ ] Uncheck from **Kjøpt** → item returns to correct aisle
- [ ] Reload page → preference persists
- [ ] List and grid layouts in active and **Kjøpt** areas

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (231 tests)
- npm run typecheck