### PR TITLE
Group duplicate shopping ingredients across recipes

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,33 +2,35 @@
 
 ## Current Objective
 
-Issue #92 — mobile quick-add bookmark for family shopping on branch `issue/92-mobile-family-shopping-quick-add`. Ready for PR review.
+Issue #94 on branch `issue/94-shopping-list-grouping`: merge duplicate generated shopping ingredients across recipes and show a recipe-count badge in shopping list UIs.
 
 ## Completed
 
-- Fixed bottom quick-add dock on mobile (`revealOnFocus`, `autoFocus`, safe-area padding) on `/families/:familyId/shopping`.
-- Desktop (`lg+`) keeps inline `ManualShoppingQuickAdd` in the “Legg til vare” card; single mount via `useIsLgViewport`.
-- `ManualShoppingQuickAdd` gained `autoFocus` and optional `searchFetcherKey` props.
-- Quick-add action tests added to `family-shopping.test.ts`.
+- Updated generated shopping grouping in `app/lib/shopping.server.ts` to merge by `categoryId + normalized displayName + unit`, instead of relying on `ingredientId`.
+- Added `recipeCount` to generated projected items and populated it from distinct contributing recipes.
+- Added `N oppskrifter` badges in both shopping list UIs (`family-meal-plan-shopping` and store mode card) when a generated item comes from more than one recipe.
+- Extended and updated shopping server tests for merge behavior across different ingredient records and for new `recipeCount` assertions.
+- Updated route test fixtures to include `recipeCount` for generated items.
 
 ## Files To Read First
 
-- `app/routes/family-shopping.tsx` — split mobile dock vs desktop inline layout
-- `app/components/manual-shopping-quick-add.tsx` — `autoFocus` / fetcher key props
-- `app/lib/use-lg-viewport.ts` — `useIsLgViewport` for responsive single mount
+- `app/lib/shopping.server.ts` - generated merge key + projected generated item shape (`recipeCount`)
+- `app/routes/family-meal-plan-shopping.tsx` - main shopping list badge rendering
+- `app/components/store-mode-shopping-item-card.tsx` - store mode badge rendering
+- `app/lib/shopping.server.test.ts` - grouping and regression coverage
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 246 tests passed (43 files)
+- `npm run test:run` — passed (247 tests, 43 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- PR review and merge; closes #92 on merge via `Closes #92`.
-- Manual smoke on iPhone home-screen bookmark: auto-focus may require one tap on iOS Safari.
+- Open PR for issue #94 and merge after review/CI.
+- Manual UI smoke-check recommended for `/families/:familyId/meal-plans/:mealPlanId/shopping` and `/families/:familyId/meal-plans/:mealPlanId/store-mode` to confirm the new badge copy and placement.
 
 ## Next Step
 
-Merge PR when CI is green.
+Create and ship the PR for issue #94 (`Closes #94`) and verify CI plus manual shopping-list behavior for duplicate ingredients.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -11,6 +11,7 @@ Issue #94 on branch `issue/94-shopping-list-grouping`: merge duplicate generated
 - Added `N oppskrifter` badges in both shopping list UIs (`family-meal-plan-shopping` and store mode card) when a generated item comes from more than one recipe.
 - Extended and updated shopping server tests for merge behavior across different ingredient records and for new `recipeCount` assertions.
 - Updated route test fixtures to include `recipeCount` for generated items.
+- Fixed an additional missing `recipeCount` in `app/routes/family-meal-plan-shopping.test.ts` expected store-group fixture.
 
 ## Files To Read First
 

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -20,6 +20,7 @@ interface StoreModeShoppingItemCardGenerated extends StoreModeShoppingItemCardBa
   lastDate: string;
   occurrenceCount: number;
   occurrences: Array<{ date: string; recipeTitle: string }>;
+  recipeCount: number;
   postponedUntilDate: string | null;
   preferredStoreConflict: boolean;
   sourceType: "GENERATED";
@@ -98,6 +99,11 @@ export function StoreModeShoppingItemCard({
                 }
               >
                 {quantityBadge}
+              </span>
+            ) : null}
+            {item.sourceType === "GENERATED" && item.recipeCount > 1 ? (
+              <span className={`${badgeClass} bg-emerald-100 text-emerald-800`}>
+                {item.recipeCount} oppskrifter
               </span>
             ) : null}
             {item.sourceType === "GENERATED" && item.preferredStoreConflict ? (

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -588,6 +588,113 @@ describe("shopping.server", () => {
     ]);
   });
 
+  it("merges canonical ingredients with different ingredient records by normalized name and unit", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: null,
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: {
+                  id: "category-produce",
+                  name: "Frukt og gront",
+                },
+                categoryId: "category-produce",
+                displayName: "Agurk",
+                id: "ingredient-1",
+                ingredientId: "canonical-cucumber-a",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Taco",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "2",
+                category: {
+                  id: "category-produce",
+                  name: "Frukt og gront",
+                },
+                categoryId: "category-produce",
+                displayName: "agurk",
+                id: "ingredient-2",
+                ingredientId: "canonical-cucumber-b",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Salat",
+          },
+          recipeId: "recipe-2",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-1",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.projectedItems).toHaveLength(1);
+
+    const mergedCucumber = result.projectedItems[0];
+
+    if (mergedCucumber.sourceType !== "GENERATED") {
+      throw new Error("Expected a generated shopping item.");
+    }
+
+    expect(mergedCucumber).toEqual(
+      expect.objectContaining({
+        name: "Agurk",
+        occurrenceCount: 2,
+        quantityLabel: "3 stk",
+        recipeCount: 2,
+      }),
+    );
+  });
+
   it("sums identical units when the same recipe is planned on multiple days", async () => {
     dbMock.mealPlan.findFirst.mockResolvedValue({
       activeShoppingDate: null,
@@ -780,6 +887,7 @@ describe("shopping.server", () => {
         name: "Agurk",
         occurrenceCount: 2,
         preferredStoreConflict: true,
+        recipeCount: 2,
         sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2",
       }),
     );
@@ -866,6 +974,7 @@ describe("shopping.server", () => {
         name: "Persille",
         occurrenceCount: 2,
         quantityLabel: "3 stk",
+        recipeCount: 2,
       }),
     );
   });
@@ -1049,6 +1158,7 @@ describe("shopping.server", () => {
       expect.objectContaining({
         checked: true,
         note: "Kjøp ekstra",
+        recipeCount: 2,
         sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2",
       }),
     );

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -250,6 +250,7 @@ export interface ProjectedGeneratedShoppingItem extends ProjectedShoppingItemBas
   firstDate: Date;
   lastDate: Date;
   occurrenceCount: number;
+  recipeCount: number;
   occurrences: ProjectedShoppingOccurrence[];
   postponedUntilDate: Date | null;
   preferredStoreConflict: boolean;
@@ -871,6 +872,7 @@ function mapGeneratedProjectionBucketToItem({
     storeSectionsByStoreId,
   });
   const occurrences = [...bucket.occurrences].sort(compareProjectedOccurrences);
+  const recipeIds = new Set(occurrences.map((occurrence) => occurrence.recipeId));
 
   return {
     amount: bucket.amount,
@@ -882,6 +884,7 @@ function mapGeneratedProjectionBucketToItem({
     note: override?.note ?? null,
     occurrenceCount: occurrences.length,
     occurrences,
+    recipeCount: recipeIds.size,
     collaborationVersion: override?.updatedAt?.toISOString() ?? "",
     postponedUntilDate: override?.postponedUntilDate ?? null,
     preferredStore,
@@ -922,7 +925,7 @@ function buildGeneratedProjectionBuckets(mealPlan: ShoppingMealPlan) {
       const mergeKey = buildGeneratedMergeKey({
         categoryId: ingredient.categoryId,
         displayName: ingredient.displayName,
-        ingredientId: ingredient.ingredientId,
+        unit: ingredient.unit,
       });
       const existingBucket = buckets.get(mergeKey);
       const incomingStoreId = ingredient.preferredStoreId ?? null;
@@ -1210,16 +1213,16 @@ function buildMergedGeneratedSourceKey(occurrenceKeys: string[]) {
 function buildGeneratedMergeKey({
   categoryId,
   displayName,
-  ingredientId,
+  unit,
 }: {
   categoryId: string;
   displayName: string;
-  ingredientId: string | null;
+  unit: string | null;
 }) {
   return JSON.stringify({
     categoryId,
-    displayName: ingredientId ? null : displayName,
-    ingredientId,
+    displayName: normalizeIngredientCanonicalName(displayName),
+    unit: unit?.trim() || null,
   });
 }
 

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -113,6 +113,7 @@ describe("family meal plan shopping route", () => {
           name: "Lime",
           note: null,
           occurrenceCount: 1,
+          recipeCount: 1,
           occurrences: [
             {
               amount: "1",
@@ -188,6 +189,7 @@ describe("family meal plan shopping route", () => {
                   name: "Lime",
                   note: null,
                   occurrenceCount: 1,
+                  recipeCount: 1,
                   occurrences: [
                     {
                       amount: "1",

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -342,6 +342,7 @@ describe("family meal plan shopping route", () => {
                   name: "Lime",
                   note: null,
                   occurrenceCount: 1,
+                  recipeCount: 1,
                   occurrences: [
                     {
                       amount: "1",

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1293,6 +1293,12 @@ export default function FamilyMealPlanShoppingRoute({
                                   </span>
                                 ) : null}
                                 {item.sourceType === "GENERATED" &&
+                                item.recipeCount > 1 ? (
+                                  <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
+                                    {item.recipeCount} oppskrifter
+                                  </span>
+                                ) : null}
+                                {item.sourceType === "GENERATED" &&
                                 item.preferredStoreConflict ? (
                                   <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800">
                                     Ulike foretrukne butikker

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -104,6 +104,7 @@ describe("family meal plan store mode route", () => {
               name: "Paprika",
               note: null,
               occurrenceCount: 1,
+              recipeCount: 1,
               occurrences: [
                 {
                   amount: "1",


### PR DESCRIPTION
## Summary
- Merge generated shopping ingredient lines by normalized name + unit so duplicate items from multiple recipes are grouped and quantity-summed.
- Add a `N oppskrifter` badge in both meal-plan shopping list and store mode cards when a generated item comes from multiple recipes.
- Extend shopping server and route fixtures/tests to cover the new grouping behavior and `recipeCount` field.

## Related issue
Closes #94

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual checks in meal-plan shopping and store mode UIs

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck