### PR TITLE
Add family-wide shopping list (Alltid på listen)

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,34 @@
 
 ## Current Objective
 
-Issue #84 — store mode preference to move checked items to a bottom **Kjøpt** section; branch `issue/84-deprioritize-bought-items`, ready for PR.
+Issue #86 — family-wide shopping list (“Alltid på listen”) on branch `issue/86-family-shopping-list`, ready for PR merge.
 
 ## Completed
 
-- Added `partitionStoreModeSections` and localStorage preference (`read`/`write` deprioritize bought) in `shopping-store-mode-client.ts`.
-- New `StoreModeDeprioritizeBoughtToggle` (“Flytt kjøpte varer til bunnen”) beside list/grid controls in store mode.
-- Route partitions active aisle sections vs flat **Kjøpt** block; empty-state when all items checked with preference on.
-- Narrowed store mode card `<details>` to `w-fit` so the info control does not span full card width.
+- Added `FamilyShoppingItem` model and migration; checked state lives on the row (not meal-plan overrides).
+- New `/families/:familyId/shopping` route with CRUD, quick-add, and ingredient search.
+- Merged unchecked family items into meal-plan shopping (pinned section) and store mode (due items + progress).
+- Link from family hub; store mode uses separate toggle action; no badge on store mode cards (details panel only).
 
 ## Files To Read First
 
