### PR TITLE
Make shopping easy to access on mobile with store mode and combined list

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,36 @@
 
 ## Current Objective
 
-Issue #96 on branch `issue/96-reset-weekly-overview`: add a secondary reset action in the weekly meal plan overview to clear all dinner entries in one click.
+Issue #99 on branch `issue/99-mobile-shopping-access`: make shopping easy to reach on mobile via bottom nav (store mode), with optional combined global + meal-plan list on the family shopping page.
 
 ## Completed
 
-- Added `reset-meal-plan-entries` intent that clears all visible weekly meal fields via `saveMealPlanEntries`.
-- Added secondary **Tilbakestill ukeoversikt** button beside **Lagre middager** with pending/disabled states.
-- Added `meal-plan-entries-reset` success notice with dedicated copy.
-- Added route action tests for reset payload, redirect, and validation error handling.
+- Added mobile bottom tab nav (Familie, Ukeplaner, Handleliste) in app layout.
+- Handleliste opens store mode via `/families/:familyId/store-mode` redirect to today's (or latest) meal plan store mode.
+- Added server-persisted `GLOBAL` / `COMBINED` shopping list mode per user+family (`UserFamilyShoppingPreference`).
+- Extended family shopping with today's meal-plan detection, combined projection, dedup, source badges, and mode toggle UI.
+- Fixed Prisma enum leaking to client by using string literal mode types instead of `@prisma/client` re-exports.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan.tsx` - reset intent, UI button, notice handling
-- `app/routes/family-meal-plan.test.ts` - reset action tests
+- `app/components/app-mobile-bottom-nav.tsx` - mobile tab bar and store-mode active state
+- `app/routes/family-store-mode.ts` - redirect into meal-plan store mode
+- `app/routes/family-shopping.tsx` - combined/global mode UI and actions
+- `app/lib/shopping.server.ts` - combined list projection and dedup
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (249 tests, 43 files)
+- `npm run test:run` — passed (260 tests, 46 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Open PR for issue #96 and merge after review/CI.
-- Manual UI smoke-check: fill several days, click reset, confirm fields clear and success notice appears.
+- Run migration before deploy: `npx prisma migrate deploy`
+- Manual mobile smoke-check: bottom nav → store mode, mode toggle on family shopping, quick-add dock vs bottom nav overlap
+- PR for issue #99 pending merge
 
 ## Next Step
 
-Create and ship the PR for issue #96 (`Closes #96`) and verify CI plus manual reset behavior on the meal plan page.
+Merge PR for issue #99 after review/CI and verify store-mode redirect when no meal plan exists (falls back to meal plans list).

--- a/app/components/app-mobile-bottom-nav.tsx
+++ b/app/components/app-mobile-bottom-nav.tsx
@@ -1,0 +1,76 @@
+import { NavLink, useLocation } from "react-router";
+
+interface MobileBottomNavItem {
+  end?: boolean;
+  label: string;
+  to: string;
+}
+
+function buildFamilyBottomNavItems(familyId: string): MobileBottomNavItem[] {
+  return [
+    { end: true, label: "Familie", to: `/families/${familyId}` },
+    {
+      end: false,
+      label: "Ukeplaner",
+      to: `/families/${familyId}/meal-plans`,
+    },
+    {
+      label: "Handleliste",
+      to: `/families/${familyId}/store-mode`,
+    },
+  ];
+}
+
+function bottomNavLinkClassName({ isActive }: { isActive: boolean }) {
+  return [
+    "flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-xs font-medium transition",
+    isActive
+      ? "bg-emerald-500/15 text-emerald-700"
+      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+  ].join(" ");
+}
+
+function isStoreModeShoppingNavActive(pathname: string, familyId: string) {
+  return (
+    pathname === `/families/${familyId}/store-mode` ||
+    (pathname.startsWith(`/families/${familyId}/meal-plans/`) &&
+      pathname.endsWith("/store-mode"))
+  );
+}
+
+export function AppMobileBottomNav({ familyId }: { familyId: string | null }) {
+  const location = useLocation();
+
+  if (!familyId) {
+    return null;
+  }
+
+  const navItems = buildFamilyBottomNavItems(familyId);
+
+  return (
+    <nav
+      aria-label="Hovednavigasjon mobil"
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-slate-200 bg-white/95 px-2 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] backdrop-blur md:hidden"
+    >
+      <div className="mx-auto flex max-w-6xl gap-1">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            className={({ isActive }) =>
+              bottomNavLinkClassName({
+                isActive:
+                  item.label === "Handleliste"
+                    ? isStoreModeShoppingNavActive(location.pathname, familyId)
+                    : isActive,
+              })
+            }
+            end={item.end}
+            to={item.to}
+          >
+            <span className="truncate">{item.label}</span>
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/app/components/app-top-nav.tsx
+++ b/app/components/app-top-nav.tsx
@@ -24,6 +24,11 @@ function buildFamilyNavItems(
       label: reviewLabel,
       to: `/families/${familyId}/meal-plans/reviews`,
     },
+    {
+      end: true,
+      label: "Handleliste",
+      to: `/families/${familyId}/store-mode`,
+    },
     { end: true, label: "Butikker", to: `/families/${familyId}/stores` },
     { end: false, label: "Oppskrifter", to: `/families/${familyId}/recipes` },
     {

--- a/app/lib/meal-plan-for-date.server.test.ts
+++ b/app/lib/meal-plan-for-date.server.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock } = vi.hoisted(() => ({
+  dbMock: {
+    mealPlan: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+import { findMealPlanCoveringDate } from "./meal-plan-for-date.server";
+
+describe("findMealPlanCoveringDate", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the meal plan that covers the reference date", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 20",
+    });
+
+    const result = await findMealPlanCoveringDate({
+      familyId: "family-1",
+      referenceDate: new Date("2026-05-16T12:00:00.000Z"),
+    });
+
+    expect(result?.id).toBe("meal-plan-1");
+    expect(dbMock.mealPlan.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          familyId: "family-1",
+          endDate: {
+            gte: new Date("2026-05-16T00:00:00.000Z"),
+          },
+          startDate: {
+            lte: new Date("2026-05-16T00:00:00.000Z"),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("returns null when no meal plan covers the date", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue(null);
+
+    const result = await findMealPlanCoveringDate({
+      familyId: "family-1",
+      referenceDate: new Date("2026-05-16T00:00:00.000Z"),
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/app/lib/meal-plan-for-date.server.ts
+++ b/app/lib/meal-plan-for-date.server.ts
@@ -1,0 +1,56 @@
+import { db } from "./db.server";
+import { formatDateOnly } from "./meal-plan-dates";
+
+export const FAMILY_SHOPPING_LIST_MODES = ["GLOBAL", "COMBINED"] as const;
+
+const mealPlanForDateSelect = {
+  endDate: true,
+  id: true,
+  startDate: true,
+  status: true,
+  title: true,
+} as const;
+
+export type MealPlanForDateSummary = {
+  endDate: Date;
+  id: string;
+  startDate: Date;
+  status: "APPROVED" | "DRAFT";
+  title: string;
+};
+
+export async function findMealPlanCoveringDate({
+  familyId,
+  referenceDate = new Date(),
+}: {
+  familyId: string;
+  referenceDate?: Date;
+}): Promise<MealPlanForDateSummary | null> {
+  const dateOnly = formatDateOnly(referenceDate);
+  const dateAtUtcMidnight = new Date(`${dateOnly}T00:00:00.000Z`);
+
+  return db.mealPlan.findFirst({
+    orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
+    select: mealPlanForDateSelect,
+    where: {
+      familyId,
+      endDate: {
+        gte: dateAtUtcMidnight,
+      },
+      startDate: {
+        lte: dateAtUtcMidnight,
+      },
+    },
+  });
+}
+
+export function serializeMealPlanForDateSummary(plan: MealPlanForDateSummary) {
+  return {
+    id: plan.id,
+    status: plan.status,
+    title: plan.title,
+  };
+}
+
+export type FamilyShoppingListModeValue =
+  (typeof FAMILY_SHOPPING_LIST_MODES)[number];

--- a/app/lib/shopping-preference-write.server.test.ts
+++ b/app/lib/shopping-preference-write.server.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => ({
+  dbMock: {
+    userFamilyShoppingPreference: {
+      upsert: vi.fn(),
+    },
+  },
+  requireFamilyMembershipMock: vi.fn(),
+}));
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+import {
+  parseFamilyShoppingListMode,
+  updateFamilyShoppingListMode,
+} from "./shopping-preference-write.server";
+
+describe("shopping-preference-write.server", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses valid shopping list modes", () => {
+    expect(parseFamilyShoppingListMode("GLOBAL")).toBe("GLOBAL");
+    expect(parseFamilyShoppingListMode("COMBINED")).toBe("COMBINED");
+    expect(parseFamilyShoppingListMode("INVALID")).toBeNull();
+  });
+
+  it("upserts the shopping list mode for the user and family", async () => {
+    requireFamilyMembershipMock.mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "ADMIN",
+    });
+
+    const result = await updateFamilyShoppingListMode({
+      familyId: "family-1",
+      listMode: "COMBINED",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(dbMock.userFamilyShoppingPreference.upsert).toHaveBeenCalledWith({
+      create: {
+        familyId: "family-1",
+        listMode: "COMBINED",
+        userId: "user-1",
+      },
+      update: {
+        listMode: "COMBINED",
+      },
+      where: {
+        userId_familyId: {
+          familyId: "family-1",
+          userId: "user-1",
+        },
+      },
+    });
+  });
+});

--- a/app/lib/shopping-preference-write.server.ts
+++ b/app/lib/shopping-preference-write.server.ts
@@ -1,0 +1,65 @@
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import {
+  FAMILY_SHOPPING_LIST_MODES,
+  type FamilyShoppingListModeValue,
+} from "./meal-plan-for-date.server";
+
+const validListModes = new Set<FamilyShoppingListModeValue>(
+  FAMILY_SHOPPING_LIST_MODES,
+);
+
+export function parseFamilyShoppingListMode(
+  value: FormDataEntryValue | null,
+): FamilyShoppingListModeValue | null {
+  const normalized = String(value ?? "").trim();
+
+  if (validListModes.has(normalized as FamilyShoppingListModeValue)) {
+    return normalized as FamilyShoppingListModeValue;
+  }
+
+  return null;
+}
+
+export async function updateFamilyShoppingListMode({
+  familyId,
+  listMode,
+  userId,
+}: {
+  familyId: string;
+  listMode: FamilyShoppingListModeValue;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  if (!validListModes.has(listMode)) {
+    return {
+      formError: "Ugyldig visningsmodus for handlelisten.",
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  await db.userFamilyShoppingPreference.upsert({
+    create: {
+      familyId,
+      listMode,
+      userId,
+    },
+    update: {
+      listMode,
+    },
+    where: {
+      userId_familyId: {
+        familyId,
+        userId,
+      },
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}

--- a/app/lib/shopping-preference.server.ts
+++ b/app/lib/shopping-preference.server.ts
@@ -1,0 +1,24 @@
+import { db } from "./db.server";
+import type { FamilyShoppingListModeValue } from "./meal-plan-for-date.server";
+
+export async function getFamilyShoppingListMode({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}): Promise<FamilyShoppingListModeValue> {
+  const preference = await db.userFamilyShoppingPreference.findUnique({
+    select: {
+      listMode: true,
+    },
+    where: {
+      userId_familyId: {
+        familyId,
+        userId,
+      },
+    },
+  });
+
+  return preference?.listMode ?? "GLOBAL";
+}

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, it, beforeEach, vi } from "vitest";
 
-const { dbMock, getFamilyStockMatchSetMock, requireFamilyMembershipMock } =
-  vi.hoisted(() => {
+const {
+  dbMock,
+  getFamilyShoppingListModeMock,
+  getFamilyStockMatchSetMock,
+  requireFamilyMembershipMock,
+} = vi.hoisted(() => {
     return {
+      getFamilyShoppingListModeMock: vi.fn(),
       dbMock: {
         familyShoppingItem: {
           findMany: vi.fn(),
@@ -49,10 +54,16 @@ vi.mock("./stock.server", async (importOriginal) => {
   };
 });
 
+vi.mock("./shopping-preference.server", () => ({
+  getFamilyShoppingListMode: getFamilyShoppingListModeMock,
+}));
+
 import {
+  getFamilyShoppingData,
   getMealPlanShoppingData,
   getMealPlanStoreModeData,
   listRecentManualShoppingItemsForFamily,
+  mergeFamilyAndMealPlanShoppingItems,
 } from "./shopping.server";
 
 const mockMembership = {
@@ -1943,6 +1954,155 @@ describe("shopping.server", () => {
         nameNormalized: "brød",
         quantity: "1",
       },
+    ]);
+  });
+
+  it("dedupes meal-plan items that overlap with family items in combined mode", () => {
+    const familyItems = [
+      {
+        category: { id: "category-dairy", name: "Meieri" },
+        checked: false,
+        collaborationVersion: "v1",
+        name: "Melk",
+        note: null,
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Meieri", sortOrder: 1 },
+        sourceKey: "family-1",
+        sourceType: "FAMILY" as const,
+      },
+    ];
+    const mealPlanItems = [
+      {
+        amount: "1",
+        buyOnDate: null,
+        category: { id: "category-dairy", name: "Meieri" },
+        checked: false,
+        collaborationVersion: "v2",
+        firstDate: new Date("2026-05-16T00:00:00.000Z"),
+        lastDate: new Date("2026-05-16T00:00:00.000Z"),
+        name: "Melk",
+        note: null,
+        occurrenceCount: 1,
+        occurrences: [],
+        postponedUntilDate: null,
+        preferredStore: null,
+        preferredStoreConflict: false,
+        quantityLabel: "1 l",
+        recipeCount: 1,
+        section: { displayName: "Meieri", sortOrder: 1 },
+        sourceKey: "generated-1",
+        sourceType: "GENERATED" as const,
+        unit: "l",
+      },
+      {
+        buyOnDate: null,
+        category: { id: "category-other", name: "Annet" },
+        checked: false,
+        collaborationVersion: "v3",
+        name: "Lime",
+        note: null,
+        overrideVersion: "",
+        preferredStore: null,
+        quantity: "2",
+        quantityLabel: "2",
+        section: { displayName: "Annet", sortOrder: 2 },
+        sourceKey: "manual-1",
+        sourceType: "MANUAL" as const,
+      },
+    ];
+
+    const merged = mergeFamilyAndMealPlanShoppingItems({
+      familyItems,
+      mealPlanItems,
+    });
+
+    expect(merged.map((item) => item.name)).toEqual(["Melk", "Lime"]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it("returns combined family shopping data when mode and meal plan are available", async () => {
+    getFamilyShoppingListModeMock.mockResolvedValue("COMBINED");
+    dbMock.familyShoppingItem.findMany.mockResolvedValue([
+      {
+        category: {
+          displayName: "Annet",
+          id: "category-other",
+        },
+        categoryId: "category-other",
+        checked: false,
+        id: "family-item-1",
+        name: "Batterier",
+        note: null,
+        preferredStore: null,
+        preferredStoreId: null,
+        quantity: "1",
+        updatedAt: new Date("2026-05-10T00:00:00.000Z"),
+      },
+    ]);
+    dbMock.mealPlan.findFirst.mockImplementation(
+      (args: { where: { id?: string } }) => {
+        if (args.where.id) {
+          return {
+            activeShoppingDate: null,
+            endDate: new Date("2026-05-18T00:00:00.000Z"),
+            entries: [],
+            id: "meal-plan-1",
+            manualShoppingItems: [
+              {
+                buyOnDate: null,
+                category: {
+                  displayName: "Annet",
+                  id: "category-other",
+                },
+                categoryId: "category-other",
+                id: "manual-1",
+                name: "Lime",
+                note: null,
+                preferredStore: null,
+                preferredStoreId: null,
+                quantity: "2",
+                updatedAt: new Date("2026-05-10T00:00:00.000Z"),
+              },
+            ],
+            shoppingOverrides: [],
+            startDate: new Date("2026-05-15T00:00:00.000Z"),
+            status: "DRAFT",
+            title: "Uke 20",
+          };
+        }
+
+        return {
+          endDate: new Date("2026-05-18T00:00:00.000Z"),
+          id: "meal-plan-1",
+          startDate: new Date("2026-05-15T00:00:00.000Z"),
+          status: "DRAFT",
+          title: "Uke 20",
+        };
+      },
+    );
+    dbMock.store.findMany.mockResolvedValue([]);
+
+    const result = await getFamilyShoppingData({
+      familyId: "family-1",
+      referenceDate: new Date("2026-05-16T00:00:00.000Z"),
+      userId: "user-1",
+    });
+
+    expect(result.activeListMode).toBe("COMBINED");
+    expect(result.canOfferCombined).toBe(true);
+    expect(result.todayMealPlan).toEqual({
+      id: "meal-plan-1",
+      status: "DRAFT",
+      title: "Uke 20",
+    });
+    expect(result.itemCounts.family).toBe(1);
+    expect(result.itemCounts.mealPlan).toBe(1);
+    expect(result.itemCounts.total).toBe(2);
+    expect(result.projectedItems.map((item) => item.name).sort()).toEqual([
+      "Batterier",
+      "Lime",
     ]);
   });
 });

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -3,7 +3,9 @@ import { MealType, Prisma, ShoppingItemSource } from "@prisma/client";
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
+import { findMealPlanCoveringDate } from "./meal-plan-for-date.server";
 import { getMealPlanDateRange } from "./meal-plan.server";
+import { getFamilyShoppingListMode } from "./shopping-preference.server";
 import {
   getFamilyStockMatchSet,
   isStockIngredientMatch,
@@ -553,11 +555,84 @@ export function projectFamilyShoppingItems({
   });
 }
 
+export function buildFamilyShoppingCrossSourceDedupKey(item: {
+  category: { id: string };
+  name: string;
+}) {
+  return JSON.stringify({
+    categoryId: item.category.id,
+    name: normalizeIngredientCanonicalName(item.name),
+  });
+}
+
+export function mergeFamilyAndMealPlanShoppingItems({
+  familyItems,
+  mealPlanItems,
+}: {
+  familyItems: ProjectedFamilyShoppingItem[];
+  mealPlanItems: Array<
+    ProjectedGeneratedShoppingItem | ProjectedManualShoppingItem
+  >;
+}) {
+  const familyKeys = new Set(
+    familyItems.map((item) => buildFamilyShoppingCrossSourceDedupKey(item)),
+  );
+
+  const dedupedMealPlanItems = mealPlanItems.filter(
+    (item) => !familyKeys.has(buildFamilyShoppingCrossSourceDedupKey(item)),
+  );
+
+  return [...familyItems, ...dedupedMealPlanItems].sort(compareProjectedItems);
+}
+
+async function projectMealPlanShoppingItemsForFamily({
+  familyId,
+  mealPlanId,
+}: {
+  familyId: string;
+  mealPlanId: string;
+}) {
+  const mealPlan = await loadShoppingMealPlan({
+    familyId,
+    mealPlanId,
+  });
+
+  if (!mealPlan) {
+    return [];
+  }
+
+  const stockMatchSet = await getFamilyStockMatchSet(familyId);
+  const includeDespiteStockKeys = buildIncludeDespiteStockKeys(
+    mealPlan.shoppingOverrides,
+  );
+  const stores = await db.store.findMany({
+    orderBy: [{ name: "asc" }],
+    select: shoppingStoreSelect,
+    where: {
+      OR: [{ familyId: null }, { familyId }],
+    },
+  });
+  const generatedItems = projectGeneratedShoppingItems({
+    includeDespiteStockKeys,
+    mealPlan,
+    stockMatchSet,
+    stores,
+  });
+  const manualItems = projectManualShoppingItems({
+    mealPlan,
+    stores,
+  });
+
+  return [...generatedItems, ...manualItems];
+}
+
 export async function getFamilyShoppingData({
   familyId,
+  referenceDate = new Date(),
   userId,
 }: {
   familyId: string;
+  referenceDate?: Date;
   userId: string;
 }) {
   const membership = await requireFamilyMembership({
@@ -565,27 +640,55 @@ export async function getFamilyShoppingData({
     userId,
   });
 
-  const [stores, categories, familyItems] = await Promise.all([
-    db.store.findMany({
-      orderBy: [{ name: "asc" }],
-      select: shoppingStoreSelect,
-      where: {
-        OR: [{ familyId: null }, { familyId }],
-      },
-    }),
-    db.ingredientCategory.findMany({
-      orderBy: [{ displayName: "asc" }],
-      select: shoppingCategorySelect,
-    }),
-    loadFamilyShoppingItems({ familyId }),
-  ]);
+  const [stores, categories, familyItems, savedListMode, todayMealPlan] =
+    await Promise.all([
+      db.store.findMany({
+        orderBy: [{ name: "asc" }],
+        select: shoppingStoreSelect,
+        where: {
+          OR: [{ familyId: null }, { familyId }],
+        },
+      }),
+      db.ingredientCategory.findMany({
+        orderBy: [{ displayName: "asc" }],
+        select: shoppingCategorySelect,
+      }),
+      loadFamilyShoppingItems({ familyId }),
+      getFamilyShoppingListMode({
+        familyId,
+        userId,
+      }),
+      findMealPlanCoveringDate({
+        familyId,
+        referenceDate,
+      }),
+    ]);
 
-  const projectedItems = projectFamilyShoppingItems({
+  const familyProjectedItems = projectFamilyShoppingItems({
     items: familyItems,
     stores,
-  }).sort(compareProjectedItems);
+  });
+  const mealPlanProjectedItems =
+    todayMealPlan === null
+      ? []
+      : await projectMealPlanShoppingItemsForFamily({
+          familyId,
+          mealPlanId: todayMealPlan.id,
+        });
+  const canOfferCombined = todayMealPlan !== null;
+  const activeListMode =
+    savedListMode === "COMBINED" && canOfferCombined ? "COMBINED" : "GLOBAL";
+  const projectedItems =
+    activeListMode === "COMBINED"
+      ? mergeFamilyAndMealPlanShoppingItems({
+          familyItems: familyProjectedItems,
+          mealPlanItems: mealPlanProjectedItems,
+        })
+      : [...familyProjectedItems].sort(compareProjectedItems);
 
   return {
+    activeListMode,
+    canOfferCombined,
     categories,
     family: {
       id: membership.family.id,
@@ -593,15 +696,27 @@ export async function getFamilyShoppingData({
     },
     itemCounts: {
       checked: projectedItems.filter((item) => item.checked).length,
+      family: familyProjectedItems.length,
+      mealPlan: mealPlanProjectedItems.length,
       total: projectedItems.length,
       unchecked: projectedItems.filter((item) => !item.checked).length,
     },
+    mealPlanItemCount: mealPlanProjectedItems.length,
     projectedItems,
+    savedListMode,
     storeGroups: buildProjectedStoreGroups(projectedItems),
     stores: stores.map((store) => ({
       id: store.id,
       name: store.name,
     })),
+    todayMealPlan:
+      todayMealPlan === null
+        ? null
+        : {
+            id: todayMealPlan.id,
+            status: todayMealPlan.status,
+            title: todayMealPlan.title,
+          },
     userRole: membership.role,
   };
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -32,6 +32,7 @@ export default [
       "families/:familyId/meal-plans/:mealPlanId/store-mode",
       "routes/family-meal-plan-store-mode.tsx",
     ),
+    route("families/:familyId/store-mode", "routes/family-store-mode.ts"),
     route("families/:familyId/shopping", "routes/family-shopping.tsx"),
     route(
       "families/:familyId/shopping/ingredient-search",

--- a/app/routes/app-layout.tsx
+++ b/app/routes/app-layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router";
 
+import { AppMobileBottomNav } from "../components/app-mobile-bottom-nav";
 import { AppTopNav } from "../components/app-top-nav";
 import { requireUser } from "../lib/auth.server";
 import { getFamilyMembershipsForUser } from "../lib/family.server";
@@ -38,13 +39,18 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 }
 
 export default function AppLayoutRoute({ loaderData }: Route.ComponentProps) {
+  const hasMobileBottomNav = Boolean(loaderData.familyId);
+
   return (
     <>
       <AppTopNav
         familyId={loaderData.familyId}
         pendingReviewCount={loaderData.pendingReviewCount}
       />
-      <Outlet />
+      <div className={hasMobileBottomNav ? "pb-[calc(4.5rem+env(safe-area-inset-bottom))] md:pb-0" : undefined}>
+        <Outlet />
+      </div>
+      <AppMobileBottomNav familyId={loaderData.familyId} />
     </>
   );
 }

--- a/app/routes/family-shopping.test.ts
+++ b/app/routes/family-shopping.test.ts
@@ -26,12 +26,26 @@ vi.mock("../lib/family-shopping-write.server", () => ({
   updateFamilyShoppingItem: vi.fn(),
 }));
 
+vi.mock("../lib/shopping-preference-write.server", () => ({
+  parseFamilyShoppingListMode: vi.fn(),
+  updateFamilyShoppingListMode: vi.fn(),
+}));
+
+vi.mock("../lib/shopping-write.server", () => ({
+  toggleShoppingItemChecked: vi.fn(),
+}));
+
 import { requireUser } from "../lib/auth.server";
 import {
   createQuickFamilyShoppingItem,
   parseQuickAddFamilyShoppingItemInput,
   toggleFamilyShoppingItemChecked,
 } from "../lib/family-shopping-write.server";
+import {
+  parseFamilyShoppingListMode,
+  updateFamilyShoppingListMode,
+} from "../lib/shopping-preference-write.server";
+import { toggleShoppingItemChecked } from "../lib/shopping-write.server";
 import {
   getFamilyShoppingData,
   listRecentManualShoppingItemsForFamily,
@@ -54,10 +68,21 @@ describe("family shopping route", () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([]);
     vi.mocked(getFamilyShoppingData).mockResolvedValue({
+      activeListMode: "GLOBAL",
+      canOfferCombined: false,
       categories: [],
       family: { id: "family-1", name: "Solberg" },
-      itemCounts: { checked: 0, total: 1, unchecked: 1 },
+      itemCounts: {
+        checked: 0,
+        family: 1,
+        mealPlan: 0,
+        total: 1,
+        unchecked: 1,
+      },
+      mealPlanItemCount: 0,
       projectedItems: [],
+      savedListMode: "GLOBAL",
+      todayMealPlan: null,
       storeGroups: [
         {
           sections: [
@@ -219,5 +244,70 @@ describe("family shopping route", () => {
       formError: "Kunne ikke legge til varen.",
       intent: "quick-add-family-shopping-item",
     });
+  });
+
+  it("updates shopping list mode from the route action", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseFamilyShoppingListMode).mockReturnValue("COMBINED");
+    vi.mocked(updateFamilyShoppingListMode).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "set-family-shopping-list-mode");
+    formData.set("listMode", "COMBINED");
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: new Request("http://localhost/families/family-1/shopping", {
+        body: formData,
+        method: "POST",
+      }),
+    });
+
+    expect(updateFamilyShoppingListMode).toHaveBeenCalledWith({
+      familyId: "family-1",
+      listMode: "COMBINED",
+      userId: "user-1",
+    });
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/shopping?notice=family-shopping-list-mode-updated",
+    );
+  });
+
+  it("toggles a meal-plan shopping item from the route action", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(toggleShoppingItemChecked).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "toggle-meal-plan-shopping-item-checked");
+    formData.set("mealPlanId", "meal-plan-1");
+    formData.set("sourceKey", "generated-1");
+    formData.set("sourceType", "GENERATED");
+    formData.set("checked", "true");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: new Request("http://localhost/families/family-1/shopping", {
+        body: formData,
+        method: "POST",
+      }),
+    });
+
+    expect(toggleShoppingItemChecked).toHaveBeenCalledWith({
+      checked: true,
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "generated-1",
+      sourceType: "GENERATED",
+      userId: "user-1",
+    });
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
   });
 });

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -1,3 +1,4 @@
+import { ShoppingItemSource } from "@prisma/client";
 import {
   Form,
   Link,
@@ -9,6 +10,7 @@ import {
 import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
 import { ShoppingListItemExpanded } from "../components/shopping-list-item-expanded";
 import { requireUser } from "../lib/auth.server";
+import { formatDateOnly } from "../lib/meal-plan-dates";
 import { useIsLgViewport } from "../lib/use-lg-viewport";
 import {
   createFamilyShoppingItem,
@@ -23,25 +25,35 @@ import {
 } from "../lib/family-shopping-write.server";
 import {
   formatCompactShoppingSourceLine,
+  formatGeneratedItemSummary,
   formatGeneratedQuantityBadge,
 } from "../lib/shopping-display";
+import {
+  parseFamilyShoppingListMode,
+  updateFamilyShoppingListMode,
+} from "../lib/shopping-preference-write.server";
 import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
   getFamilyShoppingData,
   listRecentManualShoppingItemsForFamily,
+  type ProjectedShoppingItem,
 } from "../lib/shopping.server";
+import { toggleShoppingItemChecked } from "../lib/shopping-write.server";
 
 type FamilyShoppingNotice =
   | "family-shopping-item-added"
   | "family-shopping-item-deleted"
   | "family-shopping-item-updated"
-  | "family-shopping-item-check-state-updated";
+  | "family-shopping-item-check-state-updated"
+  | "family-shopping-list-mode-updated";
 
 type FamilyShoppingIntent =
   | "add-family-shopping-item"
   | "quick-add-family-shopping-item"
   | "delete-family-shopping-item"
+  | "set-family-shopping-list-mode"
   | "toggle-family-shopping-item-checked"
+  | "toggle-meal-plan-shopping-item-checked"
   | "update-family-shopping-item";
 
 interface FamilyShoppingActionData {
@@ -95,11 +107,15 @@ export async function loader({
   ]);
 
   return {
+    activeListMode: result.activeListMode,
+    canOfferCombined: result.canOfferCombined,
     categories: result.categories,
     family: result.family,
     itemCounts: result.itemCounts,
+    mealPlanItemCount: result.mealPlanItemCount,
     notice: getFamilyShoppingNotice(request),
     recentManualItems,
+    savedListMode: result.savedListMode,
     storeGroups: result.storeGroups.map((group) => ({
       sections: group.sections.map((section) => ({
         ...section,
@@ -111,6 +127,7 @@ export async function loader({
       store: group.store,
     })),
     stores: result.stores,
+    todayMealPlan: result.todayMealPlan,
     userRole: result.userRole,
   };
 }
@@ -128,6 +145,81 @@ export async function action({
   const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "set-family-shopping-list-mode") {
+    const listMode = parseFamilyShoppingListMode(formData.get("listMode"));
+
+    if (!listMode) {
+      return {
+        formError: "Ugyldig visningsmodus for handlelisten.",
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    const result = await updateFamilyShoppingListMode({
+      familyId,
+      listMode,
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    return buildFamilyShoppingRedirect({
+      familyId,
+      notice: "family-shopping-list-mode-updated",
+      request,
+    });
+  }
+
+  if (intent === "toggle-meal-plan-shopping-item-checked") {
+    const mealPlanId = String(formData.get("mealPlanId") ?? "").trim();
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+    const sourceType = parseMealPlanShoppingItemSource(formData.get("sourceType"));
+    const checked = String(formData.get("checked") ?? "") === "true";
+
+    if (!mealPlanId || !sourceKey || !sourceType) {
+      return {
+        formError: "Fant ikke varelinjen som skulle oppdateres.",
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    const result = await toggleShoppingItemChecked({
+      checked,
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      mealPlanId,
+      sourceKey,
+      sourceType,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke ukeplanen eller varelinjen.",
+        intent,
+      } satisfies FamilyShoppingActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+        itemTarget: { sourceKey },
+      } satisfies FamilyShoppingActionData;
+    }
+
+    return buildFamilyShoppingRedirect({
+      familyId,
+      notice: "family-shopping-item-check-state-updated",
+      request,
+    });
+  }
 
   if (intent === "add-family-shopping-item") {
     const result = await createFamilyShoppingItem({
@@ -347,7 +439,7 @@ export default function FamilyShoppingRoute({
       : defaultFamilyShoppingItemValues;
 
   return (
-    <main className="min-h-screen bg-slate-100 px-4 pb-36 pt-8 text-slate-900 lg:pb-12 lg:py-12">
+    <main className="min-h-screen bg-slate-100 px-4 pb-44 pt-8 text-slate-900 lg:pb-12 lg:py-12">
       <div className="mx-auto flex max-w-5xl flex-col gap-6">
         <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8 lg:py-8">
           <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
@@ -398,6 +490,78 @@ export default function FamilyShoppingRoute({
           </section>
         ) : null}
 
+        {loaderData.canOfferCombined ? (
+          <section className="rounded-[28px] border border-sky-200 bg-sky-50 px-6 py-5 text-sky-950 shadow-sm">
+            <div className="flex flex-col gap-4">
+              <div>
+                <h2 className="text-base font-semibold">
+                  {loaderData.todayMealPlan?.title ?? "Dagens ukeplan"} har{" "}
+                  {loaderData.mealPlanItemCount} varelinjer
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-sky-900">
+                  {loaderData.todayMealPlan?.status === "DRAFT"
+                    ? "Ukeplanen er fortsatt utkast. Du kan velge om dagens ukeplan skal vises sammen med familiens faste liste."
+                    : "Du kan velge om dagens ukeplan skal vises sammen med familiens faste liste."}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Form method="post">
+                  <input
+                    name="intent"
+                    type="hidden"
+                    value="set-family-shopping-list-mode"
+                  />
+                  <input
+                    name="listMode"
+                    type="hidden"
+                    value="GLOBAL"
+                  />
+                  <button
+                    className={`rounded-2xl px-5 py-3 text-sm font-medium transition ${
+                      loaderData.activeListMode === "GLOBAL"
+                        ? "bg-slate-950 text-white"
+                        : "bg-white text-slate-900 ring-1 ring-sky-200 hover:bg-sky-100"
+                    }`}
+                    disabled={
+                      navigation.state === "submitting" &&
+                      pendingIntent === "set-family-shopping-list-mode"
+                    }
+                    type="submit"
+                  >
+                    Kun global liste
+                  </button>
+                </Form>
+                <Form method="post">
+                  <input
+                    name="intent"
+                    type="hidden"
+                    value="set-family-shopping-list-mode"
+                  />
+                  <input
+                    name="listMode"
+                    type="hidden"
+                    value="COMBINED"
+                  />
+                  <button
+                    className={`rounded-2xl px-5 py-3 text-sm font-medium transition ${
+                      loaderData.activeListMode === "COMBINED"
+                        ? "bg-emerald-600 text-white"
+                        : "bg-white text-slate-900 ring-1 ring-sky-200 hover:bg-sky-100"
+                    }`}
+                    disabled={
+                      navigation.state === "submitting" &&
+                      pendingIntent === "set-family-shopping-list-mode"
+                    }
+                    type="submit"
+                  >
+                    Vis kombinert
+                  </button>
+                </Form>
+              </div>
+            </div>
+          </section>
+        ) : null}
+
         <section className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
           <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <h2 className="text-lg font-semibold text-slate-950">Oversikt</h2>
@@ -419,6 +583,17 @@ export default function FamilyShoppingRoute({
                   {loaderData.itemCounts.checked} kjøpt.
                 </dd>
               </div>
+              {loaderData.activeListMode === "COMBINED" ? (
+                <div className="rounded-[24px] border border-slate-200 bg-slate-50 p-5">
+                  <dt className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">
+                    Visning
+                  </dt>
+                  <dd className="mt-2 text-sm leading-6 text-slate-700">
+                    {loaderData.itemCounts.family} faste varer og{" "}
+                    {loaderData.itemCounts.mealPlan} fra dagens ukeplan.
+                  </dd>
+                </div>
+              ) : null}
             </dl>
           </article>
 
@@ -521,106 +696,19 @@ export default function FamilyShoppingRoute({
                         {section.displayName}
                       </h3>
                       <div className="mt-3 grid gap-2">
-                        {section.items
-                          .filter((item) => item.sourceType === "FAMILY")
-                          .map((item) => {
-                            const isPendingCheckToggle =
-                              navigation.state === "submitting" &&
-                              pendingIntent ===
-                                "toggle-family-shopping-item-checked" &&
-                              pendingSourceKey === item.sourceKey;
-                            const isPendingFamilySave =
-                              navigation.state === "submitting" &&
-                              pendingIntent === "update-family-shopping-item" &&
-                              pendingSourceKey === item.sourceKey;
-                            const isPendingFamilyDelete =
-                              navigation.state === "submitting" &&
-                              pendingIntent === "delete-family-shopping-item" &&
-                              pendingSourceKey === item.sourceKey;
-                            const familyValues =
-                              actionData?.intent ===
-                                "update-family-shopping-item" &&
-                              actionData.itemTarget?.sourceKey ===
-                                item.sourceKey &&
-                              actionData.familyValues
-                                ? actionData.familyValues
-                                : item.sourceType === "FAMILY"
-                                  ? {
-                                      categoryId: item.category.id,
-                                      name: item.name,
-                                      note: item.note ?? "",
-                                      preferredStoreId:
-                                        item.preferredStore?.id ?? "",
-                                      quantity: item.quantity ?? "",
-                                    }
-                                  : null;
-
-                            return (
-                              <article
-                                key={item.sourceKey}
-                                className={`rounded-[24px] border p-4 ${
-                                  item.checked
-                                    ? "border-slate-200 bg-slate-100 opacity-80"
-                                    : "border-slate-200 bg-slate-50"
-                                }`}
-                              >
-                                <div className="flex flex-wrap items-center gap-2">
-                                  <h4
-                                    className={`text-base font-semibold ${
-                                      item.checked
-                                        ? "text-slate-500 line-through"
-                                        : "text-slate-950"
-                                    }`}
-                                  >
-                                    {item.name}
-                                  </h4>
-                                  {formatGeneratedQuantityBadge(item) ? (
-                                    <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
-                                      {formatGeneratedQuantityBadge(item)}
-                                    </span>
-                                  ) : null}
-                                  <span className="rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800">
-                                    Alltid på listen
-                                  </span>
-                                </div>
-                                {formatCompactShoppingSourceLine(item) ? (
-                                  <p className="mt-2 text-xs text-slate-600">
-                                    {formatCompactShoppingSourceLine(item)}
-                                  </p>
-                                ) : null}
-                                <details className="mt-4">
-                                  <summary className="cursor-pointer text-sm font-medium text-slate-800">
-                                    Detaljer
-                                  </summary>
-                                  <div className="mt-4">
-                                    <ShoppingListItemExpanded
-                                      actionData={actionData}
-                                      categories={loaderData.categories}
-                                      familyValues={familyValues}
-                                      isPendingCheckToggle={
-                                        isPendingCheckToggle
-                                      }
-                                      isPendingFamilyDelete={
-                                        isPendingFamilyDelete
-                                      }
-                                      isPendingFamilySave={isPendingFamilySave}
-                                      isPendingGeneratedExclude={false}
-                                      isPendingGeneratedSave={false}
-                                      isPendingManualDelete={false}
-                                      isPendingManualSave={false}
-                                      item={item}
-                                      manualValues={null}
-                                      overrideValues={null}
-                                      stores={loaderData.stores}
-                                      toggleExpectedVersion={getToggleExpectedVersion(
-                                        item,
-                                      )}
-                                    />
-                                  </div>
-                                </details>
-                              </article>
-                            );
-                          })}
+                        {section.items.map((item) =>
+                          renderFamilyShoppingListItem({
+                            actionData,
+                            categories: loaderData.categories,
+                            familyId: loaderData.family.id,
+                            item,
+                            navigation,
+                            pendingIntent,
+                            pendingSourceKey,
+                            stores: loaderData.stores,
+                            todayMealPlanId: loaderData.todayMealPlan?.id ?? null,
+                          }),
+                        )}
                       </div>
                     </section>
                   ))}
@@ -631,19 +719,17 @@ export default function FamilyShoppingRoute({
         ) : (
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
             <h2 className="text-lg font-semibold text-slate-950">
-              Listen er tom
+              {getFamilyShoppingEmptyStateTitle(loaderData)}
             </h2>
             <p className="mt-3 text-sm leading-6 text-slate-600">
-              {isLg
-                ? "Legg til den første varen med skjemaet over."
-                : "Legg til den første varen med feltet nederst."}
+              {getFamilyShoppingEmptyStateDescription(loaderData, isLg)}
             </p>
           </section>
         )}
       </div>
 
       {!isLg ? (
-        <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <div className="pointer-events-none fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom))] z-40 px-4 pt-3">
           <div className="pointer-events-auto mx-auto max-w-5xl">
             <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200">
               {quickAddFormError ? (
@@ -727,12 +813,298 @@ function getFamilyShoppingNotice(
     notice === "family-shopping-item-added" ||
     notice === "family-shopping-item-deleted" ||
     notice === "family-shopping-item-updated" ||
-    notice === "family-shopping-item-check-state-updated"
+    notice === "family-shopping-item-check-state-updated" ||
+    notice === "family-shopping-list-mode-updated"
   ) {
     return notice;
   }
 
   return null;
+}
+
+function formatCompactShoppingSourceLineForItem(item: ProjectedShoppingItem) {
+  if (item.sourceType === "GENERATED") {
+    return formatCompactShoppingSourceLine({
+      occurrenceCount: item.occurrenceCount,
+      occurrences: item.occurrences.map((occurrence) => ({
+        date:
+          typeof occurrence.date === "string"
+            ? occurrence.date
+            : formatDateOnly(occurrence.date),
+        recipeTitle: occurrence.recipeTitle,
+      })),
+      sourceType: item.sourceType,
+    });
+  }
+
+  if (item.sourceType === "MANUAL") {
+    return formatCompactShoppingSourceLine({
+      buyOnDate: item.buyOnDate
+        ? typeof item.buyOnDate === "string"
+          ? item.buyOnDate
+          : formatDateOnly(item.buyOnDate)
+        : null,
+      sourceType: item.sourceType,
+    });
+  }
+
+  return formatCompactShoppingSourceLine({
+    sourceType: item.sourceType,
+  });
+}
+
+function parseMealPlanShoppingItemSource(value: FormDataEntryValue | null) {
+  if (
+    value === ShoppingItemSource.GENERATED ||
+    value === ShoppingItemSource.MANUAL
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function getFamilyShoppingSourceBadge(item: ProjectedShoppingItem) {
+  if (item.sourceType === "FAMILY") {
+    return {
+      className: "rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800",
+      label: "Global",
+    };
+  }
+
+  if (item.sourceType === "GENERATED") {
+    return {
+      className: "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800",
+      label: "Ukeplan",
+    };
+  }
+
+  return {
+    className: "rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700",
+    label: "Ukeplan · Manuell",
+  };
+}
+
+function getFamilyShoppingEmptyStateTitle(
+  loaderData: Awaited<ReturnType<typeof loader>>,
+) {
+  if (
+    loaderData.activeListMode === "COMBINED" &&
+    loaderData.itemCounts.family === 0 &&
+    loaderData.mealPlanItemCount > 0
+  ) {
+    return "Ingen faste varer akkurat nå";
+  }
+
+  if (
+    loaderData.activeListMode === "COMBINED" &&
+    loaderData.itemCounts.family > 0 &&
+    loaderData.mealPlanItemCount === 0
+  ) {
+    return "Ingen varer fra dagens ukeplan";
+  }
+
+  return "Listen er tom";
+}
+
+function getFamilyShoppingEmptyStateDescription(
+  loaderData: Awaited<ReturnType<typeof loader>>,
+  isLg: boolean,
+) {
+  if (
+    loaderData.activeListMode === "COMBINED" &&
+    loaderData.itemCounts.family === 0 &&
+    loaderData.mealPlanItemCount > 0
+  ) {
+    return "Familiens faste liste er tom, men dagens ukeplan har varer. Bytt til kombinert visning for å se dem her.";
+  }
+
+  if (
+    loaderData.activeListMode === "COMBINED" &&
+    loaderData.itemCounts.family > 0 &&
+    loaderData.mealPlanItemCount === 0
+  ) {
+    return "Du har faste varer på listen, men dagens ukeplan har ingen handlelinjer ennå.";
+  }
+
+  return isLg
+    ? "Legg til den første varen med skjemaet over."
+    : "Legg til den første varen med feltet nederst.";
+}
+
+function renderFamilyShoppingListItem({
+  actionData,
+  categories,
+  familyId,
+  item,
+  navigation,
+  pendingIntent,
+  pendingSourceKey,
+  stores,
+  todayMealPlanId,
+}: {
+  actionData?: FamilyShoppingActionData;
+  categories: Awaited<ReturnType<typeof loader>>["categories"];
+  familyId: string;
+  item: ProjectedShoppingItem;
+  navigation: ReturnType<typeof useNavigation>;
+  pendingIntent: FormDataEntryValue | null | undefined;
+  pendingSourceKey: string | null;
+  stores: Awaited<ReturnType<typeof loader>>["stores"];
+  todayMealPlanId: string | null;
+}) {
+  const sourceBadge = getFamilyShoppingSourceBadge(item);
+  const isPendingCheckToggle =
+    navigation.state === "submitting" &&
+    ((pendingIntent === "toggle-family-shopping-item-checked" &&
+      item.sourceType === "FAMILY") ||
+      (pendingIntent === "toggle-meal-plan-shopping-item-checked" &&
+        item.sourceType !== "FAMILY")) &&
+    pendingSourceKey === item.sourceKey;
+  const isPendingFamilySave =
+    navigation.state === "submitting" &&
+    pendingIntent === "update-family-shopping-item" &&
+    pendingSourceKey === item.sourceKey;
+  const isPendingFamilyDelete =
+    navigation.state === "submitting" &&
+    pendingIntent === "delete-family-shopping-item" &&
+    pendingSourceKey === item.sourceKey;
+  const familyValues =
+    actionData?.intent === "update-family-shopping-item" &&
+    actionData.itemTarget?.sourceKey === item.sourceKey &&
+    actionData.familyValues
+      ? actionData.familyValues
+      : item.sourceType === "FAMILY"
+        ? {
+            categoryId: item.category.id,
+            name: item.name,
+            note: item.note ?? "",
+            preferredStoreId: item.preferredStore?.id ?? "",
+            quantity: item.quantity ?? "",
+          }
+        : null;
+
+  return (
+    <article
+      key={item.sourceKey}
+      className={`rounded-[24px] border p-4 ${
+        item.checked
+          ? "border-slate-200 bg-slate-100 opacity-80"
+          : "border-slate-200 bg-slate-50"
+      }`}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <h4
+          className={`text-base font-semibold ${
+            item.checked ? "text-slate-500 line-through" : "text-slate-950"
+          }`}
+        >
+          {item.name}
+        </h4>
+        {formatGeneratedQuantityBadge(item) ? (
+          <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+            {formatGeneratedQuantityBadge(item)}
+          </span>
+        ) : null}
+        <span className={sourceBadge.className}>{sourceBadge.label}</span>
+      </div>
+      {formatCompactShoppingSourceLineForItem(item) ? (
+        <p className="mt-2 text-xs text-slate-600">
+          {formatCompactShoppingSourceLineForItem(item)}
+        </p>
+      ) : null}
+      {item.sourceType === "GENERATED" ? (
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          {formatGeneratedItemSummary({
+            firstDate:
+              typeof item.firstDate === "string"
+                ? item.firstDate
+                : formatDateOnly(item.firstDate),
+            lastDate:
+              typeof item.lastDate === "string"
+                ? item.lastDate
+                : formatDateOnly(item.lastDate),
+            occurrenceCount: item.occurrenceCount,
+            occurrences: item.occurrences.map((occurrence) => ({
+              date:
+                typeof occurrence.date === "string"
+                  ? occurrence.date
+                  : formatDateOnly(occurrence.date),
+              recipeTitle: occurrence.recipeTitle,
+            })),
+            sourceType: item.sourceType,
+          })}
+        </p>
+      ) : null}
+      {item.sourceType === "FAMILY" ? (
+        <details className="mt-4">
+          <summary className="cursor-pointer text-sm font-medium text-slate-800">
+            Detaljer
+          </summary>
+          <div className="mt-4">
+            <ShoppingListItemExpanded
+              actionData={actionData}
+              categories={categories}
+              familyValues={familyValues}
+              isPendingCheckToggle={isPendingCheckToggle}
+              isPendingFamilyDelete={isPendingFamilyDelete}
+              isPendingFamilySave={isPendingFamilySave}
+              isPendingGeneratedExclude={false}
+              isPendingGeneratedSave={false}
+              isPendingManualDelete={false}
+              isPendingManualSave={false}
+              item={item}
+              manualValues={null}
+              overrideValues={null}
+              stores={stores}
+              toggleExpectedVersion={getToggleExpectedVersion(item)}
+            />
+          </div>
+        </details>
+      ) : todayMealPlanId ? (
+        <Form className="mt-4" method="post">
+          <input
+            name="intent"
+            type="hidden"
+            value="toggle-meal-plan-shopping-item-checked"
+          />
+          <input name="mealPlanId" type="hidden" value={todayMealPlanId} />
+          <input name="sourceKey" type="hidden" value={item.sourceKey} />
+          <input name="sourceType" type="hidden" value={item.sourceType} />
+          <input
+            name="checked"
+            type="hidden"
+            value={item.checked ? "false" : "true"}
+          />
+          <input
+            name="expectedUpdatedAt"
+            type="hidden"
+            value={getToggleExpectedVersion(item)}
+          />
+          <button
+            className="rounded-xl bg-slate-950 px-4 py-2 text-xs font-medium text-white transition hover:bg-slate-800 disabled:opacity-60"
+            disabled={isPendingCheckToggle}
+            type="submit"
+          >
+            {isPendingCheckToggle
+              ? "Oppdaterer..."
+              : item.checked
+                ? "Fjern avkryssing"
+                : "Marker som kjøpt"}
+          </button>
+          <p className="mt-3 text-xs text-slate-500">
+            <Link
+              className="font-medium text-emerald-700 underline"
+              to={`/families/${familyId}/meal-plans/${todayMealPlanId}/shopping`}
+            >
+              Åpne full handleliste for ukeplanen
+            </Link>{" "}
+            for redigering av detaljer.
+          </p>
+        </Form>
+      ) : null}
+    </article>
+  );
 }
 
 function getFamilyShoppingNoticeContent(notice: FamilyShoppingNotice) {
@@ -756,6 +1128,11 @@ function getFamilyShoppingNoticeContent(notice: FamilyShoppingNotice) {
       return {
         description: "Avkryssingen er oppdatert.",
         title: "Status oppdatert",
+      };
+    case "family-shopping-list-mode-updated":
+      return {
+        description: "Visningsmodus for handlelisten er lagret.",
+        title: "Visning oppdatert",
       };
   }
 }

--- a/app/routes/family-store-mode.test.ts
+++ b/app/routes/family-store-mode.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/family.server", () => ({
+  requireFamilyMembership: vi.fn(),
+}));
+
+vi.mock("../lib/meal-plan-for-date.server", () => ({
+  findMealPlanCoveringDate: vi.fn(),
+}));
+
+vi.mock("../lib/db.server", () => ({
+  db: {
+    mealPlan: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { requireUser } from "../lib/auth.server";
+import { db } from "../lib/db.server";
+import { requireFamilyMembership } from "../lib/family.server";
+import { findMealPlanCoveringDate } from "../lib/meal-plan-for-date.server";
+import { loader } from "./family-store-mode";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+describe("family-store-mode redirect route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects to store mode for today's meal plan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "ADMIN",
+    } as never);
+    vi.mocked(findMealPlanCoveringDate).mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      id: "meal-plan-today",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 20",
+    });
+
+    try {
+      await loader({
+        params: { familyId: "family-1" },
+        request: new Request("http://localhost/families/family-1/store-mode"),
+      } as never);
+      expect.fail("Expected redirect");
+    } catch (response) {
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(302);
+      expect((response as Response).headers.get("Location")).toBe(
+        "/families/family-1/meal-plans/meal-plan-today/store-mode",
+      );
+    }
+  });
+
+  it("falls back to the latest meal plan when none covers today", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "ADMIN",
+    } as never);
+    vi.mocked(findMealPlanCoveringDate).mockResolvedValue(null);
+    vi.mocked(db.mealPlan.findFirst).mockResolvedValue({
+      id: "meal-plan-latest",
+    } as never);
+
+    try {
+      await loader({
+        params: { familyId: "family-1" },
+        request: new Request("http://localhost/families/family-1/store-mode"),
+      } as never);
+    } catch (response) {
+      expect((response as Response).headers.get("Location")).toBe(
+        "/families/family-1/meal-plans/meal-plan-latest/store-mode",
+      );
+    }
+  });
+
+  it("redirects to meal plans when the family has none", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "ADMIN",
+    } as never);
+    vi.mocked(findMealPlanCoveringDate).mockResolvedValue(null);
+    vi.mocked(db.mealPlan.findFirst).mockResolvedValue(null);
+
+    try {
+      await loader({
+        params: { familyId: "family-1" },
+        request: new Request("http://localhost/families/family-1/store-mode"),
+      } as never);
+    } catch (response) {
+      expect((response as Response).headers.get("Location")).toBe(
+        "/families/family-1/meal-plans",
+      );
+    }
+  });
+});

--- a/app/routes/family-store-mode.ts
+++ b/app/routes/family-store-mode.ts
@@ -1,0 +1,43 @@
+import { redirect } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { db } from "../lib/db.server";
+import { requireFamilyMembership } from "../lib/family.server";
+import { findMealPlanCoveringDate } from "../lib/meal-plan-for-date.server";
+import type { Route } from "./+types/family-store-mode";
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const user = await requireUser(request);
+  const familyId = params.familyId;
+
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  await requireFamilyMembership({
+    familyId,
+    userId: user.id,
+  });
+
+  const todayMealPlan = await findMealPlanCoveringDate({
+    familyId,
+  });
+  const mealPlan =
+    todayMealPlan ??
+    (await db.mealPlan.findFirst({
+      orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
+      select: { id: true },
+      where: { familyId },
+    }));
+
+  if (mealPlan) {
+    throw redirect(
+      `/families/${familyId}/meal-plans/${mealPlan.id}/store-mode`,
+    );
+  }
+
+  throw redirect(`/families/${familyId}/meal-plans`);
+}

--- a/prisma/migrations/20260528140000_family_shopping_list_mode/migration.sql
+++ b/prisma/migrations/20260528140000_family_shopping_list_mode/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "FamilyShoppingListMode" AS ENUM ('GLOBAL', 'COMBINED');
+
+-- CreateTable
+CREATE TABLE "UserFamilyShoppingPreference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "listMode" "FamilyShoppingListMode" NOT NULL DEFAULT 'GLOBAL',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserFamilyShoppingPreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserFamilyShoppingPreference_userId_familyId_key" ON "UserFamilyShoppingPreference"("userId", "familyId");
+
+-- CreateIndex
+CREATE INDEX "UserFamilyShoppingPreference_userId_idx" ON "UserFamilyShoppingPreference"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserFamilyShoppingPreference_familyId_idx" ON "UserFamilyShoppingPreference"("familyId");
+
+-- AddForeignKey
+ALTER TABLE "UserFamilyShoppingPreference" ADD CONSTRAINT "UserFamilyShoppingPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserFamilyShoppingPreference" ADD CONSTRAINT "UserFamilyShoppingPreference_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,11 @@ enum MealPlanStatus {
   APPROVED
 }
 
+enum FamilyShoppingListMode {
+  GLOBAL
+  COMBINED
+}
+
 enum MealPlanShareStatus {
   OPEN
   CLOSED
@@ -70,6 +75,7 @@ model User {
   updatedFamilyShoppingItems   FamilyShoppingItem[]   @relation("FamilyShoppingItemUpdatedBy")
   updatedShoppingItemOverrides ShoppingItemOverride[] @relation("ShoppingItemOverrideUpdatedBy")
   storePreferences             UserStorePreference[]
+  familyShoppingPreferences    UserFamilyShoppingPreference[]
   sharedMealPlans              MealPlanShare[]        @relation("MealPlanShareSharedBy")
   mealPlanShareRecipients      MealPlanShareRecipient[]
   mealPlanReviewComments       MealPlanReviewComment[] @relation("MealPlanReviewCommentAuthor")
@@ -90,8 +96,9 @@ model Family {
   recipes         Recipe[]
   mealPlans       MealPlan[]
   stores              Store[]
-  storePreferences    UserStorePreference[]
-  stockIngredients    FamilyStockIngredient[]
+  storePreferences           UserStorePreference[]
+  familyShoppingPreferences  UserFamilyShoppingPreference[]
+  stockIngredients           FamilyStockIngredient[]
   shoppingItems       FamilyShoppingItem[]
 
   @@index([createdByUserId])
@@ -444,4 +451,19 @@ model UserStorePreference {
   @@index([userId])
   @@index([familyId])
   @@index([selectedStoreId])
+}
+
+model UserFamilyShoppingPreference {
+  id        String                 @id @default(cuid())
+  userId    String
+  familyId  String
+  listMode  FamilyShoppingListMode @default(GLOBAL)
+  createdAt DateTime               @default(now())
+  updatedAt DateTime               @updatedAt
+  user      User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  family    Family                 @relation(fields: [familyId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, familyId])
+  @@index([userId])
+  @@index([familyId])
 }


### PR DESCRIPTION
## Summary
- Adds a persistent mobile bottom tab bar (Familie, Ukeplaner, Handleliste) so shopping is one tap away on family routes.
- Handleliste opens butikkmodus via a family-level redirect that resolves today's meal plan (or the latest plan as fallback).
- Extends the family shopping page with server-persisted `GLOBAL` vs `COMBINED` list modes, including today's meal-plan items with source labels and cross-source dedup.

## Related issue
Closes #99

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: on mobile width, bottom nav shows on family routes and Handleliste lands in store mode
- [ ] Manual: family shopping page shows mode banner when a plan covers today; switching GLOBAL/COMBINED persists after reload
- [ ] Manual: run `npx prisma migrate deploy` in target environment before release

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (260 tests)
- npm run typecheck