### PR TITLE
Default «Flytt kjøpte varer til bunnen» to on in store mode

### DIFF
--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -305,16 +305,16 @@ describe("shopping-store-mode-client", () => {
     );
   });
 
-  it("defaults deprioritize-bought preference to false", () => {
+  it("defaults deprioritize-bought preference to true", () => {
     const storageKey = buildStoreModeDeprioritizeBoughtStorageKey({
       familyId: "family-1",
       mealPlanId: "meal-plan-1",
     });
 
-    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(false);
+    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(true);
   });
 
-  it("persists and reads deprioritize-bought preference", () => {
+  it("persists and reads deprioritize-bought preference when enabled", () => {
     const storageKey = buildStoreModeDeprioritizeBoughtStorageKey({
       familyId: "family-1",
       mealPlanId: "meal-plan-1",
@@ -325,7 +325,18 @@ describe("shopping-store-mode-client", () => {
     expect(readStoreModeDeprioritizeBought(storageKey)).toBe(true);
   });
 
-  it("falls back to false for invalid stored deprioritize-bought values", () => {
+  it("persists and reads deprioritize-bought preference when disabled", () => {
+    const storageKey = buildStoreModeDeprioritizeBoughtStorageKey({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+    });
+
+    writeStoreModeDeprioritizeBought(storageKey, false);
+
+    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(false);
+  });
+
+  it("falls back to true for invalid stored deprioritize-bought values", () => {
     const storageKey = buildStoreModeDeprioritizeBoughtStorageKey({
       familyId: "family-1",
       mealPlanId: "meal-plan-1",
@@ -333,7 +344,7 @@ describe("shopping-store-mode-client", () => {
 
     window.localStorage.setItem(storageKey, "yes");
 
-    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(false);
+    expect(readStoreModeDeprioritizeBought(storageKey)).toBe(true);
   });
 
   it("returns sections unchanged when deprioritize-bought is off", () => {

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -86,19 +86,23 @@ export function buildStoreModeDeprioritizeBoughtStorageKey({
 
 export function readStoreModeDeprioritizeBought(storageKey: string): boolean {
   if (typeof window === "undefined") {
-    return false;
+    return true;
   }
 
   try {
     const raw = window.localStorage.getItem(storageKey);
 
+    if (raw === "false") {
+      return false;
+    }
+
     if (raw === "true") {
       return true;
     }
 
-    return false;
+    return true;
   } catch {
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary
- Defaults the deprioritize-bought preference to on when no `localStorage` value exists
- Still honors explicit `"true"` and `"false"` per family/meal plan
- Invalid stored values fall back to default-on

## Related issue
Closes #106

## Test plan
- [x] `shopping-store-mode-client.test.ts` (23 tests)
- [ ] Manual: fresh profile → toggle on, bought items at bottom
- [ ] Manual: toggle off → reload → stays off

## Validation
- npm run test:run -- app/lib/shopping-store-mode-client.test.ts