-- `app/lib/shopping-store-mode-client.ts` — preference storage and section partitioning
-- `app/routes/family-meal-plan-store-mode.tsx` — UI wiring, `StoreModeItemGrid`
-- `app/components/store-mode-deprioritize-bought-toggle.tsx` — preference toggle
-- `app/components/store-mode-shopping-item-card.tsx` — card layout and details width
+- `app/lib/family-shopping-write.server.ts` — family item mutations
+- `app/lib/shopping.server.ts` — projection, `familyStoreGroups`, store mode merge
+- `app/routes/family-shopping.tsx` — management UI
+- `app/routes/family-meal-plan-shopping.tsx` — merged “Alltid på listen” section
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 231 tests passed (40 files)
+- `npm run test:run` — 239 tests passed (42 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke: toggle preference persists; check/uncheck moves items between aisles and **Kjøpt**; list + grid layouts.
+- Manual smoke: add item on family page → appears on meal-plan shopping + store mode → check off persists across weeks.
 
 ## Next Step
 
-Merge PR when CI is green; closes #84.
+Merge PR when CI is green; closes #86.

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -15,15 +15,17 @@ interface ManualShoppingQuickAddLoaderSlice {
 
 interface ManualShoppingQuickAddProps {
   ingredientSearchPath: string;
+  quickAddIntent?: string;
   recentManualItems: RecentManualShoppingItem[];
 }
 
 const MIN_SEARCH_LENGTH = 2;
 const SEARCH_DEBOUNCE_MS = 250;
-const QUICK_ADD_INTENT = "quick-add-manual-shopping-item";
+const DEFAULT_QUICK_ADD_INTENT = "quick-add-manual-shopping-item";
 
 export function ManualShoppingQuickAdd({
   ingredientSearchPath,
+  quickAddIntent = DEFAULT_QUICK_ADD_INTENT,
   recentManualItems,
 }: ManualShoppingQuickAddProps) {
   const listboxId = useId();
@@ -41,7 +43,7 @@ export function ManualShoppingQuickAdd({
   searchFetcherRef.current = searchFetcher;
   const pendingIntent = navigation.formData?.get("intent");
   const isQuickAdding =
-    navigation.state === "submitting" && pendingIntent === QUICK_ADD_INTENT;
+    navigation.state === "submitting" && pendingIntent === quickAddIntent;
 
   const trimmedQuery = query.trim();
   const isSearching =
@@ -53,7 +55,7 @@ export function ManualShoppingQuickAdd({
     recentNameNormalized?: string;
   }) {
     const formData = new FormData();
-    formData.set("intent", QUICK_ADD_INTENT);
+    formData.set("intent", quickAddIntent);
 
     if (fields.ingredientId) {
       formData.set("ingredientId", fields.ingredientId);

--- a/app/components/shopping-list-item-expanded.tsx
+++ b/app/components/shopping-list-item-expanded.tsx
@@ -2,6 +2,10 @@ import { Form } from "react-router";
 
 import { formatOccurrenceSourceLine } from "../lib/shopping-display";
 import type {
+  FamilyShoppingItemFieldErrors,
+  FamilyShoppingItemValues,
+} from "../lib/family-shopping-write.server";
+import type {
   GeneratedShoppingItemOverrideFieldErrors,
   GeneratedShoppingItemOverrideValues,
   ManualShoppingItemFieldErrors,
@@ -16,10 +20,14 @@ type ShoppingListItemExpandedProps = {
     generatedOverrideFieldErrors?: GeneratedShoppingItemOverrideFieldErrors;
     intent?: string;
     itemTarget?: { sourceKey: string };
+    familyFieldErrors?: FamilyShoppingItemFieldErrors;
     manualFieldErrors?: ManualShoppingItemFieldErrors;
   };
   categories: Array<{ displayName: string; id: string }>;
+  familyValues?: FamilyShoppingItemValues | null;
   isPendingCheckToggle: boolean;
+  isPendingFamilyDelete?: boolean;
+  isPendingFamilySave?: boolean;
   isPendingGeneratedExclude: boolean;
   isPendingGeneratedSave: boolean;
   isPendingManualDelete: boolean;
@@ -38,11 +46,11 @@ type ShoppingListItemExpandedProps = {
       recipeTitle: string;
     }>;
     sourceKey: string;
-    sourceType: "GENERATED" | "MANUAL";
+    sourceType: "FAMILY" | "GENERATED" | "MANUAL";
   };
   manualValues: ManualShoppingItemValues | null;
-  mealPlanEndDate: string;
-  mealPlanStartDate: string;
+  mealPlanEndDate?: string;
+  mealPlanStartDate?: string;
   overrideValues: GeneratedShoppingItemOverrideValues | null;
   stores: Array<{ id: string; name: string }>;
   toggleExpectedVersion: string;
@@ -54,12 +62,15 @@ export function ShoppingListItemExpanded({
   isPendingCheckToggle,
   isPendingGeneratedExclude,
   isPendingGeneratedSave,
+  familyValues = null,
+  isPendingFamilyDelete = false,
+  isPendingFamilySave = false,
   isPendingManualDelete,
   isPendingManualSave,
   item,
   manualValues,
-  mealPlanEndDate,
-  mealPlanStartDate,
+  mealPlanEndDate = "",
+  mealPlanStartDate = "",
   overrideValues,
   stores,
   toggleExpectedVersion,
@@ -82,6 +93,16 @@ export function ShoppingListItemExpanded({
               ))}
             </ul>
           </>
+        ) : item.sourceType === "FAMILY" ? (
+          <>
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+              Alltid på listen
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-700">
+              Denne varen følger familien på tvers av ukeplaner og kan redigeres
+              eller slettes her.
+            </p>
+          </>
         ) : (
           <>
             <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
@@ -100,10 +121,16 @@ export function ShoppingListItemExpanded({
           <input
             name="intent"
             type="hidden"
-            value="toggle-shopping-item-checked"
+            value={
+              item.sourceType === "FAMILY"
+                ? "toggle-family-shopping-item-checked"
+                : "toggle-shopping-item-checked"
+            }
           />
           <input name="sourceKey" type="hidden" value={item.sourceKey} />
-          <input name="sourceType" type="hidden" value={item.sourceType} />
+          {item.sourceType !== "FAMILY" ? (
+            <input name="sourceType" type="hidden" value={item.sourceType} />
+          ) : null}
           <input
             name="checked"
             type="hidden"
@@ -382,6 +409,128 @@ export function ShoppingListItemExpanded({
                 type="submit"
               >
                 {isPendingManualDelete
+                  ? "Sletter varelinje..."
+                  : "Slett varelinje"}
+              </button>
+            </Form>
+          </>
+        ) : null}
+
+        {item.sourceType === "FAMILY" && familyValues ? (
+          <>
+            <Form className="grid min-w-0 gap-3" method="post">
+              <input
+                name="intent"
+                type="hidden"
+                value="update-family-shopping-item"
+              />
+              <input name="familyItemId" type="hidden" value={item.sourceKey} />
+              <input
+                name="expectedUpdatedAt"
+                type="hidden"
+                value={item.collaborationVersion}
+              />
+
+              <label className="block min-w-0 text-sm font-medium text-slate-700">
+                Varenavn
+                <input
+                  className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={familyValues.name}
+                  name="name"
+                  type="text"
+                />
+              </label>
+
+              <label className="block min-w-0 text-sm font-medium text-slate-700">
+                Mengde
+                <input
+                  className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={familyValues.quantity}
+                  name="quantity"
+                  type="text"
+                />
+              </label>
+
+              <div className="grid min-w-0 gap-3 sm:grid-cols-2">
+                <label className="block min-w-0 text-sm font-medium text-slate-700">
+                  Kategori
+                  <select
+                    className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={familyValues.categoryId}
+                    name="categoryId"
+                  >
+                    <option value="">Velg kategori</option>
+                    {categories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block min-w-0 text-sm font-medium text-slate-700">
+                  Foretrukket butikk
+                  <select
+                    className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                    defaultValue={familyValues.preferredStoreId}
+                    name="preferredStoreId"
+                  >
+                    <option value="">Ingen valgt butikk</option>
+                    {stores.map((store) => (
+                      <option key={store.id} value={store.id}>
+                        {store.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <label className="block min-w-0 text-sm font-medium text-slate-700">
+                Notat
+                <textarea
+                  className="mt-2 box-border min-h-24 w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  defaultValue={familyValues.note}
+                  name="note"
+                />
+              </label>
+
+              {actionData?.intent === "update-family-shopping-item" &&
+              actionData.itemTarget?.sourceKey === item.sourceKey &&
+              actionData.familyFieldErrors?.name ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.familyFieldErrors.name}
+                </p>
+              ) : null}
+
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+                disabled={isPendingFamilySave}
+                type="submit"
+              >
+                {isPendingFamilySave
+                  ? "Lagrer varelinje..."
+                  : "Lagre varelinje"}
+              </button>
+            </Form>
+
+            <Form method="post">
+              <input
+                name="intent"
+                type="hidden"
+                value="delete-family-shopping-item"
+              />
+              <input name="familyItemId" type="hidden" value={item.sourceKey} />
+              <input
+                name="expectedUpdatedAt"
+                type="hidden"
+                value={item.collaborationVersion}
+              />
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:bg-rose-100 disabled:text-rose-400"
+                disabled={isPendingFamilyDelete}
+                type="submit"
+              >
+                {isPendingFamilyDelete
                   ? "Sletter varelinje..."
                   : "Slett varelinje"}
               </button>

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -30,9 +30,14 @@ interface StoreModeShoppingItemCardManual extends StoreModeShoppingItemCardBase 
   sourceType: "MANUAL";
 }
 
+interface StoreModeShoppingItemCardFamily extends StoreModeShoppingItemCardBase {
+  sourceType: "FAMILY";
+}
+
 export type StoreModeShoppingItemCardItem =
   | StoreModeShoppingItemCardGenerated
-  | StoreModeShoppingItemCardManual;
+  | StoreModeShoppingItemCardManual
+  | StoreModeShoppingItemCardFamily;
 
 interface StoreModeShoppingItemCardProps {
   item: StoreModeShoppingItemCardItem;
@@ -162,6 +167,10 @@ function shouldAutoOpenStoreModeDetails(item: StoreModeShoppingItemCardItem) {
 }
 
 function formatStoreModeItemSourceLine(item: StoreModeShoppingItemCardItem) {
+  if (item.sourceType === "FAMILY") {
+    return "Følger familien på tvers av ukeplaner.";
+  }
+
   if (item.sourceType === "GENERATED") {
     const recipeAttribution =
       item.occurrenceCount === 1

--- a/app/lib/family-shopping-write.server.test.ts
+++ b/app/lib/family-shopping-write.server.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      familyShoppingItem: {
+        create: vi.fn(),
+        deleteMany: vi.fn(),
+        findFirst: vi.fn(),
+        updateMany: vi.fn(),
+      },
+      ingredientCategory: {
+        findUnique: vi.fn(),
+      },
+      store: {
+        findFirst: vi.fn(),
+      },
+    },
+    requireFamilyMembershipMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+vi.mock("./shopping-write.server", () => ({
+  resolveOtherCategoryId: vi.fn(),
+  resolveQuickAddManualShoppingItemValues: vi.fn(),
+}));
+
+import { resolveQuickAddManualShoppingItemValues } from "./shopping-write.server";
+import {
+  createFamilyShoppingItem,
+  toggleFamilyShoppingItemChecked,
+} from "./family-shopping-write.server";
+
+describe("family-shopping-write.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue({
+      familyId: "family-1",
+      role: "MEMBER",
+      userId: "user-1",
+    });
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.store.findFirst.mockResolvedValue(null);
+  });
+
+  it("rejects empty family shopping item names", async () => {
+    const result = await createFamilyShoppingItem({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-other",
+        name: "   ",
+        note: "",
+        preferredStoreId: "",
+        quantity: "",
+      },
+    });
+
+    expect(result.status).toBe("VALIDATION_ERROR");
+    expect(result.fieldErrors?.name).toBeTruthy();
+  });
+
+  it("creates a family shopping item", async () => {
+    dbMock.familyShoppingItem.create.mockResolvedValue({ id: "family-item-1" });
+
+    const result = await createFamilyShoppingItem({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-other",
+        name: "Batterier",
+        note: "",
+        preferredStoreId: "",
+        quantity: "1 pk",
+      },
+    });
+
+    expect(result).toEqual({ status: "CREATED" });
+    expect(dbMock.familyShoppingItem.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          familyId: "family-1",
+          name: "Batterier",
+        }),
+      }),
+    );
+  });
+
+  it("toggles checked state on the family shopping item row", async () => {
+    dbMock.familyShoppingItem.findFirst.mockResolvedValue({
+      checked: false,
+      id: "family-item-1",
+      updatedAt: new Date("2026-05-10T00:00:00.000Z"),
+    });
+    dbMock.familyShoppingItem.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await toggleFamilyShoppingItemChecked({
+      checked: true,
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(dbMock.familyShoppingItem.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          checked: true,
+        }),
+      }),
+    );
+  });
+
+  it("quick-add delegates to manual resolver before creating", async () => {
+    vi.mocked(resolveQuickAddManualShoppingItemValues).mockResolvedValue({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-other",
+        name: "Batterier",
+        note: "",
+        preferredStoreId: "",
+        quantity: "1",
+      },
+    });
+    dbMock.familyShoppingItem.create.mockResolvedValue({ id: "family-item-1" });
+
+    const { createQuickFamilyShoppingItem } = await import(
+      "./family-shopping-write.server"
+    );
+
+    const result = await createQuickFamilyShoppingItem({
+      familyId: "family-1",
+      input: { name: "Batterier" },
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "CREATED" });
+  });
+});

--- a/app/lib/family-shopping-write.server.ts
+++ b/app/lib/family-shopping-write.server.ts
@@ -1,0 +1,650 @@
+import {
+  buildActorUpdate,
+  COLLABORATION_CONFLICT_MESSAGE,
+  matchesExpectedUpdatedAt,
+} from "./collaboration.server";
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
+import {
+  resolveQuickAddManualShoppingItemValues,
+  type QuickAddManualShoppingItemInput,
+} from "./shopping-write.server";
+import { logCollaborationFailure, logCollaborationWrite } from "./write-observability.server";
+
+export interface FamilyShoppingItemValues {
+  categoryId: string;
+  name: string;
+  note: string;
+  preferredStoreId: string;
+  quantity: string;
+}
+
+export interface FamilyShoppingItemFieldErrors {
+  categoryId?: string;
+  name?: string;
+  preferredStoreId?: string;
+}
+
+const QUICK_ADD_DEFAULT_QUANTITY = "1";
+
+export function parseFamilyShoppingItemValues(
+  formData: FormData,
+): FamilyShoppingItemValues {
+  return {
+    categoryId: String(formData.get("categoryId") ?? ""),
+    name: String(formData.get("name") ?? ""),
+    note: String(formData.get("note") ?? ""),
+    preferredStoreId: String(formData.get("preferredStoreId") ?? ""),
+    quantity: String(formData.get("quantity") ?? ""),
+  };
+}
+
+export function parseQuickAddFamilyShoppingItemInput(formData: FormData) {
+  return {
+    ingredientId: String(formData.get("ingredientId") ?? ""),
+    name: String(formData.get("name") ?? ""),
+    recentNameNormalized: String(formData.get("recentNameNormalized") ?? ""),
+  } satisfies QuickAddManualShoppingItemInput;
+}
+
+export async function createQuickFamilyShoppingItem({
+  familyId,
+  input,
+  userId,
+}: {
+  familyId: string;
+  input: QuickAddManualShoppingItemInput;
+  userId: string;
+}) {
+  const resolvedValues = await resolveQuickAddFamilyShoppingItemValues({
+    familyId,
+    input,
+  });
+
+  if (!resolvedValues.ok) {
+    return {
+      fieldErrors: resolvedValues.fieldErrors,
+      formError: resolvedValues.formError,
+      status: "VALIDATION_ERROR" as const,
+      values: resolvedValues.values,
+    };
+  }
+
+  return createFamilyShoppingItem({
+    familyId,
+    userId,
+    values: resolvedValues.values,
+  });
+}
+
+export async function createFamilyShoppingItem({
+  familyId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  userId: string;
+  values: FamilyShoppingItemValues;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const validation = await validateFamilyShoppingItemValues({
+    familyId,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  try {
+    await db.familyShoppingItem.create({
+      data: {
+        categoryId: validation.values.categoryId,
+        familyId,
+        name: validation.values.name,
+        note: validation.values.note || null,
+        preferredStoreId: validation.preferredStoreId,
+        quantity: validation.values.quantity || null,
+        ...buildActorUpdate(userId),
+      },
+    });
+
+    logCollaborationWrite({
+      action: "create-family-shopping-item",
+      domain: "shopping",
+      entityType: "family-shopping-item",
+      familyId,
+      outcome: "CREATED",
+      userId,
+    });
+
+    return {
+      status: "CREATED" as const,
+    };
+  } catch (error) {
+    logCollaborationFailure({
+      action: "create-family-shopping-item",
+      domain: "shopping",
+      entityType: "family-shopping-item",
+      error,
+      familyId,
+      outcome: "VALIDATION_ERROR",
+      userId,
+    });
+
+    throw error;
+  }
+}
+
+export async function updateFamilyShoppingItem({
+  expectedUpdatedAt,
+  familyId,
+  familyItemId,
+  userId,
+  values,
+}: {
+  expectedUpdatedAt: string;
+  familyId: string;
+  familyItemId: string;
+  userId: string;
+  values: FamilyShoppingItemValues;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const existingItem = await db.familyShoppingItem.findFirst({
+    select: {
+      id: true,
+      updatedAt: true,
+    },
+    where: {
+      familyId,
+      id: familyItemId,
+    },
+  });
+
+  if (!existingItem) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingItem.updatedAt)) {
+    return buildFamilyShoppingConflictResult({
+      action: "update-family-shopping-item",
+      entityId: existingItem.id,
+      familyId,
+      userId,
+    });
+  }
+
+  const validation = await validateFamilyShoppingItemValues({
+    familyId,
+    values,
+  });
+
+  if (!validation.ok) {
+    logCollaborationWrite({
+      action: "update-family-shopping-item",
+      domain: "shopping",
+      entityId: existingItem.id,
+      entityType: "family-shopping-item",
+      familyId,
+      outcome: "VALIDATION_ERROR",
+      userId,
+    });
+
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  try {
+    const updateResult = await db.familyShoppingItem.updateMany({
+      data: {
+        categoryId: validation.values.categoryId,
+        name: validation.values.name,
+        note: validation.values.note || null,
+        preferredStoreId: validation.preferredStoreId,
+        quantity: validation.values.quantity || null,
+        ...buildActorUpdate(userId),
+      },
+      where: {
+        familyId,
+        id: existingItem.id,
+        updatedAt: existingItem.updatedAt,
+      },
+    });
+
+    if (updateResult.count === 0) {
+      return buildFamilyShoppingConflictResult({
+        action: "update-family-shopping-item",
+        entityId: existingItem.id,
+        familyId,
+        userId,
+      });
+    }
+
+    logCollaborationWrite({
+      action: "update-family-shopping-item",
+      domain: "shopping",
+      entityId: existingItem.id,
+      entityType: "family-shopping-item",
+      familyId,
+      outcome: "UPDATED",
+      userId,
+    });
+
+    return {
+      status: "UPDATED" as const,
+    };
+  } catch (error) {
+    logCollaborationFailure({
+      action: "update-family-shopping-item",
+      domain: "shopping",
+      entityId: existingItem.id,
+      entityType: "family-shopping-item",
+      error,
+      familyId,
+      outcome: "VALIDATION_ERROR",
+      userId,
+    });
+
+    throw error;
+  }
+}
+
+export async function deleteFamilyShoppingItem({
+  expectedUpdatedAt,
+  familyId,
+  familyItemId,
+  userId,
+}: {
+  expectedUpdatedAt: string;
+  familyId: string;
+  familyItemId: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const existingItem = await db.familyShoppingItem.findFirst({
+    select: {
+      id: true,
+      updatedAt: true,
+    },
+    where: {
+      familyId,
+      id: familyItemId,
+    },
+  });
+
+  if (!existingItem) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingItem.updatedAt)) {
+    return buildFamilyShoppingConflictResult({
+      action: "delete-family-shopping-item",
+      entityId: existingItem.id,
+      familyId,
+      userId,
+    });
+  }
+
+  const deleteResult = await db.familyShoppingItem.deleteMany({
+    where: {
+      familyId,
+      id: existingItem.id,
+      updatedAt: existingItem.updatedAt,
+    },
+  });
+
+  if (deleteResult.count === 0) {
+    return buildFamilyShoppingConflictResult({
+      action: "delete-family-shopping-item",
+      entityId: existingItem.id,
+      familyId,
+      userId,
+    });
+  }
+
+  logCollaborationWrite({
+    action: "delete-family-shopping-item",
+    domain: "shopping",
+    entityId: existingItem.id,
+    entityType: "family-shopping-item",
+    familyId,
+    outcome: "DELETED",
+    userId,
+  });
+
+  return {
+    status: "DELETED" as const,
+  };
+}
+
+export async function toggleFamilyShoppingItemChecked({
+  checked,
+  expectedUpdatedAt,
+  familyId,
+  familyItemId,
+  userId,
+}: {
+  checked: boolean;
+  expectedUpdatedAt: string;
+  familyId: string;
+  familyItemId: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const existingItem = await db.familyShoppingItem.findFirst({
+    select: {
+      checked: true,
+      id: true,
+      updatedAt: true,
+    },
+    where: {
+      familyId,
+      id: familyItemId,
+    },
+  });
+
+  if (!existingItem) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingItem.updatedAt)) {
+    return buildFamilyShoppingConflictResult({
+      action: "toggle-family-shopping-item-checked",
+      entityId: existingItem.id,
+      familyId,
+      userId,
+    });
+  }
+
+  const updateResult = await db.familyShoppingItem.updateMany({
+    data: {
+      checked,
+      ...buildActorUpdate(userId),
+    },
+    where: {
+      familyId,
+      id: existingItem.id,
+      updatedAt: existingItem.updatedAt,
+    },
+  });
+
+  if (updateResult.count === 0) {
+    return buildFamilyShoppingConflictResult({
+      action: "toggle-family-shopping-item-checked",
+      entityId: existingItem.id,
+      familyId,
+      userId,
+    });
+  }
+
+  logCollaborationWrite({
+    action: "toggle-family-shopping-item-checked",
+    domain: "shopping",
+    entityId: existingItem.id,
+    entityType: "family-shopping-item",
+    familyId,
+    outcome: "UPDATED",
+    userId,
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+async function resolveQuickAddFamilyShoppingItemValues({
+  familyId,
+  input,
+}: {
+  familyId: string;
+  input: QuickAddManualShoppingItemInput;
+}) {
+  const manualResolved = await resolveQuickAddManualShoppingItemValues({
+    familyId,
+    input,
+  });
+
+  if (manualResolved.ok) {
+    return {
+      ok: true as const,
+      values: toFamilyShoppingItemValues(manualResolved.values),
+    };
+  }
+
+  const recentNameNormalized = input.recentNameNormalized?.trim().toLowerCase();
+
+  if (recentNameNormalized) {
+    const recentItem = await findLatestFamilyShoppingItemForFamilyByNormalizedName({
+      familyId,
+      nameNormalized: recentNameNormalized,
+    });
+
+    if (recentItem) {
+      return {
+        ok: true as const,
+        values: buildQuickAddFamilyShoppingItemValues({
+          categoryId: recentItem.categoryId,
+          name: recentItem.name.trim(),
+          quantity: recentItem.quantity?.trim() || QUICK_ADD_DEFAULT_QUANTITY,
+        }),
+      };
+    }
+  }
+
+  return {
+    fieldErrors: manualResolved.fieldErrors,
+    formError: manualResolved.formError,
+    ok: false as const,
+    values: toFamilyShoppingItemValues(manualResolved.values),
+  };
+}
+
+async function findLatestFamilyShoppingItemForFamilyByNormalizedName({
+  familyId,
+  nameNormalized,
+}: {
+  familyId: string;
+  nameNormalized: string;
+}) {
+  const rows = await db.familyShoppingItem.findMany({
+    orderBy: [{ updatedAt: "desc" }],
+    select: {
+      categoryId: true,
+      name: true,
+      quantity: true,
+    },
+    take: 50,
+    where: {
+      familyId,
+    },
+  });
+
+  return (
+    rows.find(
+      (row) => normalizeIngredientCanonicalName(row.name) === nameNormalized,
+    ) ?? null
+  );
+}
+
+function toFamilyShoppingItemValues(values: {
+  buyOnDate: string;
+  categoryId: string;
+  name: string;
+  note: string;
+  preferredStoreId: string;
+  quantity: string;
+}): FamilyShoppingItemValues {
+  return {
+    categoryId: values.categoryId,
+    name: values.name,
+    note: values.note,
+    preferredStoreId: values.preferredStoreId,
+    quantity: values.quantity,
+  };
+}
+
+function buildQuickAddFamilyShoppingItemValues({
+  categoryId,
+  name,
+  quantity = QUICK_ADD_DEFAULT_QUANTITY,
+}: {
+  categoryId: string;
+  name: string;
+  quantity?: string;
+}): FamilyShoppingItemValues {
+  return {
+    categoryId,
+    name,
+    note: "",
+    preferredStoreId: "",
+    quantity,
+  };
+}
+
+async function validateFamilyShoppingItemValues({
+  familyId,
+  values,
+}: {
+  familyId: string;
+  values: FamilyShoppingItemValues;
+}) {
+  const normalizedValues = normalizeFamilyShoppingItemValues(values);
+  const fieldErrors: FamilyShoppingItemFieldErrors = {};
+
+  if (!normalizedValues.name) {
+    fieldErrors.name = "Skriv inn et varenavn.";
+  }
+
+  if (!normalizedValues.categoryId) {
+    fieldErrors.categoryId = "Velg en kategori.";
+  }
+
+  if (fieldErrors.name || fieldErrors.categoryId) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  const [matchingCategory, matchingStore] = await Promise.all([
+    db.ingredientCategory.findUnique({
+      select: {
+        id: true,
+      },
+      where: {
+        id: normalizedValues.categoryId,
+      },
+    }),
+    resolveScopedStoreId(normalizedValues.preferredStoreId, familyId),
+  ]);
+
+  if (!matchingCategory) {
+    fieldErrors.categoryId = "Velg en gyldig kategori.";
+  }
+
+  if (normalizedValues.preferredStoreId && !matchingStore) {
+    fieldErrors.preferredStoreId = "Velg en gyldig butikk for familien.";
+  }
+
+  if (fieldErrors.categoryId || fieldErrors.preferredStoreId) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: normalizedValues,
+    };
+  }
+
+  return {
+    ok: true as const,
+    preferredStoreId: matchingStore,
+    values: normalizedValues,
+  };
+}
+
+function normalizeFamilyShoppingItemValues(
+  values: FamilyShoppingItemValues,
+): FamilyShoppingItemValues {
+  return {
+    categoryId: values.categoryId.trim(),
+    name: values.name.trim(),
+    note: values.note.trim(),
+    preferredStoreId: values.preferredStoreId.trim(),
+    quantity: values.quantity.trim(),
+  };
+}
+
+async function resolveScopedStoreId(preferredStoreId: string, familyId: string) {
+  if (!preferredStoreId) {
+    return null;
+  }
+
+  const store = await db.store.findFirst({
+    select: {
+      id: true,
+    },
+    where: {
+      id: preferredStoreId,
+      OR: [{ familyId: null }, { familyId }],
+    },
+  });
+
+  return store?.id ?? null;
+}
+
+function buildFamilyShoppingConflictResult({
+  action,
+  entityId,
+  familyId,
+  userId,
+}: {
+  action: string;
+  entityId: string;
+  familyId: string;
+  userId: string;
+}) {
+  logCollaborationWrite({
+    action,
+    domain: "shopping",
+    entityId,
+    entityType: "family-shopping-item",
+    familyId,
+    outcome: "CONFLICT",
+    userId,
+  });
+
+  return {
+    formError: COLLABORATION_CONFLICT_MESSAGE,
+    status: "CONFLICT" as const,
+  };
+}

--- a/app/lib/shopping-display.ts
+++ b/app/lib/shopping-display.ts
@@ -105,6 +105,10 @@ export function formatCompactShoppingSourceLine(item: {
     return occurrenceAttribution ? `Brukt i ${occurrenceAttribution}` : null;
   }
 
+  if (item.sourceType === "FAMILY") {
+    return "Alltid på listen";
+  }
+
   if (item.buyOnDate) {
     return `Manuell · Kjøpes ${formatCompactDateLabel(item.buyOnDate)}`;
   }

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -10,6 +10,7 @@ import {
   buildStoreModeQueueStorageKey,
   buildStoreModeViewStorageKey,
   computeStoreModeProgress,
+  getToggleExpectedVersion,
   partitionStoreModeSections,
   readStoreModeDeprioritizeBought,
   readStoreModeShoppingView,
@@ -139,6 +140,33 @@ describe("shopping-store-mode-client", () => {
         queue,
       }),
     ).toEqual(queue);
+  });
+
+  it("accepts FAMILY toggle operations and uses collaboration version", () => {
+    expect(
+      getToggleExpectedVersion({
+        collaborationVersion: "family-v1",
+        sourceType: "FAMILY",
+      }),
+    ).toBe("family-v1");
+
+    writeStoreModeToggleQueue(storageKey, [
+      {
+        checked: true,
+        expectedUpdatedAt: "family-v1",
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+    ]);
+
+    expect(readStoreModeToggleQueue(storageKey)).toEqual([
+      {
+        checked: true,
+        expectedUpdatedAt: "family-v1",
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+    ]);
   });
 
   it("persists and reads queue entries from localStorage", () => {

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -1,10 +1,12 @@
 import { ShoppingItemSource } from "@prisma/client";
 
+export type StoreModeItemSource = ShoppingItemSource | "FAMILY";
+
 export interface StoreModeToggleOp {
   checked: boolean;
   expectedUpdatedAt: string;
   sourceKey: string;
-  sourceType: ShoppingItemSource;
+  sourceType: StoreModeItemSource;
 }
 
 export interface StoreModeToggleItem {
@@ -12,7 +14,7 @@ export interface StoreModeToggleItem {
   collaborationVersion: string;
   overrideVersion?: string;
   sourceKey: string;
-  sourceType: ShoppingItemSource;
+  sourceType: StoreModeItemSource;
 }
 
 export interface StoreModeProgress {
@@ -310,7 +312,7 @@ export function reconcileToggleQueue({
 export function getToggleExpectedVersion(item: {
   collaborationVersion: string;
   overrideVersion?: string;
-  sourceType: ShoppingItemSource;
+  sourceType: StoreModeItemSource;
 }) {
   if (item.sourceType === ShoppingItemSource.MANUAL) {
     return item.overrideVersion ?? "";
@@ -330,7 +332,8 @@ function isStoreModeToggleOp(value: unknown): value is StoreModeToggleOp {
     typeof op.sourceKey === "string" &&
     op.sourceKey.length > 0 &&
     (op.sourceType === ShoppingItemSource.GENERATED ||
-      op.sourceType === ShoppingItemSource.MANUAL) &&
+      op.sourceType === ShoppingItemSource.MANUAL ||
+      op.sourceType === "FAMILY") &&
     typeof op.checked === "boolean" &&
     typeof op.expectedUpdatedAt === "string"
   );

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -4,6 +4,9 @@ const { dbMock, getFamilyStockMatchSetMock, requireFamilyMembershipMock } =
   vi.hoisted(() => {
     return {
       dbMock: {
+        familyShoppingItem: {
+          findMany: vi.fn(),
+        },
         ingredientCategory: {
           findMany: vi.fn(),
         },
@@ -73,6 +76,7 @@ describe("shopping.server", () => {
       ingredientIds: new Set(),
     });
     dbMock.userStorePreference.findUnique.mockResolvedValue(null);
+    dbMock.familyShoppingItem.findMany.mockResolvedValue([]);
     dbMock.ingredientCategory.findMany.mockResolvedValue([
       {
         displayName: "Brod",
@@ -346,6 +350,7 @@ describe("shopping.server", () => {
     });
     expect(result.categories.map((category) => category.displayName)).toEqual(["Brod", "Frukt og gront", "Meieri"]);
     expect(result.itemCounts).toEqual({
+      family: 0,
       generated: 4,
       manual: 1,
       total: 5,
@@ -555,6 +560,7 @@ describe("shopping.server", () => {
     });
 
     expect(result.itemCounts).toEqual({
+      family: 0,
       generated: 1,
       manual: 0,
       total: 1,
@@ -1728,22 +1734,76 @@ describe("shopping.server", () => {
     expect(dbMock.ingredientCategory.findMany).not.toHaveBeenCalled();
   });
 
+  it("includes unchecked family items in meal plan shopping data", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: null,
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 20",
+    });
+    dbMock.familyShoppingItem.findMany.mockResolvedValue([
+      {
+        category: {
+          displayName: "Annet",
+          id: "category-other",
+        },
+        categoryId: "category-other",
+        checked: false,
+        id: "family-item-1",
+        name: "Batterier",
+        note: null,
+        preferredStore: null,
+        preferredStoreId: null,
+        quantity: "1 pk",
+        updatedAt: new Date("2026-05-10T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.familyStoreGroups).toHaveLength(1);
+    expect(
+      result.familyStoreGroups[0]?.sections[0]?.items.map((item) => item.name),
+    ).toEqual(["Batterier"]);
+    expect(result.itemCounts.family).toBe(1);
+  });
+
   it("lists recent manual shopping items deduped by normalized name", async () => {
     dbMock.manualShoppingItem.findMany.mockResolvedValue([
       {
         categoryId: "category-dairy",
         name: "Melk",
         quantity: "2 liter",
+        updatedAt: new Date("2026-05-16T00:00:00.000Z"),
       },
       {
         categoryId: "category-other",
         name: "melk",
         quantity: "1 liter",
+        updatedAt: new Date("2026-05-15T00:00:00.000Z"),
       },
       {
         categoryId: "category-bakery",
         name: "Brød",
         quantity: null,
+        updatedAt: new Date("2026-05-14T00:00:00.000Z"),
+      },
+    ]);
+    dbMock.familyShoppingItem.findMany.mockResolvedValue([
+      {
+        categoryId: "category-other",
+        name: "Batterier",
+        quantity: "2",
+        updatedAt: new Date("2026-05-17T00:00:00.000Z"),
       },
     ]);
 
@@ -1752,21 +1812,15 @@ describe("shopping.server", () => {
       limit: 5,
     });
 
-    expect(dbMock.manualShoppingItem.findMany).toHaveBeenCalledWith({
-      orderBy: [{ updatedAt: "desc" }],
-      select: {
-        categoryId: true,
-        name: true,
-        quantity: true,
-      },
-      take: 100,
-      where: {
-        mealPlan: {
-          familyId: "family-1",
-        },
-      },
-    });
+    expect(dbMock.manualShoppingItem.findMany).toHaveBeenCalled();
+    expect(dbMock.familyShoppingItem.findMany).toHaveBeenCalled();
     expect(result).toEqual([
+      {
+        categoryId: "category-other",
+        displayName: "Batterier",
+        nameNormalized: "batterier",
+        quantity: "2",
+      },
       {
         categoryId: "category-dairy",
         displayName: "Melk",

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -94,6 +94,28 @@ const manualShoppingItemSelect =
     updatedAt: true,
   });
 
+const familyShoppingItemSelect =
+  Prisma.validator<Prisma.FamilyShoppingItemSelect>()({
+    category: {
+      select: categorySummarySelect,
+    },
+    categoryId: true,
+    checked: true,
+    id: true,
+    name: true,
+    note: true,
+    preferredStore: {
+      select: storeSummarySelect,
+    },
+    preferredStoreId: true,
+    quantity: true,
+    updatedAt: true,
+  });
+
+type FamilyShoppingItemRow = Prisma.FamilyShoppingItemGetPayload<{
+  select: typeof familyShoppingItemSelect;
+}>;
+
 export const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
   activeShoppingDate: true,
   endDate: true,
@@ -207,8 +229,10 @@ interface ProjectedShoppingItemBase {
   quantityLabel: string | null;
   section: StoreSectionSummary;
   sourceKey: string;
-  sourceType: ShoppingItemSource;
+  sourceType: ProjectedShoppingItemSource;
 }
+
+export type ProjectedShoppingItemSource = ShoppingItemSource | "FAMILY";
 
 export interface ProjectedShoppingOccurrence {
   amount: string | null;
@@ -240,9 +264,15 @@ export interface ProjectedManualShoppingItem extends ProjectedShoppingItemBase {
   sourceType: "MANUAL";
 }
 
+export interface ProjectedFamilyShoppingItem extends ProjectedShoppingItemBase {
+  quantity: string | null;
+  sourceType: "FAMILY";
+}
+
 export type ProjectedShoppingItem =
   | ProjectedGeneratedShoppingItem
-  | ProjectedManualShoppingItem;
+  | ProjectedManualShoppingItem
+  | ProjectedFamilyShoppingItem;
 
 export interface ProjectedShoppingSectionGroup {
   category: {
@@ -345,6 +375,14 @@ export async function getMealPlanShoppingData({
   const projectedItems = [...generatedItems, ...manualItems].sort(
     compareProjectedItems,
   );
+  const uncheckedFamilyItems = await loadFamilyShoppingItems({
+    checked: false,
+    familyId,
+  });
+  const familyProjectedItems = projectFamilyShoppingItems({
+    items: uncheckedFamilyItems,
+    stores,
+  });
 
   return {
     categories,
@@ -354,10 +392,12 @@ export async function getMealPlanShoppingData({
       id: membership.family.id,
       name: membership.family.name,
     },
+    familyStoreGroups: buildProjectedStoreGroups(familyProjectedItems),
     itemCounts: {
+      family: familyProjectedItems.length,
       generated: generatedItems.length,
       manual: manualItems.length,
-      total: projectedItems.length,
+      total: projectedItems.length + familyProjectedItems.length,
     },
     mealPlan,
     projectedItems,
@@ -389,20 +429,40 @@ export async function listRecentManualShoppingItemsForFamily({
   familyId: string;
   limit?: number;
 }) {
-  const rows = await db.manualShoppingItem.findMany({
-    orderBy: [{ updatedAt: "desc" }],
-    select: {
-      categoryId: true,
-      name: true,
-      quantity: true,
-    },
-    take: 100,
-    where: {
-      mealPlan: {
+  const [manualRows, familyRows] = await Promise.all([
+    db.manualShoppingItem.findMany({
+      orderBy: [{ updatedAt: "desc" }],
+      select: {
+        categoryId: true,
+        name: true,
+        quantity: true,
+        updatedAt: true,
+      },
+      take: 100,
+      where: {
+        mealPlan: {
+          familyId,
+        },
+      },
+    }),
+    db.familyShoppingItem.findMany({
+      orderBy: [{ updatedAt: "desc" }],
+      select: {
+        categoryId: true,
+        name: true,
+        quantity: true,
+        updatedAt: true,
+      },
+      take: 100,
+      where: {
         familyId,
       },
-    },
-  });
+    }),
+  ]);
+
+  const rows = [...manualRows, ...familyRows].sort(
+    (left, right) => right.updatedAt.getTime() - left.updatedAt.getTime(),
+  );
 
   const seen = new Set<string>();
   const recentItems: RecentManualShoppingItem[] = [];
@@ -434,6 +494,115 @@ export async function listRecentManualShoppingItemsForFamily({
   }
 
   return recentItems;
+}
+
+export async function loadFamilyShoppingItems({
+  checked,
+  familyId,
+}: {
+  checked?: boolean;
+  familyId: string;
+}) {
+  return db.familyShoppingItem.findMany({
+    orderBy: [{ checked: "asc" }, { updatedAt: "desc" }, { id: "asc" }],
+    select: familyShoppingItemSelect,
+    where: {
+      familyId,
+      ...(checked === undefined ? {} : { checked }),
+    },
+  });
+}
+
+export function projectFamilyShoppingItems({
+  items,
+  stores,
+}: {
+  items: FamilyShoppingItemRow[];
+  stores: ShoppingStore[];
+}) {
+  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
+
+  return items.map((item) => {
+    const preferredStore = item.preferredStore;
+    const section = resolveStoreSection({
+      category: {
+        id: item.category.id,
+        name: item.category.displayName,
+      },
+      preferredStore,
+      storeSectionsByStoreId,
+    });
+
+    return {
+      category: {
+        id: item.category.id,
+        name: item.category.displayName,
+      },
+      checked: item.checked,
+      collaborationVersion: item.updatedAt.toISOString(),
+      name: item.name,
+      note: item.note,
+      preferredStore,
+      quantity: item.quantity,
+      quantityLabel: buildManualQuantityLabel(item.quantity),
+      section,
+      sourceKey: item.id,
+      sourceType: "FAMILY",
+    } satisfies ProjectedFamilyShoppingItem;
+  });
+}
+
+export async function getFamilyShoppingData({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const [stores, categories, familyItems] = await Promise.all([
+    db.store.findMany({
+      orderBy: [{ name: "asc" }],
+      select: shoppingStoreSelect,
+      where: {
+        OR: [{ familyId: null }, { familyId }],
+      },
+    }),
+    db.ingredientCategory.findMany({
+      orderBy: [{ displayName: "asc" }],
+      select: shoppingCategorySelect,
+    }),
+    loadFamilyShoppingItems({ familyId }),
+  ]);
+
+  const projectedItems = projectFamilyShoppingItems({
+    items: familyItems,
+    stores,
+  }).sort(compareProjectedItems);
+
+  return {
+    categories,
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    itemCounts: {
+      checked: projectedItems.filter((item) => item.checked).length,
+      total: projectedItems.length,
+      unchecked: projectedItems.filter((item) => !item.checked).length,
+    },
+    projectedItems,
+    storeGroups: buildProjectedStoreGroups(projectedItems),
+    stores: stores.map((store) => ({
+      id: store.id,
+      name: store.name,
+    })),
+    userRole: membership.role,
+  };
 }
 
 export async function getMealPlanStoreModeData({
@@ -539,11 +708,27 @@ export async function getMealPlanStoreModeData({
       ),
     )
     .sort(compareProjectedItemsByRelevantDate);
+  const uncheckedFamilyItems = await loadFamilyShoppingItems({
+    checked: false,
+    familyId,
+  });
+  const familyDueItems = projectFamilyShoppingItems({
+    items: uncheckedFamilyItems,
+    stores,
+  });
+  const mergedDueItems = [...dueItems, ...familyDueItems].sort((left, right) =>
+    compareProjectedItemsForStoreMode(
+      left,
+      right,
+      selectedStore,
+      storeSectionsByStoreId,
+    ),
+  );
 
   return {
     activeShoppingDate,
     dueSectionGroups: buildStoreModeSectionGroups({
-      items: dueItems,
+      items: mergedDueItems,
       selectedStore,
       storeSectionsByStoreId,
     }),
@@ -553,7 +738,7 @@ export async function getMealPlanStoreModeData({
     },
     laterItems,
     mealPlan,
-    progress: buildStoreModeProgress(dueItems),
+    progress: buildStoreModeProgress(mergedDueItems),
     selectedStore,
     stockIngredientCount: stockIngredientsForPlan.length,
     stockIngredientsForPlan,
@@ -1299,6 +1484,10 @@ function isProjectedItemBeforeShoppingDate(
 }
 
 function getProjectedItemRelevantDate(item: ProjectedShoppingItem) {
+  if (item.sourceType === "FAMILY") {
+    return null;
+  }
+
   if (item.sourceType === "GENERATED") {
     return item.postponedUntilDate ?? item.firstDate;
   }
@@ -1493,7 +1682,11 @@ function getProjectedItemSortTimestamp(item: ProjectedShoppingItem) {
     return item.firstDate.getTime();
   }
 
-  return item.buyOnDate ? item.buyOnDate.getTime() : Number.MIN_SAFE_INTEGER;
+  if (item.sourceType === "MANUAL") {
+    return item.buyOnDate ? item.buyOnDate.getTime() : Number.MIN_SAFE_INTEGER;
+  }
+
+  return Number.MIN_SAFE_INTEGER;
 }
 
 function getProjectedItemRelevantTimestamp(item: ProjectedShoppingItem) {

--- a/app/lib/use-store-mode-toggle-sync.ts
+++ b/app/lib/use-store-mode-toggle-sync.ts
@@ -90,7 +90,12 @@ export function useStoreModeToggleSync<T extends StoreModeToggleItem>({
     const [nextOp] = queueRef.current;
     inFlightSourceKeyRef.current = nextOp.sourceKey;
     const formData = new FormData();
-    formData.set("intent", "toggle-shopping-item-checked");
+    formData.set(
+      "intent",
+      nextOp.sourceType === "FAMILY"
+        ? "toggle-family-shopping-item-checked"
+        : "toggle-shopping-item-checked",
+    );
     formData.set("sourceKey", nextOp.sourceKey);
     formData.set("sourceType", nextOp.sourceType);
     formData.set("checked", nextOp.checked ? "true" : "false");

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -32,6 +32,11 @@ export default [
       "families/:familyId/meal-plans/:mealPlanId/store-mode",
       "routes/family-meal-plan-store-mode.tsx",
     ),
+    route("families/:familyId/shopping", "routes/family-shopping.tsx"),
+    route(
+      "families/:familyId/shopping/ingredient-search",
+      "routes/family-shopping-ingredient-search.ts",
+    ),
     route("families/:familyId/stores", "routes/family-stores.tsx"),
     route("families/:familyId/stock-ingredients", "routes/family-stock-ingredients.tsx"),
     route("families/:familyId/recipes", "routes/family-recipes.tsx"),

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -81,7 +81,9 @@ describe("family meal plan shopping route", () => {
       },
       excludedGeneratedCount: 0,
       excludedGeneratedItems: [],
+      familyStoreGroups: [],
       itemCounts: {
+        family: 0,
         generated: 1,
         manual: 1,
         total: 2,
@@ -282,7 +284,9 @@ describe("family meal plan shopping route", () => {
         id: "family-1",
         name: "Solberg",
       },
+      familyStoreGroups: [],
       itemCounts: {
+        family: 0,
         generated: 1,
         manual: 1,
         total: 2,
@@ -421,7 +425,9 @@ describe("family meal plan shopping route", () => {
       },
       excludedGeneratedCount: 0,
       excludedGeneratedItems: [],
+      familyStoreGroups: [],
       itemCounts: {
+        family: 0,
         generated: 1,
         manual: 0,
         total: 1,

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -23,6 +23,7 @@ import {
   getMealPlanShoppingData,
   listRecentManualShoppingItemsForFamily,
 } from "../lib/shopping.server";
+import { toggleFamilyShoppingItemChecked } from "../lib/family-shopping-write.server";
 import {
   createManualShoppingItem,
   createQuickManualShoppingItem,
@@ -57,6 +58,7 @@ type ShoppingIntent =
   | "opt-in-stock-shopping-item"
   | "restore-generated-shopping-item"
   | "opt-in-stock-shopping-items"
+  | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
   | "update-generated-shopping-item"
   | "update-manual-shopping-item";
@@ -148,6 +150,13 @@ export async function loader({
     ),
     notice: getShoppingNotice(request),
     recentManualItems,
+    familyStoreGroups: result.familyStoreGroups.map((group) => ({
+      sections: group.sections.map((section) => ({
+        ...section,
+        items: section.items.map(serializeProjectedShoppingItem),
+      })),
+      store: group.store,
+    })),
     storeGroups: result.storeGroups.map((group) => ({
       sections: group.sections.map((section) => ({
         ...section,
@@ -395,6 +404,55 @@ export async function action({
       familyId,
       mealPlanId,
       notice: "generated-shopping-item-restored",
+      request,
+    });
+  }
+
+  if (intent === "toggle-family-shopping-item-checked") {
+    const familyItemId = String(formData.get("sourceKey") ?? "").trim();
+    const checked = String(formData.get("checked") ?? "") === "true";
+
+    if (!familyItemId) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    const result = await toggleFamilyShoppingItemChecked({
+      checked,
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      familyItemId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+        itemTarget: {
+          sourceKey: familyItemId,
+          sourceType: ShoppingItemSource.MANUAL,
+        },
+      } satisfies ShoppingActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+        itemTarget: {
+          sourceKey: familyItemId,
+          sourceType: ShoppingItemSource.MANUAL,
+        },
+      } satisfies ShoppingActionData;
+    }
+
+    return buildShoppingRedirect({
+      familyId,
+      mealPlanId,
+      notice: "shopping-item-check-state-updated",
       request,
     });
   }
@@ -1005,6 +1063,101 @@ export default function FamilyMealPlanShoppingRoute({
           </article>
         </section>
 
+        {loaderData.familyStoreGroups.length ? (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-violet-200">
+            <div className="flex flex-col gap-2">
+              <h2 className="text-lg font-semibold text-slate-950">
+                Alltid på listen
+              </h2>
+              <p className="text-sm leading-6 text-slate-600">
+                Faste varer som følger familien på tvers av ukeplaner. Rediger
+                listen på{" "}
+                <Link
+                  className="font-medium text-emerald-700 underline"
+                  to={`/families/${loaderData.family.id}/shopping`}
+                >
+                  familiens handleliste
+                </Link>
+                .
+              </p>
+            </div>
+            <div className="mt-6 grid gap-5">
+              {loaderData.familyStoreGroups.map((group) => (
+                <div key={`family:${group.store?.id ?? "no-store"}`}>
+                  <h3 className="text-sm font-semibold text-slate-800">
+                    {group.store?.name ?? "Ingen valgt butikk"}
+                  </h3>
+                  <div className="mt-3 grid gap-2">
+                    {group.sections.flatMap((section) =>
+                      section.items.map((item) => {
+                        const isPendingCheckToggle =
+                          navigation.state === "submitting" &&
+                          pendingIntent ===
+                            "toggle-family-shopping-item-checked" &&
+                          pendingSourceKey === item.sourceKey;
+
+                        return (
+                          <article
+                            key={`family:${item.sourceKey}`}
+                            className="rounded-[20px] border border-violet-100 bg-violet-50/60 px-4 py-4"
+                          >
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                              <div>
+                                <p className="text-sm font-semibold text-slate-950">
+                                  {item.name}
+                                  {item.quantityLabel
+                                    ? ` · ${item.quantityLabel}`
+                                    : ""}
+                                </p>
+                                <p className="mt-1 text-xs text-violet-800">
+                                  Alltid på listen
+                                </p>
+                              </div>
+                              <Form method="post">
+                                <input
+                                  name="intent"
+                                  type="hidden"
+                                  value="toggle-family-shopping-item-checked"
+                                />
+                                <input
+                                  name="sourceKey"
+                                  type="hidden"
+                                  value={item.sourceKey}
+                                />
+                                <input
+                                  name="checked"
+                                  type="hidden"
+                                  value={item.checked ? "false" : "true"}
+                                />
+                                <input
+                                  name="expectedUpdatedAt"
+                                  type="hidden"
+                                  value={getToggleExpectedVersion(item)}
+                                />
+                                <button
+                                  className="rounded-xl bg-slate-950 px-4 py-2 text-xs font-medium text-white transition hover:bg-slate-800 disabled:opacity-60"
+                                  disabled={isPendingCheckToggle}
+                                  type="submit"
+                                >
+                                  {isPendingCheckToggle
+                                    ? "Oppdaterer..."
+                                    : item.checked
+                                      ? "Fjern avkryssing"
+                                      : "Marker som kjøpt"}
+                                </button>
+                              </Form>
+                            </div>
+                          </article>
+                        );
+                      }),
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
         {loaderData.storeGroups.length ? (
           <section className="grid gap-6">
             {loaderData.storeGroups.map((group) => (
@@ -1198,7 +1351,7 @@ export default function FamilyMealPlanShoppingRoute({
                                   <p className="text-sm leading-6 text-slate-600">
                                     {item.sourceType === "GENERATED"
                                       ? formatGeneratedItemSummary(item)
-                                      : item.buyOnDate
+                                      : item.sourceType === "MANUAL" && item.buyOnDate
                                         ? `Lagt til manuelt og planlagt for ${formatDateLabel(item.buyOnDate)}.`
                                         : "Lagt til manuelt uten spesifikk handledato."}
                                   </p>
@@ -1215,7 +1368,7 @@ export default function FamilyMealPlanShoppingRoute({
                                 <p className="text-sm leading-6 text-slate-600">
                                   {item.sourceType === "GENERATED"
                                     ? formatGeneratedItemSummary(item)
-                                    : item.buyOnDate
+                                    : item.sourceType === "MANUAL" && item.buyOnDate
                                       ? `Lagt til manuelt og planlagt for ${formatDateLabel(item.buyOnDate)}.`
                                       : "Lagt til manuelt uten spesifikk handledato."}
                                 </p>
@@ -1306,8 +1459,14 @@ function requireRouteParam(value: string | undefined, message: string) {
 function serializeProjectedShoppingItem(
   item: Awaited<
     ReturnType<typeof getMealPlanShoppingData>
-  >["projectedItems"][number],
+  >["projectedItems"][number] | Awaited<
+    ReturnType<typeof getMealPlanShoppingData>
+  >["familyStoreGroups"][number]["sections"][number]["items"][number],
 ) {
+  if (item.sourceType === "FAMILY") {
+    return item;
+  }
+
   if (item.sourceType === ShoppingItemSource.GENERATED) {
     return {
       ...item,

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -27,6 +27,7 @@ import {
   writeStoreModeDeprioritizeBought,
   writeStoreModeShoppingView,
 } from "../lib/shopping-store-mode-client";
+import { toggleFamilyShoppingItemChecked } from "../lib/family-shopping-write.server";
 import { getMealPlanStoreModeData } from "../lib/shopping.server";
 import {
   toggleShoppingItemChecked,
@@ -44,6 +45,7 @@ type StoreModeNotice =
   | "shopping-item-check-state-updated";
 
 type StoreModeIntent =
+  | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
   | "update-active-shopping-date"
   | "update-selected-store";
@@ -209,6 +211,42 @@ export async function action({
       notice: "selected-store-updated",
       request,
     });
+  }
+
+  if (intent === "toggle-family-shopping-item-checked") {
+    const familyItemId = String(formData.get("sourceKey") ?? "").trim();
+    const checked = String(formData.get("checked") ?? "") === "true";
+
+    if (!familyItemId) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const result = await toggleFamilyShoppingItemChecked({
+      checked,
+      expectedUpdatedAt: String(formData.get("expectedUpdatedAt") ?? ""),
+      familyId,
+      familyItemId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    return {
+      intent,
+      ok: true,
+    } satisfies StoreModeActionData;
   }
 
   if (intent === "toggle-shopping-item-checked") {
@@ -658,9 +696,11 @@ export default function FamilyMealPlanStoreModeRoute({
                   {" · "}
                   {item.sourceType === "GENERATED"
                     ? formatDateLabel(item.postponedUntilDate ?? item.firstDate)
-                    : item.buyOnDate
+                    : item.sourceType === "MANUAL" && item.buyOnDate
                       ? formatDateLabel(item.buyOnDate)
-                      : "Ingen dato"}
+                      : item.sourceType === "FAMILY"
+                        ? "Alltid på listen"
+                        : "Ingen dato"}
                 </span>
               ))
             ) : (
@@ -708,8 +748,14 @@ export function ErrorBoundary({ error }: { error: unknown }) {
 function serializeProjectedShoppingItem(
   item: Awaited<
     ReturnType<typeof getMealPlanStoreModeData>
-  >["laterItems"][number],
+  >["laterItems"][number] | Awaited<
+    ReturnType<typeof getMealPlanStoreModeData>
+  >["dueSectionGroups"][number]["items"][number],
 ) {
+  if (item.sourceType === "FAMILY") {
+    return item;
+  }
+
   if (item.sourceType === ShoppingItemSource.GENERATED) {
     return {
       ...item,

--- a/app/routes/family-shopping-ingredient-search.ts
+++ b/app/routes/family-shopping-ingredient-search.ts
@@ -1,0 +1,20 @@
+import { requireUser } from "../lib/auth.server";
+import { searchCanonicalIngredients } from "../lib/stock.server";
+
+const MIN_SEARCH_LENGTH = 2;
+
+export async function loader({ request }: { request: Request }) {
+  await requireUser(request);
+
+  const searchQuery = new URL(request.url).searchParams.get("q")?.trim() ?? "";
+
+  if (searchQuery.length < MIN_SEARCH_LENGTH) {
+    return {
+      ingredientSearchResults: [],
+    };
+  }
+
+  return {
+    ingredientSearchResults: await searchCanonicalIngredients(searchQuery),
+  };
+}

--- a/app/routes/family-shopping.test.ts
+++ b/app/routes/family-shopping.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping.server", () => ({
+  getFamilyShoppingData: vi.fn(),
+  listRecentManualShoppingItemsForFamily: vi.fn(),
+}));
+
+vi.mock("../lib/family-shopping-write.server", () => ({
+  createFamilyShoppingItem: vi.fn(),
+  createQuickFamilyShoppingItem: vi.fn(),
+  deleteFamilyShoppingItem: vi.fn(),
+  parseFamilyShoppingItemValues: vi.fn(),
+  parseQuickAddFamilyShoppingItemInput: vi.fn(),
+  toggleFamilyShoppingItemChecked: vi.fn(),
+  updateFamilyShoppingItem: vi.fn(),
+}));
+
+import { requireUser } from "../lib/auth.server";
+import { toggleFamilyShoppingItemChecked } from "../lib/family-shopping-write.server";
+import {
+  getFamilyShoppingData,
+  listRecentManualShoppingItemsForFamily,
+} from "../lib/shopping.server";
+import { action, loader } from "./family-shopping";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+describe("family shopping route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads family shopping data", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([]);
+    vi.mocked(getFamilyShoppingData).mockResolvedValue({
+      categories: [],
+      family: { id: "family-1", name: "Solberg" },
+      itemCounts: { checked: 0, total: 1, unchecked: 1 },
+      projectedItems: [],
+      storeGroups: [
+        {
+          sections: [
+            {
+              category: { id: "category-other", name: "Annet" },
+              displayName: "Annet",
+              items: [
+                {
+                  category: { id: "category-other", name: "Annet" },
+                  checked: false,
+                  collaborationVersion: "2026-05-10T00:00:00.000Z",
+                  name: "Batterier",
+                  note: null,
+                  preferredStore: null,
+                  quantity: "1",
+                  quantityLabel: "1",
+                  section: {
+                    displayName: "Annet",
+                    sortOrder: 0,
+                  },
+                  sourceKey: "family-item-1",
+                  sourceType: "FAMILY",
+                },
+              ],
+            },
+          ],
+          store: null,
+        },
+      ],
+      stores: [],
+      userRole: "ADMIN",
+    });
+
+    const result = await loader({
+      params: { familyId: "family-1" },
+      request: new Request("http://localhost/families/family-1/shopping"),
+    });
+
+    expect(getFamilyShoppingData).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result.storeGroups[0]?.sections[0]?.items[0]?.name).toBe("Batterier");
+  });
+
+  it("toggles a family shopping item from the route action", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(toggleFamilyShoppingItemChecked).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "toggle-family-shopping-item-checked");
+    formData.set("sourceKey", "family-item-1");
+    formData.set("checked", "true");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: new Request("http://localhost/families/family-1/shopping", {
+        body: formData,
+        method: "POST",
+      }),
+    });
+
+    expect(toggleFamilyShoppingItemChecked).toHaveBeenCalledWith({
+      checked: true,
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      userId: "user-1",
+    });
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+  });
+});

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -1,0 +1,741 @@
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
+
+import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
+import { ShoppingListItemExpanded } from "../components/shopping-list-item-expanded";
+import { requireUser } from "../lib/auth.server";
+import {
+  createFamilyShoppingItem,
+  createQuickFamilyShoppingItem,
+  deleteFamilyShoppingItem,
+  parseFamilyShoppingItemValues,
+  parseQuickAddFamilyShoppingItemInput,
+  toggleFamilyShoppingItemChecked,
+  updateFamilyShoppingItem,
+  type FamilyShoppingItemFieldErrors,
+  type FamilyShoppingItemValues,
+} from "../lib/family-shopping-write.server";
+import {
+  formatCompactShoppingSourceLine,
+  formatGeneratedQuantityBadge,
+} from "../lib/shopping-display";
+import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
+import {
+  getFamilyShoppingData,
+  listRecentManualShoppingItemsForFamily,
+} from "../lib/shopping.server";
+
+type FamilyShoppingNotice =
+  | "family-shopping-item-added"
+  | "family-shopping-item-deleted"
+  | "family-shopping-item-updated"
+  | "family-shopping-item-check-state-updated";
+
+type FamilyShoppingIntent =
+  | "add-family-shopping-item"
+  | "quick-add-family-shopping-item"
+  | "delete-family-shopping-item"
+  | "toggle-family-shopping-item-checked"
+  | "update-family-shopping-item";
+
+interface FamilyShoppingActionData {
+  familyFieldErrors?: FamilyShoppingItemFieldErrors;
+  familyValues?: FamilyShoppingItemValues;
+  formError?: string;
+  intent?: FamilyShoppingIntent;
+  itemTarget?: {
+    sourceKey: string;
+  };
+}
+
+const defaultFamilyShoppingItemValues: FamilyShoppingItemValues = {
+  categoryId: "",
+  name: "",
+  note: "",
+  preferredStoreId: "",
+  quantity: "",
+};
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Alltid på listen | Mealplanner" },
+    {
+      name: "description",
+      content:
+        "Familiens faste handleliste med varer som følger på tvers av ukeplaner.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const [result, recentManualItems] = await Promise.all([
+    getFamilyShoppingData({
+      familyId,
+      userId: user.id,
+    }),
+    listRecentManualShoppingItemsForFamily({
+      familyId,
+    }),
+  ]);
+
+  return {
+    categories: result.categories,
+    family: result.family,
+    itemCounts: result.itemCounts,
+    notice: getFamilyShoppingNotice(request),
+    recentManualItems,
+    storeGroups: result.storeGroups.map((group) => ({
+      sections: group.sections.map((section) => ({
+        ...section,
+        items: section.items.map((item) => ({
+          ...item,
+          collaborationVersion: item.collaborationVersion,
+        })),
+      })),
+      store: group.store,
+    })),
+    stores: result.stores,
+    userRole: result.userRole,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "add-family-shopping-item") {
+    const result = await createFamilyShoppingItem({
+      familyId,
+      userId: user.id,
+      values: parseFamilyShoppingItemValues(formData),
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        familyFieldErrors: result.fieldErrors,
+        familyValues: result.values,
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    return buildFamilyShoppingRedirect({
+      familyId,
+      notice: "family-shopping-item-added",
+      request,
+    });
+  }
+
+  if (intent === "quick-add-family-shopping-item") {
+    const result = await createQuickFamilyShoppingItem({
+      familyId,
+      input: parseQuickAddFamilyShoppingItemInput(formData),
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        familyFieldErrors: result.fieldErrors,
+        familyValues: result.values,
+        formError: "formError" in result ? result.formError : undefined,
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    return buildFamilyShoppingRedirect({
+      familyId,
+      notice: "family-shopping-item-added",
+      request,
+    });
+  }
+
+  if (intent === "update-family-shopping-item") {
+    const familyItemId = String(formData.get("familyItemId") ?? "");
+
+    if (!familyItemId) {
+      return {
+        formError: "Fant ikke varelinjen som skulle oppdateres.",
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    const result = await updateFamilyShoppingItem({
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      familyItemId,
+      userId: user.id,
+      values: parseFamilyShoppingItemValues(formData),
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke varelinjen som skulle oppdateres.",
+        intent,
+        itemTarget: { sourceKey: familyItemId },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+        itemTarget: { sourceKey: familyItemId },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        familyFieldErrors: result.fieldErrors,
+        familyValues: result.values,
+        intent,
+        itemTarget: { sourceKey: familyItemId },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    return buildFamilyShoppingRedirect({
+      familyId,
+      notice: "family-shopping-item-updated",
+      request,
+    });
+  }
+
+  if (intent === "delete-family-shopping-item") {
+    const familyItemId = String(formData.get("familyItemId") ?? "");
+
+    if (!familyItemId) {
+      return {
+        formError: "Fant ikke varelinjen som skulle slettes.",
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    const result = await deleteFamilyShoppingItem({
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      familyItemId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke varelinjen som skulle slettes.",
+        intent,
+        itemTarget: { sourceKey: familyItemId },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+        itemTarget: { sourceKey: familyItemId },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    return buildFamilyShoppingRedirect({
+      familyId,
+      notice: "family-shopping-item-deleted",
+      request,
+    });
+  }
+
+  if (intent === "toggle-family-shopping-item-checked") {
+    const familyItemId = String(formData.get("sourceKey") ?? "").trim();
+    const checked = String(formData.get("checked") ?? "") === "true";
+
+    if (!familyItemId) {
+      return {
+        formError: "Fant ikke varelinjen som skulle oppdateres.",
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    const result = await toggleFamilyShoppingItemChecked({
+      checked,
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      familyItemId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke varelinjen som skulle oppdateres.",
+        intent,
+        itemTarget: { sourceKey: familyItemId },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+        itemTarget: { sourceKey: familyItemId },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    return buildFamilyShoppingRedirect({
+      familyId,
+      notice: "family-shopping-item-check-state-updated",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies FamilyShoppingActionData;
+}
+
+export default function FamilyShoppingRoute({
+  actionData,
+  loaderData,
+}: {
+  actionData?: FamilyShoppingActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}) {
+  const navigation = useNavigation();
+  const noticeContent =
+    loaderData.notice !== null
+      ? getFamilyShoppingNoticeContent(loaderData.notice)
+      : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const pendingSourceKey = getPendingSourceKey(navigation.formData);
+  const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
+  const addFamilyValues =
+    actionData?.intent === "add-family-shopping-item" && actionData.familyValues
+      ? actionData.familyValues
+      : defaultFamilyShoppingItemValues;
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Alltid på listen
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Varer her følger familien på tvers av ukeplaner og vises i
+                handlelisten når dere handler for en uke.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Åpne ukeplaner
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}`}
+              >
+                Tilbake til familie
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere listen
+            </h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">Oversikt</h2>
+            <dl className="mt-6 grid gap-4">
+              <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                  Totalt
+                </dt>
+                <dd className="mt-2 text-base font-semibold text-slate-950">
+                  {loaderData.itemCounts.total} varelinjer
+                </dd>
+              </div>
+              <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                  Gjenstår
+                </dt>
+                <dd className="mt-2 text-sm leading-6 text-slate-700">
+                  {loaderData.itemCounts.unchecked} å handle,{" "}
+                  {loaderData.itemCounts.checked} kjøpt.
+                </dd>
+              </div>
+            </dl>
+          </article>
+
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">
+              Legg til vare
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Bruk hurtigvalg eller det avanserte skjemaet for å legge til varer
+              som skal med uansett ukeplan.
+            </p>
+
+            {actionData?.intent === "quick-add-family-shopping-item" &&
+            actionData.formError ? (
+              <p className="mt-4 text-sm text-rose-600">{actionData.formError}</p>
+            ) : null}
+
+            <div className="mt-6">
+              <ManualShoppingQuickAdd
+                ingredientSearchPath={ingredientSearchPath}
+                quickAddIntent="quick-add-family-shopping-item"
+                recentManualItems={loaderData.recentManualItems}
+              />
+            </div>
+
+            <details className="mt-6 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <summary className="cursor-pointer text-sm font-medium text-slate-800">
+                Avansert: legg til med alle felt
+              </summary>
+              <Form className="mt-4 space-y-4" method="post">
+                <input
+                  name="intent"
+                  type="hidden"
+                  value="add-family-shopping-item"
+                />
+                <label className="block text-sm font-medium text-slate-700">
+                  Varenavn
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+                    defaultValue={addFamilyValues.name}
+                    name="name"
+                    type="text"
+                  />
+                </label>
+                <label className="block text-sm font-medium text-slate-700">
+                  Mengde
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+                    defaultValue={addFamilyValues.quantity}
+                    name="quantity"
+                    type="text"
+                  />
+                </label>
+                <label className="block text-sm font-medium text-slate-700">
+                  Kategori
+                  <select
+                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm"
+                    defaultValue={addFamilyValues.categoryId}
+                    name="categoryId"
+                  >
+                    <option value="">Velg kategori</option>
+                    {loaderData.categories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button
+                  className="rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+                  type="submit"
+                >
+                  Legg til vare
+                </button>
+              </Form>
+            </details>
+          </article>
+        </section>
+
+        {loaderData.storeGroups.length ? (
+          <section className="grid gap-6">
+            {loaderData.storeGroups.map((group) => (
+              <article
+                key={group.store?.id ?? "no-store"}
+                className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200"
+              >
+                <h2 className="text-lg font-semibold text-slate-950">
+                  {group.store?.name ?? "Ingen valgt butikk"}
+                </h2>
+                <div className="mt-6 grid gap-5">
+                  {group.sections.map((section) => (
+                    <section
+                      key={`${group.store?.id ?? "no-store"}:${section.category.id}`}
+                    >
+                      <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        {section.displayName}
+                      </h3>
+                      <div className="mt-3 grid gap-2">
+                        {section.items
+                          .filter((item) => item.sourceType === "FAMILY")
+                          .map((item) => {
+                          const isPendingCheckToggle =
+                            navigation.state === "submitting" &&
+                            pendingIntent ===
+                              "toggle-family-shopping-item-checked" &&
+                            pendingSourceKey === item.sourceKey;
+                          const isPendingFamilySave =
+                            navigation.state === "submitting" &&
+                            pendingIntent === "update-family-shopping-item" &&
+                            pendingSourceKey === item.sourceKey;
+                          const isPendingFamilyDelete =
+                            navigation.state === "submitting" &&
+                            pendingIntent === "delete-family-shopping-item" &&
+                            pendingSourceKey === item.sourceKey;
+                          const familyValues =
+                            actionData?.intent ===
+                              "update-family-shopping-item" &&
+                            actionData.itemTarget?.sourceKey ===
+                              item.sourceKey &&
+                            actionData.familyValues
+                              ? actionData.familyValues
+                              : item.sourceType === "FAMILY"
+                                ? {
+                                    categoryId: item.category.id,
+                                    name: item.name,
+                                    note: item.note ?? "",
+                                    preferredStoreId:
+                                      item.preferredStore?.id ?? "",
+                                    quantity: item.quantity ?? "",
+                                  }
+                                : null;
+
+                          return (
+                            <article
+                              key={item.sourceKey}
+                              className={`rounded-[24px] border p-4 ${
+                                item.checked
+                                  ? "border-slate-200 bg-slate-100 opacity-80"
+                                  : "border-slate-200 bg-slate-50"
+                              }`}
+                            >
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4
+                                  className={`text-base font-semibold ${
+                                    item.checked
+                                      ? "text-slate-500 line-through"
+                                      : "text-slate-950"
+                                  }`}
+                                >
+                                  {item.name}
+                                </h4>
+                                {formatGeneratedQuantityBadge(item) ? (
+                                  <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                                    {formatGeneratedQuantityBadge(item)}
+                                  </span>
+                                ) : null}
+                                <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800">
+                                  Alltid på listen
+                                </span>
+                              </div>
+                              {formatCompactShoppingSourceLine(item) ? (
+                                <p className="mt-2 text-xs text-slate-600">
+                                  {formatCompactShoppingSourceLine(item)}
+                                </p>
+                              ) : null}
+                              <details className="mt-4">
+                                <summary className="cursor-pointer text-sm font-medium text-slate-800">
+                                  Detaljer
+                                </summary>
+                                <div className="mt-4">
+                                  <ShoppingListItemExpanded
+                                    actionData={actionData}
+                                    categories={loaderData.categories}
+                                    familyValues={familyValues}
+                                    isPendingCheckToggle={isPendingCheckToggle}
+                                    isPendingFamilyDelete={isPendingFamilyDelete}
+                                    isPendingFamilySave={isPendingFamilySave}
+                                    isPendingGeneratedExclude={false}
+                                    isPendingGeneratedSave={false}
+                                    isPendingManualDelete={false}
+                                    isPendingManualSave={false}
+                                    item={item}
+                                    manualValues={null}
+                                    overrideValues={null}
+                                    stores={loaderData.stores}
+                                    toggleExpectedVersion={getToggleExpectedVersion(
+                                      item,
+                                    )}
+                                  />
+                                </div>
+                              </details>
+                            </article>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </section>
+        ) : (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">
+              Listen er tom
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Legg til den første varen med skjemaet over.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi klarte ikke å laste familiens handleliste akkurat nå.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke familien" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-16 text-slate-900">
+      <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+          to="/app"
+        >
+          Til appen
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}
+
+function buildFamilyShoppingRedirect({
+  familyId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  notice: FamilyShoppingNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/shopping`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function getFamilyShoppingNotice(
+  request: Request,
+): FamilyShoppingNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (
+    notice === "family-shopping-item-added" ||
+    notice === "family-shopping-item-deleted" ||
+    notice === "family-shopping-item-updated" ||
+    notice === "family-shopping-item-check-state-updated"
+  ) {
+    return notice;
+  }
+
+  return null;
+}
+
+function getFamilyShoppingNoticeContent(notice: FamilyShoppingNotice) {
+  switch (notice) {
+    case "family-shopping-item-added":
+      return {
+        description: "Varen er lagt til på familiens faste liste.",
+        title: "Vare lagt til",
+      };
+    case "family-shopping-item-deleted":
+      return {
+        description: "Varen er fjernet fra familiens faste liste.",
+        title: "Vare fjernet",
+      };
+    case "family-shopping-item-updated":
+      return {
+        description: "Endringene på varelinjen er lagret.",
+        title: "Vare oppdatert",
+      };
+    case "family-shopping-item-check-state-updated":
+      return {
+        description: "Avkryssingen er oppdatert.",
+        title: "Status oppdatert",
+      };
+  }
+}
+
+function parseExpectedUpdatedAt(formData: FormData) {
+  return String(formData.get("expectedUpdatedAt") ?? "");
+}
+
+function getPendingSourceKey(formData: FormData | undefined) {
+  if (!formData) {
+    return null;
+  }
+
+  const sourceKey = formData.get("sourceKey");
+  const familyItemId = formData.get("familyItemId");
+
+  if (typeof sourceKey === "string" && sourceKey.length > 0) {
+    return sourceKey;
+  }
+
+  if (typeof familyItemId === "string" && familyItemId.length > 0) {
+    return familyItemId;
+  }
+
+  return null;
+}

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -231,25 +231,48 @@ export default function FamilyRoute({
           </article>
         </section>
 
-        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold text-slate-950">
-                Ukeplaner
-              </h2>
-              <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                Gå videre til familiens ukeplaner for å opprette, velge og
-                oppdatere planer med start- og sluttdato.
-              </p>
-            </div>
+        <section className="grid gap-4 lg:grid-cols-2">
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-950">
+                  Ukeplaner
+                </h2>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                  Gå videre til familiens ukeplaner for å opprette, velge og
+                  oppdatere planer med start- og sluttdato.
+                </p>
+              </div>
 
-            <Link
-              className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
-              to={`/families/${loaderData.family.id}/meal-plans`}
-            >
-              Administrer ukeplaner
-            </Link>
-          </div>
+              <Link
+                className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Administrer ukeplaner
+              </Link>
+            </div>
+          </article>
+
+          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-950">
+                  Alltid på listen
+                </h2>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                  Varer som skal handles uansett ukeplan, for eksempel
+                  batterier eller andre faste behov.
+                </p>
+              </div>
+
+              <Link
+                className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                to={`/families/${loaderData.family.id}/shopping`}
+              >
+                Åpne listen
+              </Link>
+            </div>
+          </article>
         </section>
 
         {isAdmin ? (

--- a/prisma/migrations/20260523183647_add_family_shopping_item/migration.sql
+++ b/prisma/migrations/20260523183647_add_family_shopping_item/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable
+CREATE TABLE "FamilyShoppingItem" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "quantity" TEXT,
+    "categoryId" TEXT NOT NULL,
+    "preferredStoreId" TEXT,
+    "note" TEXT,
+    "checked" BOOLEAN NOT NULL DEFAULT false,
+    "updatedByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FamilyShoppingItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FamilyShoppingItem_familyId_idx" ON "FamilyShoppingItem"("familyId");
+
+-- CreateIndex
+CREATE INDEX "FamilyShoppingItem_familyId_checked_idx" ON "FamilyShoppingItem"("familyId", "checked");
+
+-- CreateIndex
+CREATE INDEX "FamilyShoppingItem_updatedByUserId_idx" ON "FamilyShoppingItem"("updatedByUserId");
+
+-- CreateIndex
+CREATE INDEX "FamilyShoppingItem_categoryId_idx" ON "FamilyShoppingItem"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "FamilyShoppingItem_preferredStoreId_idx" ON "FamilyShoppingItem"("preferredStoreId");
+
+-- AddForeignKey
+ALTER TABLE "FamilyShoppingItem" ADD CONSTRAINT "FamilyShoppingItem_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FamilyShoppingItem" ADD CONSTRAINT "FamilyShoppingItem_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "IngredientCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FamilyShoppingItem" ADD CONSTRAINT "FamilyShoppingItem_preferredStoreId_fkey" FOREIGN KEY ("preferredStoreId") REFERENCES "Store"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FamilyShoppingItem" ADD CONSTRAINT "FamilyShoppingItem_updatedByUserId_fkey" FOREIGN KEY ("updatedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model User {
   updatedMealPlans             MealPlan[]             @relation("MealPlanUpdatedBy")
   updatedMealPlanEntries       MealPlanEntry[]        @relation("MealPlanEntryUpdatedBy")
   updatedManualShoppingItems   ManualShoppingItem[]   @relation("ManualShoppingItemUpdatedBy")
+  updatedFamilyShoppingItems   FamilyShoppingItem[]   @relation("FamilyShoppingItemUpdatedBy")
   updatedShoppingItemOverrides ShoppingItemOverride[] @relation("ShoppingItemOverrideUpdatedBy")
   storePreferences             UserStorePreference[]
   sharedMealPlans              MealPlanShare[]        @relation("MealPlanShareSharedBy")
@@ -91,6 +92,7 @@ model Family {
   stores              Store[]
   storePreferences    UserStorePreference[]
   stockIngredients    FamilyStockIngredient[]
+  shoppingItems       FamilyShoppingItem[]
 
   @@index([createdByUserId])
   @@index([name])
@@ -120,6 +122,7 @@ model IngredientCategory {
   ingredients         Ingredient[]
   recipeIngredients   RecipeIngredient[]
   manualShoppingItems ManualShoppingItem[]
+  familyShoppingItems FamilyShoppingItem[]
   storeSections       StoreSection[]
 
   @@index([displayName])
@@ -342,6 +345,30 @@ model ManualShoppingItem {
   @@index([buyOnDate])
 }
 
+model FamilyShoppingItem {
+  id               String   @id @default(cuid())
+  familyId         String
+  name             String
+  quantity         String?
+  categoryId       String
+  preferredStoreId String?
+  note             String?
+  checked          Boolean  @default(false)
+  updatedByUserId  String?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+  family           Family             @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  category         IngredientCategory @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  preferredStore   Store?             @relation("FamilyShoppingItemPreferredStore", fields: [preferredStoreId], references: [id], onDelete: SetNull)
+  updatedByUser    User?              @relation("FamilyShoppingItemUpdatedBy", fields: [updatedByUserId], references: [id], onDelete: SetNull)
+
+  @@index([familyId])
+  @@index([familyId, checked])
+  @@index([updatedByUserId])
+  @@index([categoryId])
+  @@index([preferredStoreId])
+}
+
 model ShoppingItemOverride {
   id                 String             @id @default(cuid())
   mealPlanId         String
@@ -378,6 +405,7 @@ model Store {
   sections                   StoreSection[]
   recipeIngredientsPreferred RecipeIngredient[]     @relation("RecipeIngredientPreferredStore")
   manualItemsPreferred       ManualShoppingItem[]   @relation("ManualShoppingItemPreferredStore")
+  familyItemsPreferred       FamilyShoppingItem[]   @relation("FamilyShoppingItemPreferredStore")
   shoppingOverridesPreferred ShoppingItemOverride[] @relation("ShoppingItemOverridePreferredStore")
   selectedByPreferences      UserStorePreference[]  @relation("UserStorePreferenceSelectedStore")
 


### PR DESCRIPTION
## Summary
- Introduces a family-scoped shopping list for items that are not tied to a specific meal plan (e.g. batteries, household staples).
- New `/families/:familyId/shopping` route for full CRUD; family hub links to it as **Alltid på listen**.
- Unchecked family items appear in meal-plan shopping (pinned section) and store mode; checking off updates the family row and persists across weeks.

## Related issue
Closes #86

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Add item on family shopping page
- [ ] Confirm it appears on meal-plan shopping and store mode
- [ ] Check off in store mode; verify it stays done on the family page and does not reappear on another meal plan

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (239 tests)
- npm run typecheck