### PR TITLE
Fix store mode sync banner persisting after items are synced

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,31 +2,31 @@
 
 ## Current Objective
 
-Issue #101 on branch `issue/101-store-mode-info-overflow`: fix store mode shopping item info panel horizontal overflow on mobile (grid and list views).
+Issue #103 on branch `issue/103-store-mode-sync-banner`: fix store mode amber sync banner persisting after toggles are already synced on the server.
 
 ## Completed
 
-- Constrained `<details>` info panel to card width (`w-full min-w-0`) in `store-mode-shopping-item-card.tsx`.
-- Replaced `w-max` content wrapper with `w-full min-w-0 max-w-full` and `break-words` on info paragraphs.
-- Added `min-w-0` to card shell and inner flex column for flex/grid shrink.
-- Added `[&>*]:min-w-0` on store mode item grid to prevent grid track expansion.
+- Fetcher settlement now handles `submitting → idle` and `loading → idle`, guarded by `inFlightSourceKeyRef`.
+- `reconcileToggleQueue` drops check ops when the item is absent from the loader (family items after check).
+- Unit tests for reconcile edge cases and hook fetcher state transitions.
 
 ## Files To Read First
 
-- `app/components/store-mode-shopping-item-card.tsx` - details panel width/wrap fix
-- `app/routes/family-meal-plan-store-mode.tsx` - `StoreModeItemGrid` grid child min-width
+- `app/lib/use-store-mode-toggle-sync.ts` - fetcher queue drain on `loading → idle`
+- `app/lib/shopping-store-mode-client.ts` - reconcile when loader item missing
+- `app/lib/use-store-mode-toggle-sync.test.ts` - fetcher state machine tests
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (260 tests, 46 files)
+- `npm run test:run` — passed (265 tests, 47 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual mobile smoke-check on PR review: grid + list view, tap info icon, auto-opened details (note/postponed/conflict), card toggle vs info icon
+- Manual mobile smoke-check: throttle network in store mode, toggle meal-plan + family items, confirm amber banner clears after sync.
 
 ## Next Step
 
-Merge PR for issue #101 after review/CI; verify info panel wrapping at ~375px viewport in store mode.
+Merge PR for issue #103 after review/CI; optional manual verification on production mobile.

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -142,6 +142,40 @@ describe("shopping-store-mode-client", () => {
     ).toEqual(queue);
   });
 
+  it("drops check ops when the item is absent from the loader", () => {
+    expect(
+      reconcileToggleQueue({
+        loaderItems: [],
+        queue: [
+          {
+            checked: true,
+            expectedUpdatedAt: "family-v1",
+            sourceKey: "family-item-1",
+            sourceType: "FAMILY",
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps uncheck ops when the item is absent from the loader", () => {
+    const queue = [
+      {
+        checked: false,
+        expectedUpdatedAt: "family-v1",
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY" as const,
+      },
+    ];
+
+    expect(
+      reconcileToggleQueue({
+        loaderItems: [],
+        queue,
+      }),
+    ).toEqual(queue);
+  });
+
   it("accepts FAMILY toggle operations and uses collaboration version", () => {
     expect(
       getToggleExpectedVersion({

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -302,7 +302,9 @@ export function reconcileToggleQueue({
     const loaderItem = loaderBySourceKey.get(op.sourceKey);
 
     if (!loaderItem) {
-      return true;
+      // Family items leave the store-mode loader once checked (only unchecked
+      // items are loaded). Drop fulfilled check ops; keep uncheck ops pending.
+      return !op.checked;
     }
 
     return loaderItem.checked !== op.checked;

--- a/app/lib/use-store-mode-toggle-sync.test.ts
+++ b/app/lib/use-store-mode-toggle-sync.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { ShoppingItemSource } from "@prisma/client";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useMemo, useState } from "react";
+import type { FetcherWithComponents } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildStoreModeQueueStorageKey,
+  writeStoreModeToggleQueue,
+} from "./shopping-store-mode-client";
+import { useStoreModeToggleSync } from "./use-store-mode-toggle-sync";
+
+const syncContext = {
+  activeShoppingDate: "2026-05-16",
+  familyId: "family-1",
+  mealPlanId: "meal-plan-1",
+};
+
+const storageKey = buildStoreModeQueueStorageKey(syncContext);
+
+const loaderItem = {
+  checked: false,
+  collaborationVersion: "2026-05-01T12:00:00.000Z",
+  sourceKey: "entry-1:ingredient-1",
+  sourceType: ShoppingItemSource.GENERATED,
+} as const;
+
+const queueOp = {
+  checked: true,
+  expectedUpdatedAt: "2026-05-01T12:00:00.000Z",
+  sourceKey: loaderItem.sourceKey,
+  sourceType: loaderItem.sourceType,
+};
+
+type ToggleFetcherData = {
+  formError?: string;
+  ok?: boolean;
+};
+
+type ToggleFetcherState = "idle" | "submitting" | "loading";
+
+function useToggleSyncTestHarness({
+  initialFetcherState = "idle" as ToggleFetcherState,
+} = {}) {
+  const [fetcherState, setFetcherState] =
+    useState<ToggleFetcherState>(initialFetcherState);
+  const [fetcherData, setFetcherData] = useState<ToggleFetcherData | undefined>(
+    undefined,
+  );
+  const [submit] = useState(() =>
+    vi.fn(async () => {
+      setFetcherState("submitting");
+    }),
+  );
+
+  const toggleFetcher = useMemo(
+    () =>
+      ({
+        state: fetcherState,
+        data: fetcherData,
+        submit,
+        Form: () => null,
+        load: vi.fn(),
+      }) as unknown as FetcherWithComponents<ToggleFetcherData>,
+    [fetcherData, fetcherState, submit],
+  );
+
+  const revalidate = vi.fn();
+
+  const sync = useStoreModeToggleSync({
+    ...syncContext,
+    loaderItems: [loaderItem],
+    revalidate,
+    toggleFetcher,
+  });
+
+  return {
+    ...sync,
+    revalidate,
+    setFetcherData,
+    setFetcherState,
+    submit,
+  };
+}
+
+describe("useStoreModeToggleSync", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("drains the queue when the fetcher settles via loading to idle", async () => {
+    writeStoreModeToggleQueue(storageKey, [queueOp]);
+
+    const { result } = renderHook(() => useToggleSyncTestHarness());
+
+    await waitFor(() => {
+      expect(result.current.submit).toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.setFetcherState("loading");
+    });
+
+    act(() => {
+      result.current.setFetcherData({ ok: true });
+      result.current.setFetcherState("idle");
+    });
+
+    await waitFor(() => {
+      expect(result.current.queue).toEqual([]);
+      expect(result.current.isSyncing).toBe(false);
+    });
+  });
+
+  it("drains the queue when the fetcher settles directly from submitting to idle", async () => {
+    writeStoreModeToggleQueue(storageKey, [queueOp]);
+
+    const { result } = renderHook(() => useToggleSyncTestHarness());
+
+    await waitFor(() => {
+      expect(result.current.submit).toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.setFetcherData({ ok: true });
+      result.current.setFetcherState("idle");
+    });
+
+    await waitFor(() => {
+      expect(result.current.queue).toEqual([]);
+      expect(result.current.isSyncing).toBe(false);
+    });
+  });
+
+  it("ignores loading to idle when no toggle submission is in flight", async () => {
+    writeStoreModeToggleQueue(storageKey, [queueOp]);
+
+    const { result } = renderHook(() =>
+      useToggleSyncTestHarness({ initialFetcherState: "loading" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.queue).toEqual([queueOp]);
+      expect(result.current.submit).not.toHaveBeenCalled();
+    });
+
+    act(() => {
+      result.current.setFetcherState("loading");
+    });
+
+    act(() => {
+      result.current.setFetcherData({ ok: true });
+      result.current.setFetcherState("idle");
+    });
+
+    await waitFor(() => {
+      expect(result.current.queue).toEqual([queueOp]);
+      expect(result.current.isSyncing).toBe(true);
+    });
+  });
+});

--- a/app/lib/use-store-mode-toggle-sync.ts
+++ b/app/lib/use-store-mode-toggle-sync.ts
@@ -163,46 +163,55 @@ export function useStoreModeToggleSync<T extends StoreModeToggleItem>({
     const previousState = lastProcessedFetcherStateRef.current;
     lastProcessedFetcherStateRef.current = toggleFetcher.state;
 
-    if (previousState === "submitting" && toggleFetcher.state === "idle") {
-      const submittedSourceKeyValue = inFlightSourceKeyRef.current;
-      inFlightSourceKeyRef.current = null;
+    const settledFromSubmitOrLoad =
+      (previousState === "submitting" || previousState === "loading") &&
+      toggleFetcher.state === "idle";
 
-      if (toggleFetcher.data?.ok) {
-        const nextQueue = submittedSourceKeyValue
-          ? removeToggleOp(queueRef.current, submittedSourceKeyValue)
-          : queueRef.current.slice(1);
-        persistQueue(nextQueue);
-        setSyncError(null);
-
-        if (nextQueue.length === 0) {
-          revalidateRef.current();
-        } else {
-          submitNextOp();
-        }
-
-        return;
-      }
-
-      if (toggleFetcher.data?.formError) {
-        const nextQueue = submittedSourceKeyValue
-          ? removeToggleOp(queueRef.current, submittedSourceKeyValue)
-          : queueRef.current.slice(1);
-        persistQueue(nextQueue);
-        setSyncError(toggleFetcher.data.formError);
-        revalidateRef.current();
-        scheduleRetry();
-        return;
-      }
-
-      if (submittedSourceKeyValue) {
-        const nextQueue = removeToggleOp(queueRef.current, submittedSourceKeyValue);
-        persistQueue(nextQueue);
-        setSyncError(
-          "Kunne ikke synkronisere. Prøver igjen når nettet er tilbake.",
-        );
-        scheduleRetry();
-      }
+    if (!settledFromSubmitOrLoad) {
+      return;
     }
+
+    const submittedSourceKeyValue = inFlightSourceKeyRef.current;
+
+    if (!submittedSourceKeyValue) {
+      return;
+    }
+
+    inFlightSourceKeyRef.current = null;
+
+    if (toggleFetcher.data?.ok) {
+      const nextQueue = removeToggleOp(
+        queueRef.current,
+        submittedSourceKeyValue,
+      );
+      persistQueue(nextQueue);
+      setSyncError(null);
+
+      if (nextQueue.length === 0) {
+        revalidateRef.current();
+      } else {
+        submitNextOp();
+      }
+
+      return;
+    }
+
+    if (toggleFetcher.data?.formError) {
+      const nextQueue = removeToggleOp(
+        queueRef.current,
+        submittedSourceKeyValue,
+      );
+      persistQueue(nextQueue);
+      setSyncError(toggleFetcher.data.formError);
+      revalidateRef.current();
+      scheduleRetry();
+      return;
+    }
+
+    const nextQueue = removeToggleOp(queueRef.current, submittedSourceKeyValue);
+    persistQueue(nextQueue);
+    setSyncError("Kunne ikke synkronisere. Prøver igjen når nettet er tilbake.");
+    scheduleRetry();
   }, [
     persistQueue,
     scheduleRetry,


### PR DESCRIPTION
## Summary
- Drain the store-mode toggle queue when the fetcher settles via `loading → idle`, not only `submitting → idle`, so successful mobile syncs clear the outbox.
- Guard settlement with `inFlightSourceKeyRef` so unrelated loader revalidations do not drop queue ops.
- Reconcile away check ops when an item is absent from the loader (e.g. checked family items that leave the due list).

## Related issue
Closes #103

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: throttle network in store mode; toggle meal-plan and family items; confirm amber banner clears

## Validation
- `npm run prisma:generate`
- `npm run lint`
- `npm run test:run` (265 tests)
- `npm run typecheck`