### PR TITLE
Add reset button for weekly meal plan overview

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,36 +2,32 @@
 
 ## Current Objective
 
-Issue #94 on branch `issue/94-shopping-list-grouping`: merge duplicate generated shopping ingredients across recipes and show a recipe-count badge in shopping list UIs.
+Issue #96 on branch `issue/96-reset-weekly-overview`: add a secondary reset action in the weekly meal plan overview to clear all dinner entries in one click.
 
 ## Completed
 
-- Updated generated shopping grouping in `app/lib/shopping.server.ts` to merge by `categoryId + normalized displayName + unit`, instead of relying on `ingredientId`.
-- Added `recipeCount` to generated projected items and populated it from distinct contributing recipes.
-- Added `N oppskrifter` badges in both shopping list UIs (`family-meal-plan-shopping` and store mode card) when a generated item comes from more than one recipe.
-- Extended and updated shopping server tests for merge behavior across different ingredient records and for new `recipeCount` assertions.
-- Updated route test fixtures to include `recipeCount` for generated items.
-- Fixed an additional missing `recipeCount` in `app/routes/family-meal-plan-shopping.test.ts` expected store-group fixture.
+- Added `reset-meal-plan-entries` intent that clears all visible weekly meal fields via `saveMealPlanEntries`.
+- Added secondary **Tilbakestill ukeoversikt** button beside **Lagre middager** with pending/disabled states.
+- Added `meal-plan-entries-reset` success notice with dedicated copy.
+- Added route action tests for reset payload, redirect, and validation error handling.
 
 ## Files To Read First
 
-- `app/lib/shopping.server.ts` - generated merge key + projected generated item shape (`recipeCount`)
-- `app/routes/family-meal-plan-shopping.tsx` - main shopping list badge rendering
-- `app/components/store-mode-shopping-item-card.tsx` - store mode badge rendering
-- `app/lib/shopping.server.test.ts` - grouping and regression coverage
+- `app/routes/family-meal-plan.tsx` - reset intent, UI button, notice handling
+- `app/routes/family-meal-plan.test.ts` - reset action tests
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (247 tests, 43 files)
+- `npm run test:run` — passed (249 tests, 43 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Open PR for issue #94 and merge after review/CI.
-- Manual UI smoke-check recommended for `/families/:familyId/meal-plans/:mealPlanId/shopping` and `/families/:familyId/meal-plans/:mealPlanId/store-mode` to confirm the new badge copy and placement.
+- Open PR for issue #96 and merge after review/CI.
+- Manual UI smoke-check: fill several days, click reset, confirm fields clear and success notice appears.
 
 ## Next Step
 
-Create and ship the PR for issue #94 (`Closes #94`) and verify CI plus manual shopping-list behavior for duplicate ingredients.
+Create and ship the PR for issue #96 (`Closes #96`) and verify CI plus manual reset behavior on the meal plan page.

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -295,6 +295,103 @@ describe("family meal plan route", () => {
     );
   });
 
