### PR TITLE
Dock family quick-add at the bottom of store mode

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,36 @@
 
 ## Current Objective
 
-Issue #86 — family-wide shopping list (“Alltid på listen”) on branch `issue/86-family-shopping-list`, ready for PR merge.
+Issue #88 — streamline meal-plan store mode for "heading out to shop" on branch `issue/88-store-mode-quick-add`. Ready for PR.
 
 ## Completed
 
-- Added `FamilyShoppingItem` model and migration; checked state lives on the row (not meal-plan overrides).
-- New `/families/:familyId/shopping` route with CRUD, quick-add, and ingredient search.
-- Merged unchecked family items into meal-plan shopping (pinned section) and store mode (due items + progress).
-- Link from family hub; store mode uses separate toggle action; no badge on store mode cards (details panel only).
+- Compact single-row header replaces the large hero (`family-meal-plan-store-mode.tsx`).
+- Store and date pickers collapsed inside a `<details>` block with summary preview of current selection.
+- Family-scoped quick-add docked at the bottom of the viewport using a new `revealOnFocus` mode on `ManualShoppingQuickAdd`.
+  - Idle: slim input + button only.
+  - On focus: recently used items slide up above the input; ingredient search dropdown opens upward.
+- Loader includes `recentManualItems` via `listRecentManualShoppingItemsForFamily`.
+- Action handles `quick-add-family-shopping-item` → `createQuickFamilyShoppingItem` with new `family-shopping-item-added` notice.
 
 ## Files To Read First
 
-- `app/lib/family-shopping-write.server.ts` — family item mutations
-- `app/lib/shopping.server.ts` — projection, `familyStoreGroups`, store mode merge
-- `app/routes/family-shopping.tsx` — management UI
-- `app/routes/family-meal-plan-shopping.tsx` — merged “Alltid på listen” section
+- `app/routes/family-meal-plan-store-mode.tsx` — layout, loader/action, fixed dock
+- `app/components/manual-shopping-quick-add.tsx` — `revealOnFocus` docked variant
+- `app/routes/family-meal-plan-store-mode.test.ts` — loader recents and quick-add coverage
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 239 tests passed (42 files)
+- `npm run test:run` — 241 tests passed (42 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke: add item on family page → appears on meal-plan shopping + store mode → check off persists across weeks.
+- Manual smoke: mobile viewport — slim quick-add bar at bottom, focus reveals recents, list scrolls underneath; quick-add item also appears on `/families/:id/shopping`.
 
 ## Next Step
 
-Merge PR when CI is green; closes #86.
+Merge PR when CI is green; closes #88.

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -17,6 +17,13 @@ interface ManualShoppingQuickAddProps {
   ingredientSearchPath: string;
   quickAddIntent?: string;
   recentManualItems: RecentManualShoppingItem[];
+  /**
+   * Compact docked layout: hides label/description and recently used items
+   * until the input is focused, then slides them up above the input.
+   * Search dropdown also opens upward. Intended for fixed bottom bars where
+   * the thumb-reachable input should stay small until the user engages.
+   */
+  revealOnFocus?: boolean;
 }
 
 const MIN_SEARCH_LENGTH = 2;
@@ -27,6 +34,7 @@ export function ManualShoppingQuickAdd({
   ingredientSearchPath,
   quickAddIntent = DEFAULT_QUICK_ADD_INTENT,
   recentManualItems,
+  revealOnFocus = false,
 }: ManualShoppingQuickAddProps) {
   const listboxId = useId();
   const navigation = useNavigation();
@@ -36,6 +44,7 @@ export function ManualShoppingQuickAdd({
   });
   const [query, setQuery] = useState("");
   const [isListOpen, setIsListOpen] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
   const [displayedResults, setDisplayedResults] = useState<IngredientSearchResult[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
   const lastRequestedQueryRef = useRef<string | null>(null);
@@ -104,6 +113,7 @@ export function ManualShoppingQuickAdd({
     function handlePointerDown(event: MouseEvent) {
       if (!containerRef.current?.contains(event.target as Node)) {
         setIsListOpen(false);
+        setIsInputFocused(false);
       }
     }
 
@@ -120,6 +130,7 @@ export function ManualShoppingQuickAdd({
     }
 
     setIsListOpen(false);
+    setIsInputFocused(false);
     setQuery("");
     lastRequestedQueryRef.current = null;
   }, [isQuickAdding]);
@@ -134,19 +145,62 @@ export function ManualShoppingQuickAdd({
   );
   const showDropdown = isListOpen && trimmedQuery.length >= MIN_SEARCH_LENGTH;
   const showCreateOption = trimmedQuery.length > 0 && !hasExactMatch && !isSearching;
+  const isExpanded =
+    !revealOnFocus || isInputFocused || trimmedQuery.length > 0;
+  const recentsBlock =
+    recentManualItems.length > 0 ? (
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-slate-700">Nylig brukt</p>
+        <div className="flex flex-wrap gap-2">
+          {recentManualItems.map((item) => (
+            <button
+              key={item.nameNormalized}
+              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-800 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isQuickAdding}
+              onClick={() => {
+                submitQuickAdd({ recentNameNormalized: item.nameNormalized });
+              }}
+              type="button"
+            >
+              {item.displayName}
+            </button>
+          ))}
+        </div>
+      </div>
+    ) : null;
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-2">
-        <label className="block text-sm font-medium text-slate-700" htmlFor={`${listboxId}-input`}>
-          Legg til vare
-        </label>
+    <div className="flex flex-col gap-3" ref={containerRef}>
+      <label
+        className={
+          revealOnFocus
+            ? "sr-only"
+            : "block text-sm font-medium text-slate-700"
+        }
+        htmlFor={`${listboxId}-input`}
+      >
+        Legg til vare
+      </label>
+      {!revealOnFocus ? (
         <p className="text-sm leading-6 text-slate-600">
           Søk i ingrediensregisteret, skriv et nytt navn, eller velg en nylig brukt vare.
         </p>
-      </div>
+      ) : null}
 
-      <div className="relative" ref={containerRef}>
+      {revealOnFocus && recentsBlock ? (
+        <div
+          aria-hidden={!isExpanded}
+          className={`grid transition-[grid-template-rows,opacity,transform] duration-200 ease-out ${
+            isExpanded
+              ? "translate-y-0 grid-rows-[1fr] opacity-100"
+              : "pointer-events-none -translate-y-1 grid-rows-[0fr] opacity-0"
+          }`}
+        >
+          <div className="overflow-hidden">{recentsBlock}</div>
+        </div>
+      ) : null}
+
+      <div className="relative">
         <div className="flex gap-2">
           <input
             aria-autocomplete="list"
@@ -161,6 +215,7 @@ export function ManualShoppingQuickAdd({
             }}
             onFocus={() => {
               setIsListOpen(true);
+              setIsInputFocused(true);
             }}
             onKeyDown={(event) => {
               if (event.key === "Escape") {
@@ -191,7 +246,11 @@ export function ManualShoppingQuickAdd({
 
         {showDropdown ? (
           <ul
-            className="absolute z-10 mt-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg"
+            className={
+              revealOnFocus
+                ? "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg"
+                : "absolute z-10 mt-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg"
+            }
             id={listboxId}
             role="listbox"
           >
@@ -233,26 +292,7 @@ export function ManualShoppingQuickAdd({
         ) : null}
       </div>
 
-      {recentManualItems.length > 0 ? (
-        <div className="space-y-2">
-          <p className="text-sm font-medium text-slate-700">Nylig brukt</p>
-          <div className="flex flex-wrap gap-2">
-            {recentManualItems.map((item) => (
-              <button
-                key={item.nameNormalized}
-                className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-800 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={isQuickAdding}
-                onClick={() => {
-                  submitQuickAdd({ recentNameNormalized: item.nameNormalized });
-                }}
-                type="button"
-              >
-                {item.displayName}
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : null}
+      {!revealOnFocus && recentsBlock ? recentsBlock : null}
     </div>
   );
 }

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -12,6 +12,15 @@ vi.mock("../lib/auth.server", async () => {
 vi.mock("../lib/shopping.server", () => {
   return {
     getMealPlanStoreModeData: vi.fn(),
+    listRecentManualShoppingItemsForFamily: vi.fn(),
+  };
+});
+
+vi.mock("../lib/family-shopping-write.server", () => {
+  return {
+    createQuickFamilyShoppingItem: vi.fn(),
+    parseQuickAddFamilyShoppingItemInput: vi.fn(),
+    toggleFamilyShoppingItemChecked: vi.fn(),
   };
 });
 
@@ -28,8 +37,15 @@ vi.mock("../lib/store-write.server", () => {
   };
 });
 
+import {
+  createQuickFamilyShoppingItem,
+  parseQuickAddFamilyShoppingItemInput,
+} from "../lib/family-shopping-write.server";
 import { requireUser } from "../lib/auth.server";
-import { getMealPlanStoreModeData } from "../lib/shopping.server";
+import {
+  getMealPlanStoreModeData,
+  listRecentManualShoppingItemsForFamily,
+} from "../lib/shopping.server";
 import { toggleShoppingItemChecked, updateActiveShoppingDate } from "../lib/shopping-write.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
 import { action, loader } from "./family-meal-plan-store-mode";
@@ -58,6 +74,14 @@ describe("family meal plan store mode route", () => {
 
   it("loads and serializes store mode data", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([
+      {
+        categoryId: "",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "",
+      },
+    ]);
     vi.mocked(getMealPlanStoreModeData).mockResolvedValue({
       activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
       dueSectionGroups: [
@@ -161,6 +185,17 @@ describe("family meal plan store mode route", () => {
       mealPlanId: "meal-plan-1",
       userId: "user-1",
     });
+    expect(listRecentManualShoppingItemsForFamily).toHaveBeenCalledWith({
+      familyId: "family-1",
+    });
+    expect(result.recentManualItems).toEqual([
+      {
+        categoryId: "",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "",
+      },
+    ]);
     expect(result.activeShoppingDate).toBe("2026-05-16");
     expect(result.mealPlan.activeShoppingDate).toBe("2026-05-16");
     expect(result.dueSectionGroups[0]?.items[0]).toEqual(
@@ -209,6 +244,83 @@ describe("family meal plan store mode route", () => {
       },
       activeShoppingDateValue: "2026-05-20",
       intent: "update-active-shopping-date",
+    });
+  });
+
+  it("redirects after a family quick-add", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      ingredientId: "ingredient-1",
+      name: "Melk",
+      recentNameNormalized: "",
+    });
+    vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "quick-add-family-shopping-item");
+    formData.set("name", "Melk");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(createQuickFamilyShoppingItem).toHaveBeenCalledWith({
+      familyId: "family-1",
+      input: {
+        ingredientId: "ingredient-1",
+        name: "Melk",
+        recentNameNormalized: "",
+      },
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1/store-mode?notice=family-shopping-item-added",
+    );
+  });
+
+  it("returns quick-add validation errors without redirecting", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      ingredientId: "",
+      name: "",
+      recentNameNormalized: "",
+    });
+    vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
+      fieldErrors: {
+        name: "Skriv inn et varenavn.",
+      },
+      formError: "Kunne ikke legge til varen.",
+      status: "VALIDATION_ERROR",
+      values: {
+        categoryId: "",
+        name: "",
+        note: "",
+        preferredStoreId: "",
+        quantity: "",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "quick-add-family-shopping-item");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(result).toEqual({
+      formError: "Kunne ikke legge til varen.",
+      intent: "quick-add-family-shopping-item",
     });
   });
 

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -12,10 +12,16 @@ import {
   type MetaFunction,
 } from "react-router";
 
+import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
 import { StoreModeDeprioritizeBoughtToggle } from "../components/store-mode-deprioritize-bought-toggle";
 import { StoreModeShoppingItemCard } from "../components/store-mode-shopping-item-card";
 import { StoreModeShoppingViewToggle } from "../components/store-mode-shopping-view-toggle";
 import { requireUser } from "../lib/auth.server";
+import {
+  createQuickFamilyShoppingItem,
+  parseQuickAddFamilyShoppingItemInput,
+  toggleFamilyShoppingItemChecked,
+} from "../lib/family-shopping-write.server";
 import {
   buildStoreModeDeprioritizeBoughtStorageKey,
   buildStoreModeViewStorageKey,
@@ -27,8 +33,10 @@ import {
   writeStoreModeDeprioritizeBought,
   writeStoreModeShoppingView,
 } from "../lib/shopping-store-mode-client";
-import { toggleFamilyShoppingItemChecked } from "../lib/family-shopping-write.server";
-import { getMealPlanStoreModeData } from "../lib/shopping.server";
+import {
+  getMealPlanStoreModeData,
+  listRecentManualShoppingItemsForFamily,
+} from "../lib/shopping.server";
 import {
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
@@ -41,10 +49,12 @@ import {
 
 type StoreModeNotice =
   | "active-shopping-date-updated"
+  | "family-shopping-item-added"
   | "selected-store-updated"
   | "shopping-item-check-state-updated";
 
 type StoreModeIntent =
+  | "quick-add-family-shopping-item"
   | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
   | "update-active-shopping-date"
@@ -95,11 +105,16 @@ export async function loader({
     params.mealPlanId,
     "Fant ikke ukeplanen.",
   );
-  const result = await getMealPlanStoreModeData({
-    familyId,
-    mealPlanId,
-    userId: user.id,
-  });
+  const [result, recentManualItems] = await Promise.all([
+    getMealPlanStoreModeData({
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    }),
+    listRecentManualShoppingItemsForFamily({
+      familyId,
+    }),
+  ]);
 
   return {
     activeShoppingDate: formatDateOnly(result.activeShoppingDate),
@@ -123,6 +138,7 @@ export async function loader({
     },
     notice: getStoreModeNotice(request),
     progress: result.progress,
+    recentManualItems,
     selectedStore: result.selectedStore,
     stockIngredientCount: result.stockIngredientCount,
     stores: result.stores,
@@ -209,6 +225,28 @@ export async function action({
       familyId,
       mealPlanId,
       notice: "selected-store-updated",
+      request,
+    });
+  }
+
+  if (intent === "quick-add-family-shopping-item") {
+    const result = await createQuickFamilyShoppingItem({
+      familyId,
+      input: parseQuickAddFamilyShoppingItemInput(formData),
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        formError: "formError" in result ? result.formError : undefined,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    return buildStoreModeRedirect({
+      familyId,
+      mealPlanId,
+      notice: "family-shopping-item-added",
       request,
     });
   }
@@ -411,62 +449,55 @@ export default function FamilyMealPlanStoreModeRoute({
     actionData.activeShoppingDateValue
       ? actionData.activeShoppingDateValue
       : loaderData.activeShoppingDate;
+  const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
+  const quickAddFormError =
+    actionData?.intent === "quick-add-family-shopping-item"
+      ? actionData.formError
+      : undefined;
+  const generalFormError =
+    actionData?.formError &&
+    actionData.intent !== "quick-add-family-shopping-item"
+      ? actionData.formError
+      : undefined;
 
   return (
-    <main className="min-h-screen bg-slate-100 px-4 py-8 text-slate-900">
+    <main className="min-h-screen bg-slate-100 px-4 pb-36 pt-8 text-slate-900">
       <div className="mx-auto flex max-w-4xl flex-col gap-5">
-        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
-          <div className="flex flex-col gap-6">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
-                  Butikkmodus
-                </span>
-                <h1 className="mt-4 text-3xl font-semibold tracking-tight">
-                  {loaderData.mealPlan.title}
-                </h1>
-                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300">
-                  Storflatevisning for handleturen med seksjonsrekkefølge fra
-                  valgt butikk og varer fra handledato og utover i ukeplanen.
-                </p>
-              </div>
-              <div className="flex flex-wrap gap-3">
-                <Link
-                  className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
-                  to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
-                >
-                  Åpne handleliste
-                </Link>
-                <Link
-                  className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
-                  to={`/families/${loaderData.family.id}/stores`}
-                >
-                  Administrer butikker
-                </Link>
-              </div>
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded-[24px] bg-white/10 p-4">
-                <p className="text-sm text-slate-300">Aktiv butikk</p>
-                <p className="mt-1 text-lg font-semibold">
-                  {loaderData.selectedStore?.name ?? "Ingen valgt butikk"}
-                </p>
-              </div>
-              <div className="rounded-[24px] bg-white/10 p-4">
-                <p className="text-sm text-slate-300">Handledato</p>
-                <p className="mt-1 text-lg font-semibold">
-                  {formatDateLabel(loaderData.activeShoppingDate)}
-                </p>
-              </div>
-              <div className="rounded-[24px] bg-emerald-500/20 p-4 ring-1 ring-emerald-400/30">
-                <p className="text-sm text-emerald-100">Fremdrift</p>
-                <p className="mt-1 text-lg font-semibold">
-                  {displayProgress.checkedCount}/{displayProgress.totalCount}{" "}
-                  varer krysset av
-                </p>
-              </div>
-            </div>
+        <section className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-2xl bg-white px-4 py-3 text-sm shadow-sm ring-1 ring-slate-200">
+          <h1 className="min-w-0 truncate font-semibold text-slate-950">
+            {loaderData.mealPlan.title}
+          </h1>
+          <span className="hidden text-slate-300 sm:inline" aria-hidden="true">
+            ·
+          </span>
+          <span className="truncate text-slate-600">
+            {loaderData.selectedStore?.name ?? "Ingen butikk"}
+          </span>
+          <span className="hidden text-slate-300 sm:inline" aria-hidden="true">
+            ·
+          </span>
+          <span className="truncate text-slate-600">
+            {formatDateLabel(loaderData.activeShoppingDate)}
+          </span>
+          <span className="hidden text-slate-300 sm:inline" aria-hidden="true">
+            ·
+          </span>
+          <span className="shrink-0 font-medium text-emerald-700">
+            {displayProgress.checkedCount}/{displayProgress.totalCount}
+          </span>
+          <div className="ml-auto flex shrink-0 items-center gap-3">
+            <Link
+              className="text-slate-600 underline-offset-2 hover:text-slate-950 hover:underline"
+              to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
+            >
+              Handleliste
+            </Link>
+            <Link
+              className="text-slate-600 underline-offset-2 hover:text-slate-950 hover:underline"
+              to={`/families/${loaderData.family.id}/stores`}
+            >
+              Butikker
+            </Link>
           </div>
         </section>
 
@@ -496,12 +527,12 @@ export default function FamilyMealPlanStoreModeRoute({
           </section>
         ) : null}
 
-        {actionData?.formError ? (
+        {generalFormError ? (
           <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
             <h2 className="text-base font-semibold">
               Kunne ikke oppdatere butikkmodus
             </h2>
-            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+            <p className="mt-2 text-sm leading-6">{generalFormError}</p>
           </section>
         ) : null}
 
@@ -523,82 +554,94 @@ export default function FamilyMealPlanStoreModeRoute({
           </section>
         ) : null}
 
-        <section className="grid gap-4 sm:grid-cols-2">
-          <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">
-              Velg butikk
-            </h2>
-            <Form className="mt-4 space-y-3" method="post">
-              <input
-                name="intent"
-                type="hidden"
-                value="update-selected-store"
-              />
-              <select
-                aria-busy={isSavingStore}
-                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
-                defaultValue={selectedStoreValue}
-                disabled={isSavingStore}
-                name="selectedStoreId"
-                onChange={(event) => {
-                  submitSelectForm(event, selectedStoreValue, submit);
-                }}
-              >
-                {loaderData.stores.map((store) => (
-                  <option key={store.id} value={store.id}>
-                    {store.name}
-                  </option>
-                ))}
-              </select>
-              {actionData?.intent === "update-selected-store" &&
-              actionData.selectedStoreFieldErrors?.selectedStoreId ? (
-                <p className="text-sm text-rose-600">
-                  {actionData.selectedStoreFieldErrors.selectedStoreId}
-                </p>
-              ) : null}
-            </Form>
-          </article>
+        <details className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
+          <summary className="cursor-pointer text-sm font-medium text-slate-800">
+            Butikk og handledato
+            <span className="ml-2 font-normal text-slate-500">
+              {loaderData.selectedStore?.name ?? "Ingen butikk"} ·{" "}
+              {formatDateLabel(loaderData.activeShoppingDate)}
+            </span>
+          </summary>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <article>
+              <h2 className="text-base font-semibold text-slate-950">
+                Velg butikk
+              </h2>
+              <Form className="mt-4 space-y-3" method="post">
+                <input
+                  name="intent"
+                  type="hidden"
+                  value="update-selected-store"
+                />
+                <select
+                  aria-busy={isSavingStore}
+                  className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
+                  defaultValue={selectedStoreValue}
+                  disabled={isSavingStore}
+                  name="selectedStoreId"
+                  onChange={(event) => {
+                    submitSelectForm(event, selectedStoreValue, submit);
+                  }}
+                >
+                  {loaderData.stores.map((store) => (
+                    <option key={store.id} value={store.id}>
+                      {store.name}
+                    </option>
+                  ))}
+                </select>
+                {actionData?.intent === "update-selected-store" &&
+                actionData.selectedStoreFieldErrors?.selectedStoreId ? (
+                  <p className="text-sm text-rose-600">
+                    {actionData.selectedStoreFieldErrors.selectedStoreId}
+                  </p>
+                ) : null}
+              </Form>
+            </article>
 
-          <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">
-              Velg handledato
-            </h2>
-            <Form className="mt-4 space-y-3" method="post">
-              <input
-                name="intent"
-                type="hidden"
-                value="update-active-shopping-date"
-              />
-              <input
-                name="mealPlanUpdatedAt"
-                type="hidden"
-                value={loaderData.mealPlan.updatedAt}
-              />
-              <select
-                aria-busy={isSavingShoppingDate}
-                className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
-                defaultValue={activeShoppingDateValue}
-                disabled={isSavingShoppingDate}
-                name="activeShoppingDate"
-                onChange={(event) => {
-                  submitSelectForm(event, activeShoppingDateValue, submit);
-                }}
-              >
-                {loaderData.visibleDates.map((date) => (
-                  <option key={date} value={date}>
-                    {formatDateLabel(date)}
-                  </option>
-                ))}
-              </select>
-              {actionData?.intent === "update-active-shopping-date" &&
-              actionData.activeShoppingDateFieldErrors?.activeShoppingDate ? (
-                <p className="text-sm text-rose-600">
-                  {actionData.activeShoppingDateFieldErrors.activeShoppingDate}
-                </p>
-              ) : null}
-            </Form>
-          </article>
-        </section>
+            <article>
+              <h2 className="text-base font-semibold text-slate-950">
+                Velg handledato
+              </h2>
+              <Form className="mt-4 space-y-3" method="post">
+                <input
+                  name="intent"
+                  type="hidden"
+                  value="update-active-shopping-date"
+                />
+                <input
+                  name="mealPlanUpdatedAt"
+                  type="hidden"
+                  value={loaderData.mealPlan.updatedAt}
+                />
+                <select
+                  aria-busy={isSavingShoppingDate}
+                  className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
+                  defaultValue={activeShoppingDateValue}
+                  disabled={isSavingShoppingDate}
+                  name="activeShoppingDate"
+                  onChange={(event) => {
+                    submitSelectForm(event, activeShoppingDateValue, submit);
+                  }}
+                >
+                  {loaderData.visibleDates.map((date) => (
+                    <option key={date} value={date}>
+                      {formatDateLabel(date)}
+                    </option>
+                  ))}
+                </select>
+                {actionData?.intent === "update-active-shopping-date" &&
+                actionData.activeShoppingDateFieldErrors?.activeShoppingDate ? (
+                  <p className="text-sm text-rose-600">
+                    {
+                      actionData.activeShoppingDateFieldErrors
+                        .activeShoppingDate
+                    }
+                  </p>
+                ) : null}
+              </Form>
+            </article>
+          </div>
+        </details>
 
         {displaySectionGroups.length > 0 ? (
           <section className="grid gap-4">
@@ -711,6 +754,22 @@ export default function FamilyMealPlanStoreModeRoute({
           </div>
         </section>
       </div>
+
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3">
+        <div className="pointer-events-auto mx-auto max-w-4xl">
+          <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200">
+            {quickAddFormError ? (
+              <p className="mb-3 text-sm text-rose-600">{quickAddFormError}</p>
+            ) : null}
+            <ManualShoppingQuickAdd
+              ingredientSearchPath={ingredientSearchPath}
+              quickAddIntent="quick-add-family-shopping-item"
+              recentManualItems={loaderData.recentManualItems}
+              revealOnFocus
+            />
+          </div>
+        </div>
+      </div>
     </main>
   );
 }
@@ -782,6 +841,7 @@ function getStoreModeNotice(request: Request): StoreModeNotice | null {
 
   if (
     notice === "active-shopping-date-updated" ||
+    notice === "family-shopping-item-added" ||
     notice === "selected-store-updated" ||
     notice === "shopping-item-check-state-updated"
   ) {
@@ -807,6 +867,11 @@ function getStoreModeNoticeContent(notice: StoreModeNotice) {
       return {
         description: "Avkryssingen for varelinjen ble oppdatert.",
         title: "Vare oppdatert",
+      };
+    case "family-shopping-item-added":
+      return {
+        description: "Varen ble lagt til og vises i handlelisten.",
+        title: "Vare lagt til",
       };
   }
 }


### PR DESCRIPTION
## Summary

- Compact, single-row header replaces the large hero on the meal-plan store mode page.
- Store and shopping-date pickers collapsed inside a `<details>` panel that shows the current selection in the summary.
- New `revealOnFocus` mode on `ManualShoppingQuickAdd` powers a fixed bottom bar: idle shows just the input + button, focusing the input slides recently used items up above it and opens the search dropdown upward.
- Quick-added items go to the family list (`FamilyShoppingItem`) via `createQuickFamilyShoppingItem` so they persist across meal plans and also show on `/families/:id/shopping`.
- Loader now provides `recentManualItems` via `listRecentManualShoppingItemsForFamily`; action handles `quick-add-family-shopping-item` with a `family-shopping-item-added` notice.

## Related issue

Closes #88

## Test plan

- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual: mobile viewport — slim quick-add bar at bottom; focus reveals recents; list scrolls underneath; added items also appear on `/families/:id/shopping`
- [ ] Manual: expand store/date `<details>`, change values, confirm auto-submit still works

## Validation

- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck