### PR TITLE
Fix store mode info panel overflow on mobile

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,22 +2,19 @@
 
 ## Current Objective
 
-Issue #99 on branch `issue/99-mobile-shopping-access`: make shopping easy to reach on mobile via bottom nav (store mode), with optional combined global + meal-plan list on the family shopping page.
+Issue #101 on branch `issue/101-store-mode-info-overflow`: fix store mode shopping item info panel horizontal overflow on mobile (grid and list views).
 
 ## Completed
 
-- Added mobile bottom tab nav (Familie, Ukeplaner, Handleliste) in app layout.
-- Handleliste opens store mode via `/families/:familyId/store-mode` redirect to today's (or latest) meal plan store mode.
-- Added server-persisted `GLOBAL` / `COMBINED` shopping list mode per user+family (`UserFamilyShoppingPreference`).
-- Extended family shopping with today's meal-plan detection, combined projection, dedup, source badges, and mode toggle UI.
-- Fixed Prisma enum leaking to client by using string literal mode types instead of `@prisma/client` re-exports.
+- Constrained `<details>` info panel to card width (`w-full min-w-0`) in `store-mode-shopping-item-card.tsx`.
+- Replaced `w-max` content wrapper with `w-full min-w-0 max-w-full` and `break-words` on info paragraphs.
+- Added `min-w-0` to card shell and inner flex column for flex/grid shrink.
+- Added `[&>*]:min-w-0` on store mode item grid to prevent grid track expansion.
 
 ## Files To Read First
 
-- `app/components/app-mobile-bottom-nav.tsx` - mobile tab bar and store-mode active state
-- `app/routes/family-store-mode.ts` - redirect into meal-plan store mode
-- `app/routes/family-shopping.tsx` - combined/global mode UI and actions
-- `app/lib/shopping.server.ts` - combined list projection and dedup
+- `app/components/store-mode-shopping-item-card.tsx` - details panel width/wrap fix
+- `app/routes/family-meal-plan-store-mode.tsx` - `StoreModeItemGrid` grid child min-width
 
 ## Validation
 
@@ -28,10 +25,8 @@ Issue #99 on branch `issue/99-mobile-shopping-access`: make shopping easy to rea
 
 ## Open Items
 
-- Run migration before deploy: `npx prisma migrate deploy`
-- Manual mobile smoke-check: bottom nav → store mode, mode toggle on family shopping, quick-add dock vs bottom nav overlap
-- PR for issue #99 pending merge
+- Manual mobile smoke-check on PR review: grid + list view, tap info icon, auto-opened details (note/postponed/conflict), card toggle vs info icon
 
 ## Next Step
 
-Merge PR for issue #99 after review/CI and verify store-mode redirect when no meal plan exists (falls back to meal plans list).
+Merge PR for issue #101 after review/CI; verify info panel wrapping at ~375px viewport in store mode.

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -71,7 +71,7 @@ export function StoreModeShoppingItemCard({
     : "text-sm font-semibold leading-5 text-slate-950";
 
   return (
-    <div className={`block h-full ${cardShellClass}`}>
+    <div className={`block h-full min-w-0 ${cardShellClass}`}>
       <button
         aria-label={
           item.checked
@@ -84,7 +84,7 @@ export function StoreModeShoppingItemCard({
         type="button"
       />
 
-      <div className="relative z-10 flex h-full min-h-[32px] flex-col pointer-events-none">
+      <div className="relative z-10 flex h-full min-h-[32px] min-w-0 flex-col pointer-events-none">
         <div className="min-w-0 flex-1">
           <span className="flex flex-wrap items-center gap-1.5">
             <span className={nameClass}>{item.name}</span>
@@ -121,7 +121,7 @@ export function StoreModeShoppingItemCard({
         </div>
 
         <details
-          className="group mt-auto w-fit self-start flex flex-col-reverse items-start pointer-events-auto"
+          className="group mt-auto flex w-full min-w-0 flex-col-reverse items-start pointer-events-auto"
           open={shouldAutoOpenDetails}
         >
           <summary
@@ -132,20 +132,20 @@ export function StoreModeShoppingItemCard({
             <span className="sr-only">Vis informasjon</span>
           </summary>
           <div
-            className="mb-1 w-max max-w-full space-y-1 border-b border-slate-200 pb-1.5 pointer-events-auto"
+            className="mb-1 w-full min-w-0 max-w-full space-y-1 border-b border-slate-200 pb-1.5 pointer-events-auto"
             onClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => event.stopPropagation()}
           >
-            <p className="text-xs leading-4 text-slate-600">
+            <p className="break-words text-xs leading-4 text-slate-600">
               {formatStoreModeItemSourceLine(item)}
             </p>
             {item.note ? (
-              <p className="text-xs leading-4 text-slate-700">
+              <p className="break-words text-xs leading-4 text-slate-700">
                 Notat: {item.note}
               </p>
             ) : null}
             {item.sourceType === "GENERATED" && item.postponedUntilDate ? (
-              <p className="text-xs leading-4 text-amber-800">
+              <p className="break-words text-xs leading-4 text-amber-800">
                 Utsatt til {formatDateLabel(item.postponedUntilDate)}.
               </p>
             ) : null}

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -911,7 +911,7 @@ function StoreModeItemGrid<TItem extends ComponentProps<typeof StoreModeShopping
     <div
       className={
         layout === "grid"
-          ? "mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4"
+          ? "mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 [&>*]:min-w-0"
           : "mt-4 flex flex-col gap-2"
       }
     >


### PR DESCRIPTION
## Summary
- Constrain the store mode shopping item info `<details>` panel to the card width so expanded text wraps instead of overflowing horizontally on narrow viewports.
- Add `min-w-0` on the card shell, inner column, and grid children so flex/grid layouts can shrink below intrinsic content width.

## Related issue
Closes #101

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual: ~375px viewport in store mode — grid and list views, tap info icon on items with long source lines/notes
- [ ] Manual: auto-opened details (note, postponed, store conflict) do not overflow on load
- [ ] Manual: card toggle and info icon still work independently

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck