### PR TITLE
Mobile quick-add dock for family shopping bookmark

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,33 @@
 
 ## Current Objective
 
-Issue #90 — highlight today's date in meal plan day rows on branch `issue/90-highlight-today-meal-plan-day`. Ready for PR.
+Issue #92 — mobile quick-add bookmark for family shopping on branch `issue/92-mobile-family-shopping-quick-add`. Ready for PR review.
 
 ## Completed
 
-- `MealPlanDayRow` highlights the current UTC plan date with emerald styling and an **I dag** badge.
-- `isPlanDateToday` / `formatDateOnly` live in client-safe `app/lib/meal-plan-dates.ts`; `meal-plan.server.ts` re-exports for server callers.
-- Route imports `isPlanDateToday` from `meal-plan-dates` (fixes React Router server-only client import error).
+- Fixed bottom quick-add dock on mobile (`revealOnFocus`, `autoFocus`, safe-area padding) on `/families/:familyId/shopping`.
+- Desktop (`lg+`) keeps inline `ManualShoppingQuickAdd` in the “Legg til vare” card; single mount via `useIsLgViewport`.
+- `ManualShoppingQuickAdd` gained `autoFocus` and optional `searchFetcherKey` props.
+- Quick-add action tests added to `family-shopping.test.ts`.
 
 ## Files To Read First
 
-- `app/lib/meal-plan-dates.ts` — shared UTC date helpers
-- `app/routes/family-meal-plan.tsx` — `MealPlanDayRow` and `isToday` wiring
-- `app/lib/meal-plan-dates.test.ts` — `isPlanDateToday` unit tests
+- `app/routes/family-shopping.tsx` — split mobile dock vs desktop inline layout
+- `app/components/manual-shopping-quick-add.tsx` — `autoFocus` / fetcher key props
+- `app/lib/use-lg-viewport.ts` — `useIsLgViewport` for responsive single mount
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 244 tests passed (43 files)
+- `npm run test:run` — 246 tests passed (43 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- PR review and merge.
-- Manual smoke: open a plan spanning today — one emerald row with **I dag**; open another week — no highlight.
+- PR review and merge; closes #92 on merge via `Closes #92`.
+- Manual smoke on iPhone home-screen bookmark: auto-focus may require one tap on iOS Safari.
 
 ## Next Step
 
-Merge PR when CI is green; closes #90.
+Merge PR when CI is green.

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -14,6 +14,7 @@ interface ManualShoppingQuickAddLoaderSlice {
 }
 
 interface ManualShoppingQuickAddProps {
+  autoFocus?: boolean;
   ingredientSearchPath: string;
   quickAddIntent?: string;
   recentManualItems: RecentManualShoppingItem[];
@@ -24,29 +25,34 @@ interface ManualShoppingQuickAddProps {
    * the thumb-reachable input should stay small until the user engages.
    */
   revealOnFocus?: boolean;
+  searchFetcherKey?: string;
 }
 
 const MIN_SEARCH_LENGTH = 2;
 const SEARCH_DEBOUNCE_MS = 250;
 const DEFAULT_QUICK_ADD_INTENT = "quick-add-manual-shopping-item";
+const DEFAULT_SEARCH_FETCHER_KEY = "manual-shopping-ingredient-search";
 
 export function ManualShoppingQuickAdd({
+  autoFocus = false,
   ingredientSearchPath,
   quickAddIntent = DEFAULT_QUICK_ADD_INTENT,
   recentManualItems,
   revealOnFocus = false,
+  searchFetcherKey = DEFAULT_SEARCH_FETCHER_KEY,
 }: ManualShoppingQuickAddProps) {
   const listboxId = useId();
   const navigation = useNavigation();
   const submit = useSubmit();
   const searchFetcher = useFetcher<ManualShoppingQuickAddLoaderSlice>({
-    key: "manual-shopping-ingredient-search",
+    key: searchFetcherKey,
   });
   const [query, setQuery] = useState("");
   const [isListOpen, setIsListOpen] = useState(false);
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [displayedResults, setDisplayedResults] = useState<IngredientSearchResult[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const lastRequestedQueryRef = useRef<string | null>(null);
   const searchFetcherRef = useRef(searchFetcher);
   searchFetcherRef.current = searchFetcher;
@@ -135,6 +141,14 @@ export function ManualShoppingQuickAdd({
     lastRequestedQueryRef.current = null;
   }, [isQuickAdding]);
 
+  useEffect(() => {
+    if (!autoFocus) {
+      return;
+    }
+
+    inputRef.current?.focus({ preventScroll: true });
+  }, [autoFocus]);
+
   const hasExactMatch = useMemo(
     () =>
       displayedResults.some(
@@ -206,9 +220,11 @@ export function ManualShoppingQuickAdd({
             aria-autocomplete="list"
             aria-controls={showDropdown ? listboxId : undefined}
             aria-expanded={showDropdown}
+            autoFocus={autoFocus}
             className="min-w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
             id={`${listboxId}-input`}
             name="quickAddQuery"
+            ref={inputRef}
             onChange={(event) => {
               setQuery(event.target.value);
               setIsListOpen(true);

--- a/app/lib/use-lg-viewport.ts
+++ b/app/lib/use-lg-viewport.ts
@@ -1,0 +1,24 @@
+import { useSyncExternalStore } from "react";
+
+const LG_MEDIA_QUERY = "(min-width: 1024px)";
+
+function subscribe(onStoreChange: () => void) {
+  const mediaQueryList = window.matchMedia(LG_MEDIA_QUERY);
+  mediaQueryList.addEventListener("change", onStoreChange);
+
+  return () => {
+    mediaQueryList.removeEventListener("change", onStoreChange);
+  };
+}
+
+function getSnapshot() {
+  return window.matchMedia(LG_MEDIA_QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function useIsLgViewport() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/app/routes/family-shopping.test.ts
+++ b/app/routes/family-shopping.test.ts
@@ -27,7 +27,11 @@ vi.mock("../lib/family-shopping-write.server", () => ({
 }));
 
 import { requireUser } from "../lib/auth.server";
-import { toggleFamilyShoppingItemChecked } from "../lib/family-shopping-write.server";
+import {
+  createQuickFamilyShoppingItem,
+  parseQuickAddFamilyShoppingItemInput,
+  toggleFamilyShoppingItemChecked,
+} from "../lib/family-shopping-write.server";
 import {
   getFamilyShoppingData,
   listRecentManualShoppingItemsForFamily,
@@ -128,5 +132,92 @@ describe("family shopping route", () => {
     });
     expect(response).toBeInstanceOf(Response);
     expect((response as Response).status).toBe(302);
+  });
+
+  it("redirects after a family quick-add", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      ingredientId: "ingredient-1",
+      name: "Melk",
+      recentNameNormalized: "",
+    });
+    vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "quick-add-family-shopping-item");
+    formData.set("name", "Melk");
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: new Request("http://localhost/families/family-1/shopping", {
+        body: formData,
+        method: "POST",
+      }),
+    });
+
+    expect(createQuickFamilyShoppingItem).toHaveBeenCalledWith({
+      familyId: "family-1",
+      input: {
+        ingredientId: "ingredient-1",
+        name: "Melk",
+        recentNameNormalized: "",
+      },
+      userId: "user-1",
+    });
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/shopping?notice=family-shopping-item-added",
+    );
+  });
+
+  it("returns quick-add validation errors without redirecting", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      ingredientId: "",
+      name: "",
+      recentNameNormalized: "",
+    });
+    vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
+      fieldErrors: {
+        name: "Skriv inn et varenavn.",
+      },
+      formError: "Kunne ikke legge til varen.",
+      status: "VALIDATION_ERROR",
+      values: {
+        categoryId: "",
+        name: "",
+        note: "",
+        preferredStoreId: "",
+        quantity: "",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "quick-add-family-shopping-item");
+
+    const result = await action({
+      params: { familyId: "family-1" },
+      request: new Request("http://localhost/families/family-1/shopping", {
+        body: formData,
+        method: "POST",
+      }),
+    });
+
+    expect(result).toEqual({
+      familyFieldErrors: {
+        name: "Skriv inn et varenavn.",
+      },
+      familyValues: {
+        categoryId: "",
+        name: "",
+        note: "",
+        preferredStoreId: "",
+        quantity: "",
+      },
+      formError: "Kunne ikke legge til varen.",
+      intent: "quick-add-family-shopping-item",
+    });
   });
 });

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -9,6 +9,7 @@ import {
 import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
 import { ShoppingListItemExpanded } from "../components/shopping-list-item-expanded";
 import { requireUser } from "../lib/auth.server";
+import { useIsLgViewport } from "../lib/use-lg-viewport";
 import {
   createFamilyShoppingItem,
   createQuickFamilyShoppingItem,
@@ -318,6 +319,7 @@ export default function FamilyShoppingRoute({
   loaderData: Awaited<ReturnType<typeof loader>>;
 }) {
   const navigation = useNavigation();
+  const isLg = useIsLgViewport();
   const noticeContent =
     loaderData.notice !== null
       ? getFamilyShoppingNoticeContent(loaderData.notice)
@@ -325,21 +327,35 @@ export default function FamilyShoppingRoute({
   const pendingIntent = navigation.formData?.get("intent");
   const pendingSourceKey = getPendingSourceKey(navigation.formData);
   const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
+  const quickAddFormError =
+    actionData?.intent === "quick-add-family-shopping-item"
+      ? actionData.formError
+      : undefined;
+  const generalFormError =
+    actionData?.formError &&
+    actionData.intent !== "quick-add-family-shopping-item"
+      ? actionData.formError
+      : undefined;
+  const quickAddProps = {
+    ingredientSearchPath,
+    quickAddIntent: "quick-add-family-shopping-item" as const,
+    recentManualItems: loaderData.recentManualItems,
+  };
   const addFamilyValues =
     actionData?.intent === "add-family-shopping-item" && actionData.familyValues
       ? actionData.familyValues
       : defaultFamilyShoppingItemValues;
 
   return (
-    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+    <main className="min-h-screen bg-slate-100 px-4 pb-36 pt-8 text-slate-900 lg:pb-12 lg:py-12">
       <div className="mx-auto flex max-w-5xl flex-col gap-6">
-        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8 lg:py-8">
           <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
             <div>
               <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
                 Alltid på listen
               </span>
-              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+              <h1 className="mt-4 text-3xl font-semibold tracking-tight lg:text-4xl">
                 {loaderData.family.name}
               </h1>
               <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
@@ -373,12 +389,12 @@ export default function FamilyShoppingRoute({
           </section>
         ) : null}
 
-        {actionData?.formError ? (
+        {generalFormError ? (
           <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
             <h2 className="text-base font-semibold">
               Kunne ikke oppdatere listen
             </h2>
-            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+            <p className="mt-2 text-sm leading-6">{generalFormError}</p>
           </section>
         ) : null}
 
@@ -411,24 +427,28 @@ export default function FamilyShoppingRoute({
               Legg til vare
             </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600">
-              Bruk hurtigvalg eller det avanserte skjemaet for å legge til varer
-              som skal med uansett ukeplan.
+              {isLg
+                ? "Bruk hurtigvalg eller det avanserte skjemaet for å legge til varer som skal med uansett ukeplan."
+                : "Bruk feltet nederst for hurtig innlegging, eller det avanserte skjemaet under."}
             </p>
 
-            {actionData?.intent === "quick-add-family-shopping-item" &&
-            actionData.formError ? (
-              <p className="mt-4 text-sm text-rose-600">{actionData.formError}</p>
+            {isLg ? (
+              <>
+                {quickAddFormError ? (
+                  <p className="mt-4 text-sm text-rose-600">
+                    {quickAddFormError}
+                  </p>
+                ) : null}
+
+                <div className="mt-6">
+                  <ManualShoppingQuickAdd {...quickAddProps} />
+                </div>
+              </>
             ) : null}
 
-            <div className="mt-6">
-              <ManualShoppingQuickAdd
-                ingredientSearchPath={ingredientSearchPath}
-                quickAddIntent="quick-add-family-shopping-item"
-                recentManualItems={loaderData.recentManualItems}
-              />
-            </div>
-
-            <details className="mt-6 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+            <details
+              className={`rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 ${isLg ? "mt-6" : "mt-4"}`}
+            >
               <summary className="cursor-pointer text-sm font-medium text-slate-800">
                 Avansert: legg til med alle felt
               </summary>
@@ -504,99 +524,103 @@ export default function FamilyShoppingRoute({
                         {section.items
                           .filter((item) => item.sourceType === "FAMILY")
                           .map((item) => {
-                          const isPendingCheckToggle =
-                            navigation.state === "submitting" &&
-                            pendingIntent ===
-                              "toggle-family-shopping-item-checked" &&
-                            pendingSourceKey === item.sourceKey;
-                          const isPendingFamilySave =
-                            navigation.state === "submitting" &&
-                            pendingIntent === "update-family-shopping-item" &&
-                            pendingSourceKey === item.sourceKey;
-                          const isPendingFamilyDelete =
-                            navigation.state === "submitting" &&
-                            pendingIntent === "delete-family-shopping-item" &&
-                            pendingSourceKey === item.sourceKey;
-                          const familyValues =
-                            actionData?.intent ===
-                              "update-family-shopping-item" &&
-                            actionData.itemTarget?.sourceKey ===
-                              item.sourceKey &&
-                            actionData.familyValues
-                              ? actionData.familyValues
-                              : item.sourceType === "FAMILY"
-                                ? {
-                                    categoryId: item.category.id,
-                                    name: item.name,
-                                    note: item.note ?? "",
-                                    preferredStoreId:
-                                      item.preferredStore?.id ?? "",
-                                    quantity: item.quantity ?? "",
-                                  }
-                                : null;
+                            const isPendingCheckToggle =
+                              navigation.state === "submitting" &&
+                              pendingIntent ===
+                                "toggle-family-shopping-item-checked" &&
+                              pendingSourceKey === item.sourceKey;
+                            const isPendingFamilySave =
+                              navigation.state === "submitting" &&
+                              pendingIntent === "update-family-shopping-item" &&
+                              pendingSourceKey === item.sourceKey;
+                            const isPendingFamilyDelete =
+                              navigation.state === "submitting" &&
+                              pendingIntent === "delete-family-shopping-item" &&
+                              pendingSourceKey === item.sourceKey;
+                            const familyValues =
+                              actionData?.intent ===
+                                "update-family-shopping-item" &&
+                              actionData.itemTarget?.sourceKey ===
+                                item.sourceKey &&
+                              actionData.familyValues
+                                ? actionData.familyValues
+                                : item.sourceType === "FAMILY"
+                                  ? {
+                                      categoryId: item.category.id,
+                                      name: item.name,
+                                      note: item.note ?? "",
+                                      preferredStoreId:
+                                        item.preferredStore?.id ?? "",
+                                      quantity: item.quantity ?? "",
+                                    }
+                                  : null;
 
-                          return (
-                            <article
-                              key={item.sourceKey}
-                              className={`rounded-[24px] border p-4 ${
-                                item.checked
-                                  ? "border-slate-200 bg-slate-100 opacity-80"
-                                  : "border-slate-200 bg-slate-50"
-                              }`}
-                            >
-                              <div className="flex flex-wrap items-center gap-2">
-                                <h4
-                                  className={`text-base font-semibold ${
-                                    item.checked
-                                      ? "text-slate-500 line-through"
-                                      : "text-slate-950"
-                                  }`}
-                                >
-                                  {item.name}
-                                </h4>
-                                {formatGeneratedQuantityBadge(item) ? (
-                                  <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
-                                    {formatGeneratedQuantityBadge(item)}
+                            return (
+                              <article
+                                key={item.sourceKey}
+                                className={`rounded-[24px] border p-4 ${
+                                  item.checked
+                                    ? "border-slate-200 bg-slate-100 opacity-80"
+                                    : "border-slate-200 bg-slate-50"
+                                }`}
+                              >
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <h4
+                                    className={`text-base font-semibold ${
+                                      item.checked
+                                        ? "text-slate-500 line-through"
+                                        : "text-slate-950"
+                                    }`}
+                                  >
+                                    {item.name}
+                                  </h4>
+                                  {formatGeneratedQuantityBadge(item) ? (
+                                    <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                                      {formatGeneratedQuantityBadge(item)}
+                                    </span>
+                                  ) : null}
+                                  <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800">
+                                    Alltid på listen
                                   </span>
-                                ) : null}
-                                <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800">
-                                  Alltid på listen
-                                </span>
-                              </div>
-                              {formatCompactShoppingSourceLine(item) ? (
-                                <p className="mt-2 text-xs text-slate-600">
-                                  {formatCompactShoppingSourceLine(item)}
-                                </p>
-                              ) : null}
-                              <details className="mt-4">
-                                <summary className="cursor-pointer text-sm font-medium text-slate-800">
-                                  Detaljer
-                                </summary>
-                                <div className="mt-4">
-                                  <ShoppingListItemExpanded
-                                    actionData={actionData}
-                                    categories={loaderData.categories}
-                                    familyValues={familyValues}
-                                    isPendingCheckToggle={isPendingCheckToggle}
-                                    isPendingFamilyDelete={isPendingFamilyDelete}
-                                    isPendingFamilySave={isPendingFamilySave}
-                                    isPendingGeneratedExclude={false}
-                                    isPendingGeneratedSave={false}
-                                    isPendingManualDelete={false}
-                                    isPendingManualSave={false}
-                                    item={item}
-                                    manualValues={null}
-                                    overrideValues={null}
-                                    stores={loaderData.stores}
-                                    toggleExpectedVersion={getToggleExpectedVersion(
-                                      item,
-                                    )}
-                                  />
                                 </div>
-                              </details>
-                            </article>
-                          );
-                        })}
+                                {formatCompactShoppingSourceLine(item) ? (
+                                  <p className="mt-2 text-xs text-slate-600">
+                                    {formatCompactShoppingSourceLine(item)}
+                                  </p>
+                                ) : null}
+                                <details className="mt-4">
+                                  <summary className="cursor-pointer text-sm font-medium text-slate-800">
+                                    Detaljer
+                                  </summary>
+                                  <div className="mt-4">
+                                    <ShoppingListItemExpanded
+                                      actionData={actionData}
+                                      categories={loaderData.categories}
+                                      familyValues={familyValues}
+                                      isPendingCheckToggle={
+                                        isPendingCheckToggle
+                                      }
+                                      isPendingFamilyDelete={
+                                        isPendingFamilyDelete
+                                      }
+                                      isPendingFamilySave={isPendingFamilySave}
+                                      isPendingGeneratedExclude={false}
+                                      isPendingGeneratedSave={false}
+                                      isPendingManualDelete={false}
+                                      isPendingManualSave={false}
+                                      item={item}
+                                      manualValues={null}
+                                      overrideValues={null}
+                                      stores={loaderData.stores}
+                                      toggleExpectedVersion={getToggleExpectedVersion(
+                                        item,
+                                      )}
+                                    />
+                                  </div>
+                                </details>
+                              </article>
+                            );
+                          })}
                       </div>
                     </section>
                   ))}
@@ -610,11 +634,30 @@ export default function FamilyShoppingRoute({
               Listen er tom
             </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600">
-              Legg til den første varen med skjemaet over.
+              {isLg
+                ? "Legg til den første varen med skjemaet over."
+                : "Legg til den første varen med feltet nederst."}
             </p>
           </section>
         )}
       </div>
+
+      {!isLg ? (
+        <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
+          <div className="pointer-events-auto mx-auto max-w-5xl">
+            <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200">
+              {quickAddFormError ? (
+                <p className="mb-3 text-sm text-rose-600">{quickAddFormError}</p>
+              ) : null}
+              <ManualShoppingQuickAdd
+                {...quickAddProps}
+                autoFocus
+                revealOnFocus
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a fixed bottom quick-add dock on mobile for `/families/:familyId/shopping` with `revealOnFocus`, auto-focus, and safe-area padding so the global list works as a phone bookmark.
- Keeps inline quick-add in the “Legg til vare” card on desktop (`lg+`) via `useIsLgViewport` so only one `ManualShoppingQuickAdd` mounts at a time.
- Extends `ManualShoppingQuickAdd` with `autoFocus` and optional `searchFetcherKey`; adds quick-add action tests.

## Related issue
Closes #92

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] iPhone home-screen bookmark → keyboard opens or dock visible at bottom → add item via Enter
- [ ] Desktop `lg+`: inline quick-add in card, no bottom dock
- [ ] Recent chips and ingredient search dropdown open upward in mobile dock

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (246 tests)
- npm run typecheck