### PR TITLE
Remove basisvarer banner from store mode

### DIFF
--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -785,11 +785,6 @@ export async function getMealPlanStoreModeData({
     mealPlan,
     stores,
   });
-  const stockIngredientsForPlan = getStockIngredientsForMealPlan({
-    includeDespiteStockKeys,
-    mealPlan,
-    stockMatchSet,
-  });
   const projectedItems = [...generatedItems, ...manualItems];
   const activeShoppingDate = mealPlan.activeShoppingDate ?? mealPlan.startDate;
   const selectedStore = resolveSelectedStoreSummary(
@@ -856,8 +851,6 @@ export async function getMealPlanStoreModeData({
     mealPlan,
     progress: buildStoreModeProgress(mergedDueItems),
     selectedStore,
-    stockIngredientCount: stockIngredientsForPlan.length,
-    stockIngredientsForPlan,
     stores: stores.map((store) => ({
       id: store.id,
       name: store.name,

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -161,8 +161,6 @@ describe("family meal plan store mode route", () => {
         id: "store-1",
         name: "Meny",
       },
-      stockIngredientCount: 0,
-      stockIngredientsForPlan: [],
       stores: [
         {
           id: "store-1",

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -140,7 +140,6 @@ export async function loader({
     progress: result.progress,
     recentManualItems,
     selectedStore: result.selectedStore,
-    stockIngredientCount: result.stockIngredientCount,
     stores: result.stores,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
@@ -533,24 +532,6 @@ export default function FamilyMealPlanStoreModeRoute({
               Kunne ikke oppdatere butikkmodus
             </h2>
             <p className="mt-2 text-sm leading-6">{generalFormError}</p>
-          </section>
-        ) : null}
-
-        {loaderData.stockIngredientCount > 0 ? (
-          <section className="rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm">
-            <p className="text-sm font-semibold">
-              {loaderData.stockIngredientCount} basisvarer brukt denne uken
-            </p>
-            <p className="mt-2 text-sm leading-6 text-amber-900">
-              Basisvarer ligger utenfor butikkmodus med mindre de er lagt til i
-              handlelisten.
-            </p>
-            <Link
-              className="mt-4 inline-flex rounded-2xl bg-amber-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-950"
-              to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
-            >
-              Åpne handlelisten
-            </Link>
           </section>
         ) : null}
 


### PR DESCRIPTION
## Summary
- Removes the amber «{n} basisvarer brukt denne uken» banner from store mode
- Drops unused `stockIngredientCount` / `stockIngredientsForPlan` from `getMealPlanStoreModeData`
- Keeps the full basisvarer section on the shopping list route unchanged

## Related issue
Closes #107

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: meal plan with basisvarer → store mode has no banner; shopping list still shows expandable basisvarer section

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck