### PR TITLE
Nordic Playful store mode redesign

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,31 +2,32 @@
 
 ## Current Objective
 
-Issue #103 on branch `issue/103-store-mode-sync-banner`: fix store mode amber sync banner persisting after toggles are already synced on the server.
+Issue #111 on branch `issue/111-nordic-playful-store-mode`: Nordic Playful store-mode visual refresh (warm brown accent) ready for PR merge.
 
 ## Completed
 
-- Fetcher settlement now handles `submitting → idle` and `loading → idle`, guarded by `inFlightSourceKeyRef`.
-- `reconcileToggleQueue` drops check ops when the item is absent from the loader (family items after check).
-- Unit tests for reconcile edge cases and hook fetcher state transitions.
+- Store-mode theme tokens in `app/app.css` and shared classes in `app/lib/store-mode-theme.ts`.
+- Restyled `family-meal-plan-store-mode` route, store-mode components, and `ManualShoppingQuickAdd` `appearance="store-mode"`.
+- Bought (`Kjøpt`) section wrapped in `<details>`, closed by default.
+- Design concept HTML mockups and comparison doc under `docs/design/` (from #112).
 
 ## Files To Read First
 
-- `app/lib/use-store-mode-toggle-sync.ts` - fetcher queue drain on `loading → idle`
-- `app/lib/shopping-store-mode-client.ts` - reconcile when loader item missing
-- `app/lib/use-store-mode-toggle-sync.test.ts` - fetcher state machine tests
+- `app/lib/store-mode-theme.ts` - semantic Tailwind class strings for store mode
+- `app/routes/family-meal-plan-store-mode.tsx` - route layout, collapsible bought section
+- `docs/design/store-mode-concepts/nordic-playful.html` - visual reference
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (265 tests, 47 files)
+- `npm run test:run` — passed (267 tests, 48 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual mobile smoke-check: throttle network in store mode, toggle meal-plan + family items, confirm amber banner clears after sync.
+- Manual mobile smoke-check: store mode in ~390px viewport; expand Kjøpt section; quick-add focus ring; toggle items (red checked state).
 
 ## Next Step
 
-Merge PR for issue #103 after review/CI; optional manual verification on production mobile.
+Merge PR (Closes #111) after review/CI.

--- a/app/app.css
+++ b/app/app.css
@@ -3,6 +3,13 @@
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+
+  /* Store mode — Nordic Playful warm accent */
+  --color-store-bg: #fafaf9;
+  --color-store-accent-light: #ebe4dc;
+  --color-store-accent: #c9bfb0;
+  --color-store-accent-deep: #a89988;
+  --color-store-accent-text: #57534e;
 }
 
 @layer base {

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -13,7 +13,10 @@ interface ManualShoppingQuickAddLoaderSlice {
   ingredientSearchResults: IngredientSearchResult[];
 }
 
+type ManualShoppingQuickAddAppearance = "default" | "store-mode";
+
 interface ManualShoppingQuickAddProps {
+  appearance?: ManualShoppingQuickAddAppearance;
   autoFocus?: boolean;
   ingredientSearchPath: string;
   quickAddIntent?: string;
@@ -33,7 +36,56 @@ const SEARCH_DEBOUNCE_MS = 250;
 const DEFAULT_QUICK_ADD_INTENT = "quick-add-manual-shopping-item";
 const DEFAULT_SEARCH_FETCHER_KEY = "manual-shopping-ingredient-search";
 
+const quickAddStyles = {
+  default: {
+    createOption:
+      "flex w-full px-4 py-3 text-left text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60",
+    description: "text-sm leading-6 text-slate-600",
+    dropdown:
+      "absolute z-10 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg",
+    dropdownUp:
+      "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg",
+    input:
+      "min-w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100",
+    label: "block text-sm font-medium text-slate-700",
+    option:
+      "flex w-full items-center justify-between px-4 py-3 text-left text-sm text-slate-900 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60",
+    optionMeta: "text-xs text-slate-500",
+    recentButton:
+      "rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-800 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60",
+    recentLabel: "text-sm font-medium text-slate-700",
+    searchPending: "px-4 py-2 text-sm text-slate-500",
+    submit:
+      "inline-flex h-full shrink-0 items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400",
+  },
+  "store-mode": {
+    createOption:
+      "flex w-full px-4 py-3 text-left text-sm font-medium text-store-accent-text transition hover:bg-store-accent-light disabled:cursor-not-allowed disabled:opacity-60",
+    description: "text-sm leading-6 text-stone-600",
+    dropdown:
+      "absolute z-10 max-h-64 w-full overflow-y-auto rounded-2xl border border-stone-200 bg-white py-2 shadow-lg",
+    dropdownUp:
+      "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-stone-200 bg-white py-2 shadow-lg",
+    input:
+      "min-w-0 flex-1 rounded-2xl border border-stone-300 bg-stone-50 px-4 py-3 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60",
+    label: "block text-sm font-medium text-stone-700",
+    option:
+      "flex w-full items-center justify-between px-4 py-3 text-left text-sm text-stone-900 transition hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-60",
+    optionMeta: "text-xs text-stone-500",
+    recentButton:
+      "rounded-full border border-stone-200 bg-stone-50 px-4 py-2 text-sm font-medium text-stone-800 transition hover:border-store-accent hover:bg-white disabled:cursor-not-allowed disabled:opacity-60",
+    recentLabel: "text-sm font-medium text-stone-700",
+    searchPending: "px-4 py-2 text-sm text-stone-500",
+    submit:
+      "inline-flex h-full shrink-0 items-center justify-center rounded-2xl bg-stone-900 px-5 py-3 text-sm font-medium text-white transition hover:bg-stone-800 disabled:cursor-not-allowed disabled:bg-stone-400",
+  },
+} as const satisfies Record<
+  ManualShoppingQuickAddAppearance,
+  Record<string, string>
+>;
+
 export function ManualShoppingQuickAdd({
+  appearance = "default",
   autoFocus = false,
   ingredientSearchPath,
   quickAddIntent = DEFAULT_QUICK_ADD_INTENT,
@@ -41,6 +93,7 @@ export function ManualShoppingQuickAdd({
   revealOnFocus = false,
   searchFetcherKey = DEFAULT_SEARCH_FETCHER_KEY,
 }: ManualShoppingQuickAddProps) {
+  const styles = quickAddStyles[appearance];
   const listboxId = useId();
   const navigation = useNavigation();
   const submit = useSubmit();
@@ -164,12 +217,12 @@ export function ManualShoppingQuickAdd({
   const recentsBlock =
     recentManualItems.length > 0 ? (
       <div className="space-y-2">
-        <p className="text-sm font-medium text-slate-700">Nylig brukt</p>
+        <p className={styles.recentLabel}>Nylig brukt</p>
         <div className="flex flex-wrap gap-2">
           {recentManualItems.map((item) => (
             <button
               key={item.nameNormalized}
-              className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-800 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+              className={styles.recentButton}
               disabled={isQuickAdding}
               onClick={() => {
                 submitQuickAdd({ recentNameNormalized: item.nameNormalized });
@@ -186,17 +239,13 @@ export function ManualShoppingQuickAdd({
   return (
     <div className="flex flex-col gap-3" ref={containerRef}>
       <label
-        className={
-          revealOnFocus
-            ? "sr-only"
-            : "block text-sm font-medium text-slate-700"
-        }
+        className={revealOnFocus ? "sr-only" : styles.label}
         htmlFor={`${listboxId}-input`}
       >
         Legg til vare
       </label>
       {!revealOnFocus ? (
-        <p className="text-sm leading-6 text-slate-600">
+        <p className={styles.description}>
           Søk i ingrediensregisteret, skriv et nytt navn, eller velg en nylig brukt vare.
         </p>
       ) : null}
@@ -221,7 +270,7 @@ export function ManualShoppingQuickAdd({
             aria-controls={showDropdown ? listboxId : undefined}
             aria-expanded={showDropdown}
             autoFocus={autoFocus}
-            className="min-w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            className={styles.input}
             id={`${listboxId}-input`}
             name="quickAddQuery"
             ref={inputRef}
@@ -249,7 +298,7 @@ export function ManualShoppingQuickAdd({
             value={query}
           />
           <button
-            className="inline-flex h-full shrink-0 items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+            className={styles.submit}
             disabled={!trimmedQuery || isQuickAdding}
             onClick={() => {
               submitQuickAdd({ name: trimmedQuery });
@@ -262,23 +311,19 @@ export function ManualShoppingQuickAdd({
 
         {showDropdown ? (
           <ul
-            className={
-              revealOnFocus
-                ? "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg"
-                : "absolute z-10 mt-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg"
-            }
+            className={revealOnFocus ? styles.dropdownUp : styles.dropdown}
             id={listboxId}
             role="listbox"
           >
             {isSearching ? (
-              <li className="px-4 py-2 text-sm text-slate-500" role="presentation">
+              <li className={styles.searchPending} role="presentation">
                 Søker...
               </li>
             ) : null}
             {displayedResults.map((ingredient) => (
               <li key={ingredient.id} role="option">
                 <button
-                  className="flex w-full items-center justify-between px-4 py-3 text-left text-sm text-slate-900 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  className={styles.option}
                   disabled={isQuickAdding}
                   onClick={() => {
                     submitQuickAdd({ ingredientId: ingredient.id });
@@ -286,14 +331,14 @@ export function ManualShoppingQuickAdd({
                   type="button"
                 >
                   <span className="font-medium">{ingredient.canonicalName}</span>
-                  <span className="text-xs text-slate-500">Fra register</span>
+                  <span className={styles.optionMeta}>Fra register</span>
                 </button>
               </li>
             ))}
             {showCreateOption ? (
               <li role="option">
                 <button
-                  className="flex w-full px-4 py-3 text-left text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  className={styles.createOption}
                   disabled={isQuickAdding}
                   onClick={() => {
                     submitQuickAdd({ name: trimmedQuery });

--- a/app/components/store-mode-deprioritize-bought-toggle.tsx
+++ b/app/components/store-mode-deprioritize-bought-toggle.tsx
@@ -12,8 +12,8 @@ export function StoreModeDeprioritizeBoughtToggle({
       aria-pressed={enabled}
       className={
         enabled
-          ? "rounded-2xl bg-white px-4 py-2 text-sm font-medium text-slate-950 shadow-sm ring-1 ring-slate-200"
-          : "rounded-2xl bg-slate-100 px-4 py-2 text-sm font-medium text-slate-600 ring-1 ring-slate-200 transition hover:text-slate-950"
+          ? "rounded-2xl bg-white px-4 py-2.5 text-sm font-medium text-stone-950 shadow-sm ring-1 ring-stone-200"
+          : "rounded-2xl bg-stone-100 px-4 py-2.5 text-sm font-medium text-stone-600 ring-1 ring-stone-200 transition hover:text-stone-950"
       }
       onClick={() => onChange(!enabled)}
       type="button"

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -59,16 +59,16 @@ export function StoreModeShoppingItemCard({
   const shouldAutoOpenDetails = shouldAutoOpenStoreModeDetails(item);
 
   const cardShellClass = item.checked
-    ? "relative flex h-full min-h-[36px] flex-col rounded-2xl border border-red-200 bg-red-50 p-2"
-    : "relative flex h-full min-h-[36px] flex-col rounded-2xl border border-slate-200 bg-slate-50 p-2";
+    ? "relative flex h-full min-h-[44px] flex-col rounded-2xl border border-red-200 bg-red-50 p-2.5 transition-colors duration-150"
+    : "relative flex h-full min-h-[44px] flex-col rounded-2xl border border-stone-200 bg-stone-50 p-2.5 transition-colors duration-150";
 
   const toggleOverlayClass = item.checked
     ? "absolute inset-0 z-0 cursor-pointer touch-manipulation rounded-[inherit] transition hover:bg-red-100 active:bg-red-200"
-    : "absolute inset-0 z-0 cursor-pointer touch-manipulation rounded-[inherit] transition hover:bg-slate-100 active:bg-slate-200";
+    : "absolute inset-0 z-0 cursor-pointer touch-manipulation rounded-[inherit] transition hover:bg-stone-100 active:bg-stone-200";
 
   const nameClass = item.checked
-    ? "text-sm font-semibold leading-5 text-slate-500 line-through decoration-slate-400"
-    : "text-sm font-semibold leading-5 text-slate-950";
+    ? "text-sm font-semibold leading-5 text-stone-500 line-through decoration-stone-400"
+    : "text-sm font-semibold leading-5 text-stone-950";
 
   return (
     <div className={`block h-full min-w-0 ${cardShellClass}`}>
@@ -84,7 +84,7 @@ export function StoreModeShoppingItemCard({
         type="button"
       />
 
-      <div className="relative z-10 flex h-full min-h-[32px] min-w-0 flex-col pointer-events-none">
+      <div className="relative z-10 flex h-full min-h-[36px] min-w-0 flex-col pointer-events-none">
         <div className="min-w-0 flex-1">
           <span className="flex flex-wrap items-center gap-1.5">
             <span className={nameClass}>{item.name}</span>
@@ -95,7 +95,7 @@ export function StoreModeShoppingItemCard({
                   !item.quantityLabel &&
                   item.occurrenceCount > 1
                     ? `${badgeClass} bg-amber-100 text-amber-800`
-                    : `${badgeClass} bg-white text-slate-700 ring-1 ring-slate-200`
+                    : `${badgeClass} bg-white text-stone-700 ring-1 ring-stone-200`
                 }
               >
                 {quantityBadge}
@@ -126,21 +126,21 @@ export function StoreModeShoppingItemCard({
         >
           <summary
             aria-label={`Vis informasjon om ${item.name}`}
-            className="mt-1 flex h-6 w-6 cursor-pointer list-none items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-100 hover:text-slate-950 group-open:border-emerald-200 group-open:bg-emerald-50 group-open:text-emerald-700 marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-emerald-500 [&::-webkit-details-marker]:hidden"
+            className="mt-1 flex h-7 w-7 cursor-pointer list-none items-center justify-center rounded-full border border-stone-200 bg-white text-stone-600 transition hover:bg-stone-100 hover:text-stone-950 group-open:border-store-accent group-open:bg-store-accent-light group-open:text-store-accent-text marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-store-accent [&::-webkit-details-marker]:hidden"
           >
             <StoreModeInfoIcon className="h-3.5 w-3.5" />
             <span className="sr-only">Vis informasjon</span>
           </summary>
           <div
-            className="mb-1 w-full min-w-0 max-w-full space-y-1 border-b border-slate-200 pb-1.5 pointer-events-auto"
+            className="mb-1 w-full min-w-0 max-w-full space-y-1 border-b border-stone-200 pb-1.5 pointer-events-auto"
             onClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => event.stopPropagation()}
           >
-            <p className="break-words text-xs leading-4 text-slate-600">
+            <p className="break-words text-xs leading-4 text-stone-600">
               {formatStoreModeItemSourceLine(item)}
             </p>
             {item.note ? (
-              <p className="break-words text-xs leading-4 text-slate-700">
+              <p className="break-words text-xs leading-4 text-stone-700">
                 Notat: {item.note}
               </p>
             ) : null}

--- a/app/components/store-mode-shopping-view-toggle.tsx
+++ b/app/components/store-mode-shopping-view-toggle.tsx
@@ -12,15 +12,15 @@ export function StoreModeShoppingViewToggle({
   return (
     <div
       aria-label="Visning av handleliste"
-      className="inline-flex rounded-2xl bg-slate-100 p-1 ring-1 ring-slate-200"
+      className="inline-flex rounded-2xl bg-stone-100 p-1 ring-1 ring-stone-200"
       role="radiogroup"
     >
       <button
         aria-checked={view === "list"}
         className={
           view === "list"
-            ? "rounded-xl bg-white px-4 py-2 text-sm font-medium text-slate-950 shadow-sm ring-1 ring-slate-200"
-            : "rounded-xl px-4 py-2 text-sm font-medium text-slate-600 transition hover:text-slate-950"
+            ? "rounded-xl bg-white px-4 py-2.5 text-sm font-medium text-stone-950 shadow-sm ring-1 ring-stone-200"
+            : "rounded-xl px-4 py-2.5 text-sm font-medium text-stone-600 transition hover:text-stone-950"
         }
         onClick={() => onChange("list")}
         role="radio"
@@ -32,8 +32,8 @@ export function StoreModeShoppingViewToggle({
         aria-checked={view === "grid"}
         className={
           view === "grid"
-            ? "rounded-xl bg-white px-4 py-2 text-sm font-medium text-slate-950 shadow-sm ring-1 ring-slate-200"
-            : "rounded-xl px-4 py-2 text-sm font-medium text-slate-600 transition hover:text-slate-950"
+            ? "rounded-xl bg-white px-4 py-2.5 text-sm font-medium text-stone-950 shadow-sm ring-1 ring-stone-200"
+            : "rounded-xl px-4 py-2.5 text-sm font-medium text-stone-600 transition hover:text-stone-950"
         }
         onClick={() => onChange("grid")}
         role="radio"

--- a/app/lib/store-mode-theme.test.ts
+++ b/app/lib/store-mode-theme.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { getStoreModeBannerClass } from "./store-mode-theme";
+
+describe("store-mode-theme", () => {
+  it("returns distinct banner classes per tone", () => {
+    const success = getStoreModeBannerClass("success");
+    const sync = getStoreModeBannerClass("sync");
+    const error = getStoreModeBannerClass("error");
+
+    expect(success).toContain("emerald");
+    expect(sync).toContain("amber");
+    expect(error).toContain("rose");
+    expect(success).not.toBe(sync);
+  });
+});

--- a/app/lib/store-mode-theme.ts
+++ b/app/lib/store-mode-theme.ts
@@ -1,0 +1,47 @@
+/** Nordic Playful palette for store mode — see docs/design/store-mode-concepts/nordic-playful.html */
+
+export const storeModePageClass = "min-h-screen bg-stone-50 px-4 pb-36 pt-8 text-stone-900";
+
+export const storeModeMetaStripClass =
+  "flex flex-wrap items-center gap-x-3 gap-y-2 rounded-2xl bg-white px-4 py-3 text-sm shadow-sm ring-1 ring-stone-200";
+
+export const storeModeProgressPillClass =
+  "inline-flex shrink-0 items-center gap-1.5 rounded-full bg-store-accent-light px-2 py-0.5 text-sm font-semibold text-store-accent-text";
+
+export const storeModeProgressDotClass =
+  "size-1.5 shrink-0 rounded-full bg-store-accent-deep";
+
+export const storeModeSurfaceCardClass =
+  "rounded-[28px] bg-white shadow-sm ring-1 ring-stone-200";
+
+export const storeModeSectionCardClass = `${storeModeSurfaceCardClass} p-5`;
+
+export const storeModeMutedPanelClass = `${storeModeSurfaceCardClass} bg-stone-50/80 p-5`;
+
+export const storeModeAccentBarClass =
+  "mb-3 h-0.5 w-10 rounded-full bg-gradient-to-r from-store-accent-light to-store-accent";
+
+export const storeModeSelectClass =
+  "w-full rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60 disabled:cursor-wait disabled:bg-stone-50";
+
+export const storeModeCountChipClass =
+  "rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600";
+
+export const storeModeLaterChipClass =
+  "rounded-full bg-stone-100 px-3 py-1.5 text-xs font-medium text-stone-700";
+
+export const storeModeQuickAddDockClass =
+  "rounded-[28px] bg-white p-4 shadow-2xl ring-2 ring-store-accent";
+
+export type StoreModeBannerTone = "success" | "sync" | "error";
+
+export function getStoreModeBannerClass(tone: StoreModeBannerTone) {
+  switch (tone) {
+    case "success":
+      return "rounded-[28px] border border-emerald-200/80 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm";
+    case "sync":
+      return "rounded-[28px] border border-amber-200/80 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm";
+    case "error":
+      return "rounded-[28px] border border-rose-200/80 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm";
+  }
+}

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -43,6 +43,21 @@ import {
 } from "../lib/shopping-write.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
 import {
+  getStoreModeBannerClass,
+  storeModeAccentBarClass,
+  storeModeCountChipClass,
+  storeModeLaterChipClass,
+  storeModeMetaStripClass,
+  storeModeMutedPanelClass,
+  storeModePageClass,
+  storeModeProgressDotClass,
+  storeModeProgressPillClass,
+  storeModeQuickAddDockClass,
+  storeModeSectionCardClass,
+  storeModeSelectClass,
+  storeModeSurfaceCardClass,
+} from "../lib/store-mode-theme";
+import {
   STORE_MODE_SYNC_PROGRESS_MESSAGE,
   useStoreModeToggleSync,
 } from "../lib/use-store-mode-toggle-sync";
@@ -460,39 +475,40 @@ export default function FamilyMealPlanStoreModeRoute({
       : undefined;
 
   return (
-    <main className="min-h-screen bg-slate-100 px-4 pb-36 pt-8 text-slate-900">
+    <main className={storeModePageClass}>
       <div className="mx-auto flex max-w-4xl flex-col gap-5">
-        <section className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-2xl bg-white px-4 py-3 text-sm shadow-sm ring-1 ring-slate-200">
-          <h1 className="min-w-0 truncate font-semibold text-slate-950">
+        <section className={storeModeMetaStripClass}>
+          <h1 className="min-w-0 truncate font-semibold text-stone-950">
             {loaderData.mealPlan.title}
           </h1>
-          <span className="hidden text-slate-300 sm:inline" aria-hidden="true">
+          <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
             ·
           </span>
-          <span className="truncate text-slate-600">
+          <span className="truncate text-stone-600">
             {loaderData.selectedStore?.name ?? "Ingen butikk"}
           </span>
-          <span className="hidden text-slate-300 sm:inline" aria-hidden="true">
+          <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
             ·
           </span>
-          <span className="truncate text-slate-600">
+          <span className="truncate text-stone-600">
             {formatDateLabel(loaderData.activeShoppingDate)}
           </span>
-          <span className="hidden text-slate-300 sm:inline" aria-hidden="true">
+          <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
             ·
           </span>
-          <span className="shrink-0 font-medium text-emerald-700">
+          <span className={storeModeProgressPillClass}>
+            <span aria-hidden="true" className={storeModeProgressDotClass} />
             {displayProgress.checkedCount}/{displayProgress.totalCount}
           </span>
           <div className="ml-auto flex shrink-0 items-center gap-3">
             <Link
-              className="text-slate-600 underline-offset-2 hover:text-slate-950 hover:underline"
+              className="text-stone-600 underline-offset-2 hover:text-stone-950 hover:underline"
               to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping`}
             >
               Handleliste
             </Link>
             <Link
-              className="text-slate-600 underline-offset-2 hover:text-slate-950 hover:underline"
+              className="text-stone-600 underline-offset-2 hover:text-stone-950 hover:underline"
               to={`/families/${loaderData.family.id}/stores`}
             >
               Butikker
@@ -501,7 +517,7 @@ export default function FamilyMealPlanStoreModeRoute({
         </section>
 
         {noticeContent ? (
-          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+          <section className={getStoreModeBannerClass("success")}>
             <h2 className="text-base font-semibold">{noticeContent.title}</h2>
             <p className="mt-2 text-sm leading-6 text-emerald-900">
               {noticeContent.description}
@@ -511,11 +527,11 @@ export default function FamilyMealPlanStoreModeRoute({
 
         {syncBannerMessage ? (
           <section
-            className={
+            className={getStoreModeBannerClass(
               syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
-                ? "rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm"
-                : "rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm"
-            }
+                ? "sync"
+                : "error",
+            )}
           >
             <h2 className="text-base font-semibold">
               {syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
@@ -527,7 +543,7 @@ export default function FamilyMealPlanStoreModeRoute({
         ) : null}
 
         {generalFormError ? (
-          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+          <section className={getStoreModeBannerClass("error")}>
             <h2 className="text-base font-semibold">
               Kunne ikke oppdatere butikkmodus
             </h2>
@@ -535,17 +551,17 @@ export default function FamilyMealPlanStoreModeRoute({
           </section>
         ) : null}
 
-        <details className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
-          <summary className="cursor-pointer text-sm font-medium text-slate-800">
+        <details className={storeModeSectionCardClass}>
+          <summary className="cursor-pointer text-sm font-medium text-stone-800">
             Butikk og handledato
-            <span className="ml-2 font-normal text-slate-500">
+            <span className="ml-2 font-normal text-stone-500">
               {loaderData.selectedStore?.name ?? "Ingen butikk"} ·{" "}
               {formatDateLabel(loaderData.activeShoppingDate)}
             </span>
           </summary>
           <div className="mt-4 grid gap-4 sm:grid-cols-2">
             <article>
-              <h2 className="text-base font-semibold text-slate-950">
+              <h2 className="text-base font-semibold text-stone-950">
                 Velg butikk
               </h2>
               <Form className="mt-4 space-y-3" method="post">
@@ -556,7 +572,7 @@ export default function FamilyMealPlanStoreModeRoute({
                 />
                 <select
                   aria-busy={isSavingStore}
-                  className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
+                  className={storeModeSelectClass}
                   defaultValue={selectedStoreValue}
                   disabled={isSavingStore}
                   name="selectedStoreId"
@@ -580,7 +596,7 @@ export default function FamilyMealPlanStoreModeRoute({
             </article>
 
             <article>
-              <h2 className="text-base font-semibold text-slate-950">
+              <h2 className="text-base font-semibold text-stone-950">
                 Velg handledato
               </h2>
               <Form className="mt-4 space-y-3" method="post">
@@ -596,7 +612,7 @@ export default function FamilyMealPlanStoreModeRoute({
                 />
                 <select
                   aria-busy={isSavingShoppingDate}
-                  className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 disabled:cursor-wait disabled:bg-slate-50"
+                  className={storeModeSelectClass}
                   defaultValue={activeShoppingDateValue}
                   disabled={isSavingShoppingDate}
                   name="activeShoppingDate"
@@ -627,7 +643,7 @@ export default function FamilyMealPlanStoreModeRoute({
         {displaySectionGroups.length > 0 ? (
           <section className="grid gap-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <h2 className="text-lg font-semibold text-slate-950">
+              <h2 className="text-lg font-semibold tracking-tight text-stone-950">
                 Varer å handle
               </h2>
               <div className="flex flex-wrap items-center gap-2">
@@ -645,13 +661,14 @@ export default function FamilyMealPlanStoreModeRoute({
               activeSections.map((section) => (
                 <article
                   key={`${loaderData.selectedStore?.id ?? "no-store"}:${section.category.id}`}
-                  className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200"
+                  className={storeModeSectionCardClass}
                 >
+                  <div aria-hidden="true" className={storeModeAccentBarClass} />
                   <div className="flex items-center justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-slate-950">
+                    <h2 className="text-lg font-semibold tracking-tight text-stone-950">
                       {section.displayName}
                     </h2>
-                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                    <span className={storeModeCountChipClass}>
                       {section.items.length} varer
                     </span>
                   </div>
@@ -665,24 +682,26 @@ export default function FamilyMealPlanStoreModeRoute({
                 </article>
               ))
             ) : deprioritizeBought ? (
-              <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-                <h3 className="text-base font-semibold text-slate-950">
+              <article className={`${storeModeSurfaceCardClass} p-6`}>
+                <h3 className="text-base font-semibold text-stone-950">
                   Alt er krysset av
                 </h3>
-                <p className="mt-3 text-sm leading-6 text-slate-600">
+                <p className="mt-3 text-sm leading-6 text-stone-600">
                   Du har handlet alle varene for denne turen. Kjøpte varer ligger
                   nedenfor hvis du vil se eller endre dem.
                 </p>
               </article>
             ) : null}
             {deprioritizeBought && boughtItems.length > 0 ? (
-              <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
-                <div className="flex items-center justify-between gap-3">
-                  <h2 className="text-lg font-semibold text-slate-950">Kjøpt</h2>
-                  <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+              <details className={storeModeMutedPanelClass}>
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 marker:content-none [&::-webkit-details-marker]:hidden">
+                  <span className="text-lg font-semibold tracking-tight text-stone-950">
+                    Kjøpt
+                  </span>
+                  <span className={storeModeCountChipClass}>
                     {boughtItems.length} varer
                   </span>
-                </div>
+                </summary>
 
                 <StoreModeItemGrid
                   items={boughtItems}
@@ -690,23 +709,23 @@ export default function FamilyMealPlanStoreModeRoute({
                   onToggleItem={handleToggle}
                   selectedStoreId={loaderData.selectedStore?.id}
                 />
-              </article>
+              </details>
             ) : null}
           </section>
         ) : (
-          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">
+          <section className={`${storeModeSurfaceCardClass} p-6`}>
+            <h2 className="text-lg font-semibold tracking-tight text-stone-950">
               Ingen varer må handles nå
             </h2>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
+            <p className="mt-3 text-sm leading-6 text-stone-600">
               Alt er enten ferdig handlet, utenfor denne handleturen, eller
               allerede passert.
             </p>
           </section>
         )}
 
-        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-          <h2 className="text-lg font-semibold text-slate-950">
+        <section className={`${storeModeSurfaceCardClass} p-6`}>
+          <h2 className="text-lg font-semibold tracking-tight text-stone-950">
             Før handledato
           </h2>
           <div className="mt-4 flex flex-wrap gap-2">
@@ -714,7 +733,7 @@ export default function FamilyMealPlanStoreModeRoute({
               loaderData.laterItems.map((item) => (
                 <span
                   key={`later:${item.sourceKey}`}
-                  className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-700"
+                  className={storeModeLaterChipClass}
                 >
                   {item.name}
                   {" · "}
@@ -728,7 +747,7 @@ export default function FamilyMealPlanStoreModeRoute({
                 </span>
               ))
             ) : (
-              <p className="text-sm leading-6 text-slate-600">
+              <p className="text-sm leading-6 text-stone-600">
                 Ingen varer ligger før handledato akkurat nå.
               </p>
             )}
@@ -738,11 +757,12 @@ export default function FamilyMealPlanStoreModeRoute({
 
       <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3">
         <div className="pointer-events-auto mx-auto max-w-4xl">
-          <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200">
+          <div className={storeModeQuickAddDockClass}>
             {quickAddFormError ? (
               <p className="mb-3 text-sm text-rose-600">{quickAddFormError}</p>
             ) : null}
             <ManualShoppingQuickAdd
+              appearance="store-mode"
               ingredientSearchPath={ingredientSearchPath}
               quickAddIntent="quick-add-family-shopping-item"
               recentManualItems={loaderData.recentManualItems}
@@ -770,12 +790,12 @@ export function ErrorBoundary({ error }: { error: unknown }) {
   }
 
   return (
-    <main className="min-h-screen bg-slate-100 px-4 py-16 text-slate-900">
-      <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
-        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
-        <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
+    <main className={`${storeModePageClass} py-16`}>
+      <div className={`mx-auto max-w-2xl ${storeModeSurfaceCardClass} p-8`}>
+        <h1 className="text-2xl font-semibold text-stone-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-stone-600">{message}</p>
         <Link
-          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+          className="mt-6 inline-flex rounded-2xl bg-stone-900 px-5 py-3 text-sm font-medium text-white"
           to="/app"
         >
           Til appen

--- a/docs/design/store-mode-concepts/color-sectioned-sprint.html
+++ b/docs/design/store-mode-concepts/color-sectioned-sprint.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>C — Color-Sectioned Sprint · Butikkmodus</title>
+    <link rel="stylesheet" href="shared.css" />
+    <style>
+      body {
+        background: #f1f5f9;
+        color: #0f172a;
+      }
+
+      .concept-label {
+        background: #ffedd5;
+        color: #c2410c;
+      }
+
+      .meta-strip {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+      }
+
+      .progress-pill {
+        background: #0f172a;
+        color: #fff;
+      }
+
+      .progress-pill .dot {
+        background: #4ade80;
+      }
+
+      .banner.sync {
+        background: #fef9c3;
+        border: 1px solid #fde047;
+        color: #713f12;
+      }
+
+      .toolbar button.on {
+        background: #fff;
+        color: #0f172a;
+        outline: 1px solid #cbd5e1;
+      }
+
+      .toolbar button.off {
+        background: #e2e8f0;
+        color: #64748b;
+      }
+
+      /* Category tints — maps to IngredientCategoryKey in seed data */
+      .section-card.cat-produce {
+        background: #d1fae5;
+        border: 1px solid #6ee7b7;
+      }
+
+      .section-card.cat-produce .count-chip {
+        background: #059669;
+        color: #fff;
+      }
+
+      .section-card.cat-produce .item-card {
+        background: #ecfdf5;
+        border: 1px solid #a7f3d0;
+      }
+
+      .section-card.cat-dairy {
+        background: #ede9fe;
+        border: 1px solid #c4b5fd;
+      }
+
+      .section-card.cat-dairy .count-chip {
+        background: #7c3aed;
+        color: #fff;
+      }
+
+      .section-card.cat-dairy .item-card {
+        background: #f5f3ff;
+        border: 1px solid #ddd6fe;
+      }
+
+      .section-card.cat-pantry {
+        background: #ffedd5;
+        border: 1px solid #fdba74;
+      }
+
+      .section-card.cat-pantry .count-chip {
+        background: #ea580c;
+        color: #fff;
+      }
+
+      .section-card.cat-pantry .item-card {
+        background: #fff7ed;
+        border: 1px solid #fed7aa;
+      }
+
+      .item-card .badge {
+        background: #fff;
+        color: #475569;
+        outline: 1px solid rgba(0, 0, 0, 0.06);
+      }
+
+      .item-card.checked {
+        background: #fef2f2 !important;
+        border-color: #fca5a5 !important;
+      }
+
+      .item-card.checked .name {
+        color: #64748b;
+      }
+
+      .legend {
+        margin-top: 1rem;
+        padding: 0.75rem;
+        background: #fff;
+        border-radius: 0.75rem;
+        font-size: 0.6875rem;
+        color: #64748b;
+        line-height: 1.6;
+      }
+
+      .legend strong {
+        color: #0f172a;
+      }
+
+      .swatches {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        margin-top: 0.35rem;
+      }
+
+      .swatches span {
+        padding: 0.15rem 0.4rem;
+        border-radius: 0.35rem;
+        font-weight: 600;
+        font-size: 0.625rem;
+      }
+
+      .quick-add-dock .inner {
+        background: #fff;
+        border: 2px solid #0f172a;
+        box-shadow: 0 -6px 20px rgba(15, 23, 42, 0.12);
+      }
+
+      .quick-add-dock label {
+        color: #0f172a;
+        font-weight: 600;
+      }
+
+      .quick-add-dock input {
+        background: #f8fafc;
+        border: 1px solid #cbd5e1;
+      }
+
+      .quick-add-dock input:focus {
+        border-color: #0f172a;
+        box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.12);
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="concept-nav" aria-label="Konsepter">
+      <a href="index.html">Oversikt</a>
+      <a href="soft-pastel-calm.html">A — Calm</a>
+      <a href="nordic-playful.html">B — Nordic</a>
+      <a href="color-sectioned-sprint.html" aria-current="page">C — Sprint</a>
+    </nav>
+
+    <div class="phone-frame">
+      <span class="concept-label">C · Color-Sectioned Sprint</span>
+
+      <header class="meta-strip">
+        <h1>Uke 22 · Middager</h1>
+        <span class="sep">·</span>
+        <span class="muted">Rema 1000</span>
+        <span class="sep">·</span>
+        <span class="muted">fredag 30. mai</span>
+        <span class="progress-pill">
+          <span class="dot" aria-hidden="true"></span>
+          12/18
+        </span>
+        <div class="links">
+          <a href="#">Handleliste</a>
+          <a href="#">Butikker</a>
+        </div>
+      </header>
+
+      <section class="banner sync" aria-label="Synkroniserer">
+        <h2>Synkroniserer</h2>
+        <p>Lagrer avkryssing …</p>
+      </section>
+
+      <div class="toolbar">
+        <button type="button" class="on">Flytt kjøpte til bunnen</button>
+        <button type="button" class="on">Liste</button>
+        <button type="button" class="off">Rutenett</button>
+      </div>
+
+      <section
+        class="section-card cat-produce"
+        aria-labelledby="sec-produce"
+      >
+        <div class="section-head">
+          <h2 id="sec-produce">Frukt og grønt</h2>
+          <span class="count-chip">4 varer</span>
+        </div>
+        <div class="item-grid">
+          <article class="item-card">
+            <span class="name">Cherrytomater</span>
+            <span class="badge">400 g</span>
+          </article>
+          <article class="item-card checked">
+            <span class="name">Spinat</span>
+          </article>
+          <article class="item-card">
+            <span class="name">Avokado</span>
+            <span class="badge">2 stk</span>
+          </article>
+          <article class="item-card">
+            <span class="name">Sitron</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="section-card cat-dairy" aria-labelledby="sec-dairy">
+        <div class="section-head">
+          <h2 id="sec-dairy">Meieri</h2>
+          <span class="count-chip">2 varer</span>
+        </div>
+        <div class="item-grid">
+          <article class="item-card">
+            <span class="name">Melk</span>
+            <span class="badge">1 L</span>
+          </article>
+          <article class="item-card checked">
+            <span class="name">Revet ost</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="section-card cat-pantry" aria-labelledby="sec-pantry">
+        <div class="section-head">
+          <h2 id="sec-pantry">Tørrvarer</h2>
+          <span class="count-chip">1 vare</span>
+        </div>
+        <div class="item-grid">
+          <article class="item-card">
+            <span class="name">Pasta</span>
+            <span class="badge">500 g</span>
+          </article>
+        </div>
+      </section>
+
+      <aside class="legend">
+        <strong>Kategorifarger</strong> (9 nøkler i appen): produce, meat-fish,
+        dairy, pantry, frozen, bakery-bread, drinks, household, other.
+        <div class="swatches">
+          <span style="background: #d1fae5">produce</span>
+          <span style="background: #fecdd3">meat-fish</span>
+          <span style="background: #ede9fe">dairy</span>
+          <span style="background: #ffedd5">pantry</span>
+          <span style="background: #e0f2fe">frozen</span>
+          <span style="background: #fef3c7">bakery</span>
+          <span style="background: #dbeafe">drinks</span>
+          <span style="background: #e2e8f0">household</span>
+          <span style="background: #f1f5f9">other</span>
+        </div>
+      </aside>
+    </div>
+
+    <div class="quick-add-dock">
+      <div class="inner">
+        <label for="quick-add">Legg til vare</label>
+        <input
+          id="quick-add"
+          type="search"
+          placeholder="Søk eller skriv varenavn …"
+          autocomplete="off"
+        />
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/store-mode-concepts/index.html
+++ b/docs/design/store-mode-concepts/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Store mode — velg konsept</title>
+    <link rel="stylesheet" href="shared.css" />
+    <style>
+      body {
+        background: #f8fafc;
+        color: #0f172a;
+        padding: 2rem 1.25rem 3rem;
+      }
+
+      main {
+        max-width: 32rem;
+        margin: 0 auto;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin: 0 0 0.5rem;
+      }
+
+      .lead {
+        color: #475569;
+        font-size: 0.9375rem;
+        margin: 0 0 1.5rem;
+        line-height: 1.6;
+      }
+
+      .cards {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .card {
+        display: block;
+        padding: 1.1rem 1.25rem;
+        border-radius: 1rem;
+        text-decoration: none;
+        color: inherit;
+        border: 1px solid #e2e8f0;
+        background: #fff;
+        transition: box-shadow 0.15s ease, transform 0.15s ease;
+      }
+
+      .card:hover {
+        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+        transform: translateY(-1px);
+      }
+
+      .card h2 {
+        margin: 0 0 0.35rem;
+        font-size: 1.0625rem;
+      }
+
+      .card p {
+        margin: 0;
+        font-size: 0.875rem;
+        color: #64748b;
+        line-height: 1.5;
+      }
+
+      .tag {
+        display: inline-block;
+        margin-top: 0.65rem;
+        font-size: 0.6875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 0.2rem 0.5rem;
+        border-radius: 999px;
+      }
+
+      .tag.a {
+        background: #ede9fe;
+        color: #5b21b6;
+      }
+
+      .tag.b {
+        background: #f1f5f9;
+        color: #334155;
+      }
+
+      .tag.c {
+        background: #ffedd5;
+        color: #c2410c;
+      }
+
+      .doc-link {
+        margin-top: 2rem;
+        font-size: 0.875rem;
+      }
+
+      .doc-link a {
+        color: #6366f1;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Butikkmodus — visuelle konsepter</h1>
+      <p class="lead">
+        Tre isolerte mobilmockups for issue #112. Åpne hver side på telefon eller
+        smal nettleservindu (~390px). Krysset av-varer bruker rød «ferdig»-stil som i
+        appen i dag.
+      </p>
+
+      <div class="cards">
+        <a class="card" href="soft-pastel-calm.html">
+          <h2>A — Soft Pastel Calm</h2>
+          <p>Lavendel, fersken og mint. Rolig gradient og myke flater — mindre stress, fortsatt oversiktlig.</p>
+          <span class="tag a">Mest avslappende</span>
+        </a>
+        <a class="card" href="nordic-playful.html">
+          <h2>B — Nordic Playful</h2>
+          <p>Lys base, mye luft, pastell kun på det som teller (fremdrift, fokus). Lesbarhet først.</p>
+          <span class="tag b">Anbefalt default</span>
+        </a>
+        <a class="card" href="color-sectioned-sprint.html">
+          <h2>C — Color-Sectioned Sprint</h2>
+          <p>Hver varegruppe har egen pastellfarge — rask gjenkjenning i butikken.</p>
+          <span class="tag c">Raskest skanning</span>
+        </a>
+      </div>
+
+      <p class="doc-link">
+        Sammenligning og anbefaling:
+        <a href="../store-mode-visual-concepts.md">store-mode-visual-concepts.md</a>
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/design/store-mode-concepts/nordic-playful.html
+++ b/docs/design/store-mode-concepts/nordic-playful.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>B — Nordic Playful · Butikkmodus</title>
+    <link rel="stylesheet" href="shared.css" />
+    <style>
+      :root {
+        --accent-warm: #c9bfb0;
+        --accent-warm-light: #ebe4dc;
+        --accent-warm-deep: #a89988;
+        --accent-warm-text: #57534e;
+      }
+
+      body {
+        background: #fafaf9;
+        color: #1c1917;
+      }
+
+      .concept-label {
+        background: #f5f5f4;
+        color: #57534e;
+      }
+
+      .meta-strip {
+        background: #fff;
+        border: 1px solid #e7e5e4;
+        box-shadow: 0 1px 3px rgba(28, 25, 23, 0.04);
+      }
+
+      .meta-strip h1 {
+        font-size: 0.9375rem;
+        letter-spacing: -0.02em;
+      }
+
+      .progress-pill {
+        background: var(--accent-warm-light);
+        color: var(--accent-warm-text);
+        font-size: 0.875rem;
+        padding: 0.25rem 0.65rem;
+      }
+
+      .progress-pill .dot {
+        background: var(--accent-warm-deep);
+      }
+
+      .banner.sync {
+        background: #fffbeb;
+        border: 1px solid #fde68a;
+        color: #92400e;
+      }
+
+      .toolbar button.on {
+        background: #fff;
+        color: #1c1917;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+        outline: 1px solid #e7e5e4;
+      }
+
+      .toolbar button.off {
+        background: #f5f5f4;
+        color: #78716c;
+      }
+
+      .section-card {
+        background: #fff;
+        border: 1px solid #e7e5e4;
+        box-shadow: 0 1px 2px rgba(28, 25, 23, 0.04);
+      }
+
+      .section-head h2 {
+        font-size: 1.125rem;
+        letter-spacing: -0.03em;
+      }
+
+      .count-chip {
+        background: #f5f5f4;
+        color: #57534e;
+      }
+
+      .item-card {
+        background: #fafaf9;
+        border: 1px solid #e7e5e4;
+        min-height: 4.5rem;
+      }
+
+      .item-card .badge {
+        background: #fff;
+        color: #57534e;
+        outline: 1px solid #e7e5e4;
+      }
+
+      .item-card.checked {
+        background: #fef2f2;
+        border-color: #fecaca;
+      }
+
+      .item-card.checked .name {
+        color: #64748b;
+      }
+
+      .accent-bar {
+        height: 3px;
+        width: 2.5rem;
+        border-radius: 999px;
+        background: linear-gradient(90deg, var(--accent-warm-light), var(--accent-warm));
+        margin-bottom: 0.65rem;
+      }
+
+      .quick-add-dock .inner {
+        background: #fff;
+        border: 2px solid var(--accent-warm);
+        box-shadow: 0 -4px 24px rgba(168, 153, 136, 0.18);
+      }
+
+      .quick-add-dock label {
+        color: #57534e;
+        font-weight: 600;
+      }
+
+      .quick-add-dock input {
+        background: #fafaf9;
+        border: 1px solid #d6d3d1;
+        color: #1c1917;
+      }
+
+      .quick-add-dock input:focus {
+        border-color: var(--accent-warm);
+        box-shadow: 0 0 0 3px rgba(201, 191, 176, 0.45);
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="concept-nav" aria-label="Konsepter">
+      <a href="index.html">Oversikt</a>
+      <a href="soft-pastel-calm.html">A — Calm</a>
+      <a href="nordic-playful.html" aria-current="page">B — Nordic</a>
+      <a href="color-sectioned-sprint.html">C — Sprint</a>
+    </nav>
+
+    <div class="phone-frame">
+      <span class="concept-label">B · Nordic Playful</span>
+
+      <header class="meta-strip">
+        <h1>Uke 22 · Middager</h1>
+        <span class="sep">·</span>
+        <span class="muted">Rema 1000</span>
+        <span class="sep">·</span>
+        <span class="muted">fredag 30. mai</span>
+        <span class="progress-pill">
+          <span class="dot" aria-hidden="true"></span>
+          12/18
+        </span>
+        <div class="links">
+          <a href="#">Handleliste</a>
+          <a href="#">Butikker</a>
+        </div>
+      </header>
+
+      <section class="banner sync" aria-label="Synkroniserer">
+        <h2>Synkroniserer</h2>
+        <p>Lagrer avkryssing …</p>
+      </section>
+
+      <div class="toolbar">
+        <button type="button" class="on">Flytt kjøpte til bunnen</button>
+        <button type="button" class="on">Liste</button>
+        <button type="button" class="off">Rutenett</button>
+      </div>
+
+      <section class="section-card" aria-labelledby="sec-produce">
+        <div class="accent-bar" aria-hidden="true"></div>
+        <div class="section-head">
+          <h2 id="sec-produce">Frukt og grønt</h2>
+          <span class="count-chip">4 varer</span>
+        </div>
+        <div class="item-grid">
+          <article class="item-card">
+            <span class="name">Cherrytomater</span>
+            <span class="badge">400 g</span>
+          </article>
+          <article class="item-card checked">
+            <span class="name">Spinat</span>
+          </article>
+          <article class="item-card">
+            <span class="name">Avokado</span>
+            <span class="badge">2 stk</span>
+          </article>
+          <article class="item-card">
+            <span class="name">Sitron</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="section-card" aria-labelledby="sec-dairy">
+        <div class="accent-bar" aria-hidden="true"></div>
+        <div class="section-head">
+          <h2 id="sec-dairy">Meieri</h2>
+          <span class="count-chip">2 varer</span>
+        </div>
+        <div class="item-grid">
+          <article class="item-card">
+            <span class="name">Melk</span>
+            <span class="badge">1 L</span>
+          </article>
+          <article class="item-card checked">
+            <span class="name">Revet ost</span>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <div class="quick-add-dock">
+      <div class="inner">
+        <label for="quick-add">Legg til vare</label>
+        <input
+          id="quick-add"
+          type="search"
+          placeholder="Søk eller skriv varenavn …"
+          autocomplete="off"
+        />
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/store-mode-concepts/shared.css
+++ b/docs/design/store-mode-concepts/shared.css
@@ -1,0 +1,262 @@
+/* Shared layout for isolated store-mode concept mockups */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+  line-height: 1.5;
+}
+
+.concept-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid #e2e8f0;
+  backdrop-filter: blur(8px);
+}
+
+.concept-nav a {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #475569;
+  text-decoration: none;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+}
+
+.concept-nav a:hover {
+  color: #0f172a;
+  background: #e2e8f0;
+}
+
+.concept-nav a[aria-current="page"] {
+  color: #fff;
+  background: #334155;
+}
+
+.phone-frame {
+  max-width: 390px;
+  margin: 0 auto;
+  min-height: calc(100dvh - 52px);
+  padding: 1rem 1rem 6.5rem;
+}
+
+.concept-label {
+  display: inline-block;
+  margin-bottom: 0.75rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.meta-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  font-size: 0.8125rem;
+}
+
+.meta-strip h1 {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta-strip .sep {
+  color: inherit;
+  opacity: 0.35;
+}
+
+.meta-strip .muted {
+  opacity: 0.75;
+}
+
+.meta-strip .links {
+  margin-left: auto;
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.meta-strip .links a {
+  color: inherit;
+  opacity: 0.7;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.banner {
+  margin-top: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.25rem;
+  font-size: 0.875rem;
+}
+
+.banner h2 {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.banner p {
+  margin: 0.35rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.section-head h2 {
+  margin: 0;
+  font-size: 1.0625rem;
+  font-weight: 600;
+}
+
+.count-chip {
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.toolbar button {
+  border: none;
+  border-radius: 1rem;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: default;
+}
+
+.item-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.item-card {
+  position: relative;
+  min-height: 4.25rem;
+  padding: 0.5rem 0.55rem;
+  border-radius: 1rem;
+  font-size: 0.8125rem;
+}
+
+.item-card .name {
+  display: block;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.item-card .badge {
+  display: inline-block;
+  margin-top: 0.2rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.625rem;
+  font-weight: 600;
+}
+
+.item-card.checked .name {
+  text-decoration: line-through;
+  opacity: 0.65;
+}
+
+.section-card {
+  margin-top: 1rem;
+  padding: 1rem 1rem 1.1rem;
+  border-radius: 1.25rem;
+}
+
+.quick-add-dock {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0.75rem 1rem 1rem;
+  pointer-events: none;
+}
+
+.quick-add-dock .inner {
+  max-width: 390px;
+  margin: 0 auto;
+  pointer-events: auto;
+  padding: 0.85rem 1rem;
+  border-radius: 1.25rem;
+}
+
+.quick-add-dock label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-bottom: 0.35rem;
+}
+
+.quick-add-dock input {
+  width: 100%;
+  border-radius: 1rem;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.9375rem;
+  font-family: inherit;
+  border: 2px solid transparent;
+}
+
+.quick-add-dock input:focus {
+  outline: none;
+}
+
+.progress-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.progress-pill .dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+}

--- a/docs/design/store-mode-concepts/soft-pastel-calm.html
+++ b/docs/design/store-mode-concepts/soft-pastel-calm.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>A — Soft Pastel Calm · Butikkmodus</title>
+    <link rel="stylesheet" href="shared.css" />
+    <style>
+      body {
+        background: linear-gradient(165deg, #faf5ff 0%, #fdf2f8 45%, #ecfdf5 100%);
+        color: #3b0764;
+      }
+
+      .concept-label {
+        background: #ede9fe;
+        color: #6d28d9;
+      }
+
+      .meta-strip {
+        background: rgba(255, 255, 255, 0.85);
+        border: 1px solid #e9d5ff;
+        box-shadow: 0 4px 20px rgba(139, 92, 246, 0.08);
+        color: #4c1d95;
+      }
+
+      .progress-pill {
+        background: #d1fae5;
+        color: #047857;
+      }
+
+      .progress-pill .dot {
+        background: #10b981;
+      }
+
+      .banner.sync {
+        background: linear-gradient(135deg, #fef9c3, #fde68a);
+        border: 1px solid #fcd34d;
+        color: #854d0e;
+      }
+
+      .toolbar button.on {
+        background: #fff;
+        color: #6d28d9;
+        box-shadow: 0 2px 8px rgba(139, 92, 246, 0.15);
+        outline: 1px solid #e9d5ff;
+      }
+
+      .toolbar button.off {
+        background: rgba(255, 255, 255, 0.6);
+        color: #7c3aed;
+      }
+
+      .section-card {
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 253, 245, 0.9));
+        border: 1px solid #a7f3d0;
+        box-shadow: 0 6px 24px rgba(16, 185, 129, 0.06);
+      }
+
+      .section-card.dairy {
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(237, 233, 254, 0.92));
+        border-color: #ddd6fe;
+        box-shadow: 0 6px 24px rgba(139, 92, 246, 0.06);
+      }
+
+      .count-chip {
+        background: #f3e8ff;
+        color: #7e22ce;
+      }
+
+      .item-card {
+        background: rgba(255, 255, 255, 0.9);
+        border: 1px solid #e9d5ff;
+        color: #4c1d95;
+      }
+
+      .item-card .badge {
+        background: #fef3c7;
+        color: #b45309;
+      }
+
+      .item-card.checked {
+        background: #fef2f2;
+        border-color: #fecaca;
+        color: #991b1b;
+      }
+
+      .item-card.checked .name {
+        color: #64748b;
+      }
+
+      .quick-add-dock .inner {
+        background: rgba(255, 255, 255, 0.95);
+        border: 2px solid #c4b5fd;
+        box-shadow: 0 -8px 32px rgba(139, 92, 246, 0.12);
+      }
+
+      .quick-add-dock label {
+        color: #6d28d9;
+      }
+
+      .quick-add-dock input {
+        background: #faf5ff;
+        border-color: #ddd6fe;
+        color: #4c1d95;
+      }
+
+      .quick-add-dock input:focus {
+        border-color: #a78bfa;
+        box-shadow: 0 0 0 4px rgba(167, 139, 250, 0.25);
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="concept-nav" aria-label="Konsepter">
+      <a href="index.html">Oversikt</a>
+      <a href="soft-pastel-calm.html" aria-current="page">A — Calm</a>
+      <a href="nordic-playful.html">B — Nordic</a>
+      <a href="color-sectioned-sprint.html">C — Sprint</a>
+    </nav>
+
+    <div class="phone-frame">
+      <span class="concept-label">A · Soft Pastel Calm</span>
+
+      <header class="meta-strip">
+        <h1>Uke 22 · Middager</h1>
+        <span class="sep">·</span>
+        <span class="muted">Rema 1000</span>
+        <span class="sep">·</span>
+        <span class="muted">fredag 30. mai</span>
+        <span class="progress-pill">
+          <span class="dot" aria-hidden="true"></span>
+          12/18
+        </span>
+        <div class="links">
+          <a href="#">Handleliste</a>
+          <a href="#">Butikker</a>
+        </div>
+      </header>
+
+      <section class="banner sync" aria-label="Synkroniserer">
+        <h2>Synkroniserer</h2>
+        <p>Lagrer avkryssing …</p>
+      </section>
+
+      <div class="toolbar">
+        <button type="button" class="on">Flytt kjøpte til bunnen</button>
+        <button type="button" class="on">Liste</button>
+        <button type="button" class="off">Rutenett</button>
+      </div>
+
+      <section class="section-card" aria-labelledby="sec-produce">
+        <div class="section-head">
+          <h2 id="sec-produce">Frukt og grønt</h2>
+          <span class="count-chip">4 varer</span>
+        </div>
+        <div class="item-grid">
+          <article class="item-card">
+            <span class="name">Cherrytomater</span>
+            <span class="badge">400 g</span>
+          </article>
+          <article class="item-card checked">
+            <span class="name">Spinat</span>
+          </article>
+          <article class="item-card">
+            <span class="name">Avokado</span>
+            <span class="badge">2 stk</span>
+          </article>
+          <article class="item-card">
+            <span class="name">Sitron</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="section-card dairy" aria-labelledby="sec-dairy">
+        <div class="section-head">
+          <h2 id="sec-dairy">Meieri</h2>
+          <span class="count-chip">2 varer</span>
+        </div>
+        <div class="item-grid">
+          <article class="item-card">
+            <span class="name">Melk</span>
+            <span class="badge">1 L</span>
+          </article>
+          <article class="item-card checked">
+            <span class="name">Revet ost</span>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <div class="quick-add-dock">
+      <div class="inner">
+        <label for="quick-add">Legg til vare</label>
+        <input
+          id="quick-add"
+          type="search"
+          placeholder="Søk eller skriv varenavn …"
+          autocomplete="off"
+        />
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/store-mode-visual-concepts.md
+++ b/docs/design/store-mode-visual-concepts.md
@@ -1,0 +1,71 @@
+# Store mode visual concepts
+
+Design exploration for [#112](https://github.com/sndrem/mealplanner/issues/112). Implementation target: [#111](https://github.com/sndrem/mealplanner/issues/111).
+
+## How to review
+
+Open these files in a browser (double-click or `open docs/design/store-mode-concepts/index.html`):
+
+| Concept | File |
+|---------|------|
+| Overview | [store-mode-concepts/index.html](./store-mode-concepts/index.html) |
+| A — Soft Pastel Calm | [soft-pastel-calm.html](./store-mode-concepts/soft-pastel-calm.html) |
+| B — Nordic Playful | [nordic-playful.html](./store-mode-concepts/nordic-playful.html) |
+| C — Color-Sectioned Sprint | [color-sectioned-sprint.html](./store-mode-concepts/color-sectioned-sprint.html) |
+
+Each page is self-contained HTML + CSS, isolated from the React app. Viewport is tuned for mobile (~390px).
+
+**Checked items** intentionally keep red “done” styling (matches current app).
+
+## Comparison matrix
+
+| Criterion | A — Soft Pastel Calm | B — Nordic Playful | C — Color-Sectioned Sprint |
+|-----------|----------------------|--------------------|----------------------------|
+| Scan speed in store | Good; soft hierarchy | **Best**; clearest type hierarchy | **Strong** if you know category colors |
+| Emotional tone | **Most calming / playful** | Warm but restrained | Energetic, market-like |
+| Accessibility risk | Medium (gradients + pastels) | **Lowest** | Higher (many tinted panels) |
+| Implementation effort (#111) | Medium | **Lowest** | Medium–high (category token map) |
+| Maintenance | Medium | **Lowest** | Category palette must stay in sync |
+
+## Recommendation (for sign-off)
+
+**Primary: B — Nordic Playful** (accent: subtle warm light brown, not purple)
+
+- Closest to current layout; smallest jump for users.
+- Pastel personality via warm taupe accent + progress without sacrificing readability when tired.
+- Easiest to express as semantic tokens in `app/app.css` later.
+
+**Nordic accent tokens (mockup):**
+
+| Role | Value |
+|------|-------|
+| `--accent-warm-light` | `#ebe4dc` |
+| `--accent-warm` | `#c9bfb0` |
+| `--accent-warm-deep` | `#a89988` |
+| `--accent-warm-text` | `#57534e` |
+
+**Runner-up: A — Soft Pastel Calm** if the goal is maximum stress relief over scan speed.
+
+**Borrow from C selectively:** category-tinted **section headers only** (not full card backgrounds) if you want faster aisle scanning without contrast risk.
+
+## Semantic tokens (draft for #111)
+
+```css
+/* Shared roles — values differ per chosen concept */
+--store-bg
+--store-surface
+--store-surface-elevated
+--store-text
+--store-text-muted
+--store-accent
+--store-progress
+--store-success / --store-warning / --store-error
+--store-item-default-bg / --store-item-checked-bg  /* checked stays red family */
+--store-category-tint  /* concept C only */
+```
+
+## Sign-off
+
+- [x] Concept chosen: **B — Nordic Playful** (warm light brown accent)
+- Reviewer: product owner
+- Notes: Red checked styling retained. #112 closed; implementation in #111.


### PR DESCRIPTION
## Summary
- Apply the Nordic Playful visual direction to butikkmodus: warm stone surfaces, light-brown accents, and a clearer progress pill.
- Keep red styling for checked items; add a collapsible **Kjøpt** section (closed by default) when deprioritize-bought is on.
- Add isolated HTML concept mockups under `docs/design/` for future reference (#112).

## Related issue
Closes #111

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: open store mode on mobile width; verify progress pill, quick-add focus, toggle items
- [ ] Manual: with deprioritize bought on, confirm **Kjøpt** is collapsed by default and expands on tap

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (267 tests)
- npm run typecheck