### PR TITLE
Highlight today's date in meal plan day rows

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,36 +2,32 @@
 
 ## Current Objective
 
-Issue #88 — streamline meal-plan store mode for "heading out to shop" on branch `issue/88-store-mode-quick-add`. Ready for PR.
+Issue #90 — highlight today's date in meal plan day rows on branch `issue/90-highlight-today-meal-plan-day`. Ready for PR.
 
 ## Completed
 
-- Compact single-row header replaces the large hero (`family-meal-plan-store-mode.tsx`).
-- Store and date pickers collapsed inside a `<details>` block with summary preview of current selection.
-- Family-scoped quick-add docked at the bottom of the viewport using a new `revealOnFocus` mode on `ManualShoppingQuickAdd`.
-  - Idle: slim input + button only.
-  - On focus: recently used items slide up above the input; ingredient search dropdown opens upward.
-- Loader includes `recentManualItems` via `listRecentManualShoppingItemsForFamily`.
-- Action handles `quick-add-family-shopping-item` → `createQuickFamilyShoppingItem` with new `family-shopping-item-added` notice.
+- `MealPlanDayRow` highlights the current UTC plan date with emerald styling and an **I dag** badge.
+- `isPlanDateToday` / `formatDateOnly` live in client-safe `app/lib/meal-plan-dates.ts`; `meal-plan.server.ts` re-exports for server callers.
+- Route imports `isPlanDateToday` from `meal-plan-dates` (fixes React Router server-only client import error).
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx` — layout, loader/action, fixed dock
-- `app/components/manual-shopping-quick-add.tsx` — `revealOnFocus` docked variant
-- `app/routes/family-meal-plan-store-mode.test.ts` — loader recents and quick-add coverage
+- `app/lib/meal-plan-dates.ts` — shared UTC date helpers
+- `app/routes/family-meal-plan.tsx` — `MealPlanDayRow` and `isToday` wiring
+- `app/lib/meal-plan-dates.test.ts` — `isPlanDateToday` unit tests
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 241 tests passed (42 files)
+- `npm run test:run` — 244 tests passed (43 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - PR review and merge.
-- Manual smoke: mobile viewport — slim quick-add bar at bottom, focus reveals recents, list scrolls underneath; quick-add item also appears on `/families/:id/shopping`.
+- Manual smoke: open a plan spanning today — one emerald row with **I dag**; open another week — no highlight.
 
 ## Next Step
 
-Merge PR when CI is green; closes #88.
+Merge PR when CI is green; closes #90.

--- a/app/lib/meal-plan-dates.test.ts
+++ b/app/lib/meal-plan-dates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { isPlanDateToday } from "./meal-plan-dates";
+
+describe("isPlanDateToday", () => {
+  it("returns true when plan date matches the reference UTC calendar day", () => {
+    const referenceDate = new Date("2026-05-26T15:30:00.000Z");
+
+    expect(isPlanDateToday("2026-05-26", referenceDate)).toBe(true);
+  });
+
+  it("returns false for adjacent plan dates", () => {
+    const referenceDate = new Date("2026-05-26T00:00:00.000Z");
+
+    expect(isPlanDateToday("2026-05-25", referenceDate)).toBe(false);
+    expect(isPlanDateToday("2026-05-27", referenceDate)).toBe(false);
+  });
+
+  it("uses the UTC calendar day near midnight boundaries", () => {
+    const lateUtcEvening = new Date("2026-05-26T23:59:59.000Z");
+    const nextUtcDay = new Date("2026-05-27T00:00:00.000Z");
+
+    expect(isPlanDateToday("2026-05-26", lateUtcEvening)).toBe(true);
+    expect(isPlanDateToday("2026-05-26", nextUtcDay)).toBe(false);
+    expect(isPlanDateToday("2026-05-27", nextUtcDay)).toBe(true);
+  });
+});

--- a/app/lib/meal-plan-dates.ts
+++ b/app/lib/meal-plan-dates.ts
@@ -1,0 +1,14 @@
+export function formatDateOnly(date: Date) {
+  return [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+  ].join("-");
+}
+
+export function isPlanDateToday(
+  planDate: string,
+  referenceDate = new Date(),
+) {
+  return planDate === formatDateOnly(referenceDate);
+}

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -11,10 +11,13 @@ import {
 } from "./collaboration.server";
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
+import { formatDateOnly } from "./meal-plan-dates";
 import {
   logCollaborationFailure,
   logCollaborationWrite,
 } from "./write-observability.server";
+
+export { formatDateOnly, isPlanDateToday } from "./meal-plan-dates";
 
 const MEAL_PLAN_MAX_SPAN_DAYS = 7;
 const MEAL_PLAN_MAX_DAY_OFFSET = MEAL_PLAN_MAX_SPAN_DAYS - 1;
@@ -164,14 +167,6 @@ const AUTO_FILL_NO_ELIGIBLE_RECIPES_MESSAGE =
   "Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de to forrige ukeplanene.";
 const AUTO_FILL_REPEAT_WARNING_MESSAGE =
   "Noen middager ble valgt flere ganger fordi det var for fa oppskrifter igjen.";
-
-export function formatDateOnly(date: Date) {
-  return [
-    date.getUTCFullYear().toString().padStart(4, "0"),
-    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
-    date.getUTCDate().toString().padStart(2, "0"),
-  ].join("-");
-}
 
 export function getMealPlanDateRange(startDate: Date, endDate: Date) {
   let currentDate = new Date(startDate.getTime());

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -17,6 +17,7 @@ import {
   listSharesForMealPlan,
   markReviewCommentAddressed,
 } from "../lib/meal-plan-share.server";
+import { isPlanDateToday } from "../lib/meal-plan-dates";
 import {
   approveMealPlan,
   autoFillMealPlanEntries,
@@ -687,6 +688,7 @@ export default function FamilyMealPlanRoute({
                       date={date}
                       entry={entry}
                       familyId={loaderData.family.id}
+                      isToday={isPlanDateToday(date)}
                       mealPlanId={loaderData.mealPlan.id}
                       recipes={loaderData.recipes}
                     />
@@ -1534,6 +1536,7 @@ function MealPlanDayRow({
   date,
   entry,
   familyId,
+  isToday,
   mealPlanId,
   recipes,
 }: {
@@ -1542,6 +1545,7 @@ function MealPlanDayRow({
   date: string;
   entry: MealPlanEntryFormState;
   familyId: string;
+  isToday: boolean;
   mealPlanId: string;
   recipes: MealPlanRecipeOption[];
 }) {
@@ -1551,8 +1555,14 @@ function MealPlanDayRow({
   const hasNoteOnly = !entry.recipeId && Boolean(entry.note.trim());
 
   return (
-    <details className="group min-w-0 max-w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50">
-      <summary className="flex cursor-pointer list-none items-center justify-between gap-2 p-3 marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-emerald-500 [&::-webkit-details-marker]:hidden">
+    <details
+      className={
+        isToday
+          ? "group min-w-0 max-w-full overflow-hidden rounded-2xl border border-emerald-200 bg-emerald-50 ring-1 ring-emerald-100"
+          : "group min-w-0 max-w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50"
+      }
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-2 p-3 marker:content-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-emerald-500 [&::-webkit-details-marker]:hidden">
         <div className="min-w-0 flex-1">
           <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500">
             {formatWeekdayLabel(date)}
@@ -1563,6 +1573,11 @@ function MealPlanDayRow({
           <p className="text-xs text-slate-500">{formatDateLabel(date)}</p>
         </div>
         <div className="flex shrink-0 flex-col items-end gap-1">
+          {isToday ? (
+            <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-800">
+              I dag
+            </span>
+          ) : null}
           {hasNoteOnly ? (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800">
               Notat


### PR DESCRIPTION
## Summary
- Highlights the current day in **Ukeoversikt** with emerald row styling and an **I dag** badge when today falls within the plan's visible dates.
- Adds client-safe `meal-plan-dates` helpers (`formatDateOnly`, `isPlanDateToday`) so the route component does not import server-only modules.

## Related issue
Closes #90

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: open a meal plan that includes today — one emerald row with **I dag**
- [ ] Manual: open a plan for another week — no row highlighted

## Validation
- `npm run prisma:generate`
- `npm run lint`
- `npm run test:run` (244 tests)
- `npm run typecheck`