+  it("clears all weekly meal fields when resetting entries", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(saveMealPlanEntries).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "reset-meal-plan-entries");
+    formData.append("entryDate", "2026-05-15");
+    formData.append("entryDate", "2026-05-16");
+    formData.set("entryUpdatedAt:2026-05-15", "2026-05-01T12:00:00.000Z");
+    formData.set("entryUpdatedAt:2026-05-16", "2026-05-02T12:00:00.000Z");
+    formData.set("note:2026-05-15", "Bruk rester til lunsj");
+    formData.set("recipeId:2026-05-15", "");
+    formData.set("note:2026-05-16", "");
+    formData.set("recipeId:2026-05-16", "kylling-taco");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(saveMealPlanEntries).toHaveBeenCalledWith({
+      entries: [
+        {
+          date: "2026-05-15",
+          note: "",
+          recipeId: "",
+        },
+        {
+          date: "2026-05-16",
+          note: "",
+          recipeId: "",
+        },
+      ],
+      entryVersions: {
+        "2026-05-15": "2026-05-01T12:00:00.000Z",
+        "2026-05-16": "2026-05-02T12:00:00.000Z",
+      },
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1?notice=meal-plan-entries-reset",
+    );
+  });
+
+  it("returns reset validation errors from the server module", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(saveMealPlanEntries).mockResolvedValue({
+      formError: "En av dagene ligger utenfor den aktive perioden.",
+      status: "VALIDATION_ERROR",
+      values: [
+        {
+          date: "2026-05-15",
+          note: "",
+          recipeId: "",
+        },
+      ],
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "reset-meal-plan-entries");
+    formData.append("entryDate", "2026-05-15");
+    formData.set("entryUpdatedAt:2026-05-15", "2026-05-01T12:00:00.000Z");
+    formData.set("note:2026-05-15", "Skal ignoreres");
+    formData.set("recipeId:2026-05-15", "kylling-taco");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(result).toEqual({
+      entryFormError: "En av dagene ligger utenfor den aktive perioden.",
+      entryValues: {
+        "2026-05-15": {
+          note: "",
+          recipeId: "",
+          updatedAt: "2026-05-01T12:00:00.000Z",
+        },
+      },
+      intent: "reset-meal-plan-entries",
+    });
+  });
+
   it("redirects with an explicit notice after approving a meal plan", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(approveMealPlan).mockResolvedValue({

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -33,6 +33,7 @@ type MealPlanNotice =
   | "meal-plan-approved"
   | "meal-plan-auto-filled"
   | "meal-plan-created"
+  | "meal-plan-entries-reset"
   | "meal-plan-entries-saved"
   | "meal-plan-feedback-addressed"
   | "meal-plan-reopened"
@@ -43,6 +44,7 @@ type MealPlanIntent =
   | "auto-fill-meal-plan-entries"
   | "mark-comment-addressed"
   | "reopen-meal-plan"
+  | "reset-meal-plan-entries"
   | "save-meal-plan-entries"
   | "share-meal-plan"
   | "update-meal-plan";
@@ -275,10 +277,17 @@ export async function action({
     } satisfies MealPlanActionData;
   }
 
-  if (intent === "save-meal-plan-entries") {
+  if (
+    intent === "save-meal-plan-entries" ||
+    intent === "reset-meal-plan-entries"
+  ) {
     const entryVersions = parseMealPlanEntryVersions(formData);
+    const entries =
+      intent === "reset-meal-plan-entries"
+        ? buildResetMealPlanEntries(formData)
+        : parseMealPlanEntries(formData);
     const result = await saveMealPlanEntries({
-      entries: parseMealPlanEntries(formData),
+      entries,
       entryVersions,
       familyId,
       mealPlanId,
@@ -311,7 +320,10 @@ export async function action({
     return buildMealPlanRedirect({
       familyId,
       mealPlanId,
-      notice: "meal-plan-entries-saved",
+      notice:
+        intent === "reset-meal-plan-entries"
+          ? "meal-plan-entries-reset"
+          : "meal-plan-entries-saved",
       request,
     });
   }
@@ -488,6 +500,9 @@ export default function FamilyMealPlanRoute({
   const isSavingEntries =
     navigation.state === "submitting" &&
     pendingIntent === "save-meal-plan-entries";
+  const isResettingEntries =
+    navigation.state === "submitting" &&
+    pendingIntent === "reset-meal-plan-entries";
   const isUpdatingMetadata =
     navigation.state === "submitting" && pendingIntent === "update-meal-plan";
   const isSharingMealPlan =
@@ -529,7 +544,9 @@ export default function FamilyMealPlanRoute({
         ? "Gjenåpner..."
         : "Gjenåpne som utkast";
   const entryValues =
-    actionData?.intent === "save-meal-plan-entries" && actionData.entryValues
+    (actionData?.intent === "save-meal-plan-entries" ||
+      actionData?.intent === "reset-meal-plan-entries") &&
+    actionData.entryValues
       ? actionData.entryValues
       : loaderData.entriesByDate;
   const selectedRecipeIds = new Set(
@@ -666,12 +683,6 @@ export default function FamilyMealPlanRoute({
               className="mt-4 min-w-0 space-y-3"
               method="post"
             >
-              <input
-                name="intent"
-                type="hidden"
-                value="save-meal-plan-entries"
-              />
-
               <div className="grid min-w-0 gap-2">
                 {loaderData.visibleDates.map((date) => {
                   const entry = entryValues[date] ?? {
@@ -696,7 +707,8 @@ export default function FamilyMealPlanRoute({
                 })}
               </div>
 
-              {actionData?.intent === "save-meal-plan-entries" &&
+              {(actionData?.intent === "save-meal-plan-entries" ||
+                actionData?.intent === "reset-meal-plan-entries") &&
               actionData.entryFormError ? (
                 <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
                   {actionData.entryFormError}
@@ -706,10 +718,31 @@ export default function FamilyMealPlanRoute({
               <div className="grid gap-3 sm:grid-cols-2">
                 <button
                   className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                  disabled={isSavingEntries || isAutoFillingEntries}
+                  disabled={
+                    isSavingEntries ||
+                    isResettingEntries ||
+                    isAutoFillingEntries
+                  }
+                  name="intent"
                   type="submit"
+                  value="save-meal-plan-entries"
                 >
                   {isSavingEntries ? "Lagrer middager..." : "Lagre middager"}
+                </button>
+                <button
+                  className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-800 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                  disabled={
+                    isSavingEntries ||
+                    isResettingEntries ||
+                    isAutoFillingEntries
+                  }
+                  name="intent"
+                  type="submit"
+                  value="reset-meal-plan-entries"
+                >
+                  {isResettingEntries
+                    ? "Tilbakestiller..."
+                    : "Tilbakestill ukeoversikt"}
                 </button>
               </div>
             </Form>
@@ -735,7 +768,10 @@ export default function FamilyMealPlanRoute({
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
                 disabled={
-                  !canAutoFillEntries || isAutoFillingEntries || isSavingEntries
+                  !canAutoFillEntries ||
+                  isAutoFillingEntries ||
+                  isSavingEntries ||
+                  isResettingEntries
                 }
                 type="submit"
               >
@@ -929,6 +965,7 @@ function getMealPlanNotice(request: Request): MealPlanNotice | null {
     notice === "meal-plan-approved" ||
     notice === "meal-plan-auto-filled" ||
     notice === "meal-plan-created" ||
+    notice === "meal-plan-entries-reset" ||
     notice === "meal-plan-entries-saved" ||
     notice === "meal-plan-feedback-addressed" ||
     notice === "meal-plan-reopened" ||
@@ -1021,6 +1058,12 @@ function getMealPlanNoticeContent(
         description:
           "Ukeplanen er klar for videre arbeid med innhold og handleliste.",
         title: "Ukeplan opprettet",
+      };
+    case "meal-plan-entries-reset":
+      return {
+        description:
+          "Alle middager og notater i ukeoversikten ble fjernet for den aktive perioden.",
+        title: "Ukeoversikt tilbakestilt",
       };
     case "meal-plan-entries-saved":
       return {
@@ -1712,6 +1755,14 @@ function parseMealPlanEntries(formData: FormData): MealPlanEntryValues[] {
       recipeId: String(formData.get(`recipeId:${date}`) ?? ""),
     };
   });
+}
+
+function buildResetMealPlanEntries(formData: FormData): MealPlanEntryValues[] {
+  return formData.getAll("entryDate").map((dateValue) => ({
+    date: String(dateValue),
+    note: "",
+    recipeId: "",
+  }));
 }
 
 function parseMealPlanEntryVersions(formData: FormData) {


### PR DESCRIPTION
## Summary
- Adds a secondary **Tilbakestill ukeoversikt** button next to **Lagre middager** on the meal plan page.
- Reset clears all weekly dinner entries (recipe + note) in one action via `saveMealPlanEntries`, with optimistic concurrency preserved.
- Shows a dedicated success notice when reset completes.

## Related issue
Closes #96

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: fill multiple days with recipes/notes, click reset, confirm all fields clear and success notice appears
- [ ] Manual: confirm save still works after reset

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (249 tests)
- npm run typecheck