### PR TITLE
Allow Handledato selection across all family meal plan date ranges

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,34 @@
 
 ## Current Objective
 
-Issue #111 on branch `issue/111-nordic-playful-store-mode`: Nordic Playful store-mode visual refresh (warm brown accent) ready for PR merge.
+Issue #114 on branch `issue/114-handledato-multi-plan`: allow Handledato and related shopping-date fields across all family meal plan date ranges (shopping page + store mode). Ready for PR merge.
 
 ## Completed
 
-- Store-mode theme tokens in `app/app.css` and shared classes in `app/lib/store-mode-theme.ts`.
-- Restyled `family-meal-plan-store-mode` route, store-mode components, and `ManualShoppingQuickAdd` `appearance="store-mode"`.
-- Bought (`Kjøpt`) section wrapped in `<details>`, closed by default.
-- Design concept HTML mockups and comparison doc under `docs/design/` (from #112).
+- Added `unionMealPlanDateRanges` and `selectableShoppingDates` in shopping/store-mode loaders.
+- Replaced date inputs with `ShoppingDateSelect` on meal-plan shopping (Handledato, Utsatt til, add-manual form).
+- Store mode **Velg handledato** uses the same union via `ShoppingDateSelect`.
+- Server validation via `validateOptionalDateInFamilyMealPlans` for manual buy dates, generated postpone dates, and active shopping date.
 
 ## Files To Read First
 
-- `app/lib/store-mode-theme.ts` - semantic Tailwind class strings for store mode
-- `app/routes/family-meal-plan-store-mode.tsx` - route layout, collapsible bought section
-- `docs/design/store-mode-concepts/nordic-playful.html` - visual reference
+- `app/lib/meal-plan.server.ts` - `unionMealPlanDateRanges`
+- `app/components/shopping-list-item-expanded.tsx` - `ShoppingDateSelect` component
+- `app/lib/shopping-write.server.ts` - family-wide date validation
+- `app/routes/family-meal-plan-store-mode.tsx` - store mode handledato picker
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (267 tests, 48 files)
+- `npm run test:run` — passed (272 tests, 48 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual mobile smoke-check: store mode in ~390px viewport; expand Kjøpt section; quick-add focus ring; toggle items (red checked state).
+- Manual check: two meal plans with non-overlapping ranges; set Handledato / store mode handledato to a date from the other plan and confirm save + display.
+- Known side effect: cross-plan `buyOnDate` on a plan may not appear in that plan's store-mode trip filtering (out of scope for #114).
 
 ## Next Step
 
-Merge PR (Closes #111) after review/CI.
+Merge PR (Closes #114) after review/CI.

--- a/app/components/shopping-list-item-expanded.tsx
+++ b/app/components/shopping-list-item-expanded.tsx
@@ -1,4 +1,5 @@
 import { Form } from "react-router";
+import type { ChangeEventHandler } from "react";
 
 import { formatOccurrenceSourceLine } from "../lib/shopping-display";
 import type {
@@ -14,6 +15,72 @@ import type {
 
 export const shoppingDateInputClassName =
   "mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100";
+
+function buildShoppingDateSelectOptions(
+  selectableShoppingDates: string[],
+  selectedDate: string,
+) {
+  const dates = new Set(selectableShoppingDates);
+
+  if (selectedDate) {
+    dates.add(selectedDate);
+  }
+
+  return [...dates].sort();
+}
+
+function formatShoppingDateOptionLabel(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00.000Z`));
+}
+
+export function ShoppingDateSelect({
+  "aria-busy": ariaBusy,
+  className = shoppingDateInputClassName,
+  defaultValue,
+  disabled = false,
+  emptyOptionLabel = "Ingen dato valgt",
+  name,
+  onChange,
+  selectableShoppingDates,
+  showEmptyOption = true,
+}: {
+  "aria-busy"?: boolean;
+  className?: string;
+  defaultValue: string;
+  disabled?: boolean;
+  emptyOptionLabel?: string;
+  name: string;
+  onChange?: ChangeEventHandler<HTMLSelectElement>;
+  selectableShoppingDates: string[];
+  showEmptyOption?: boolean;
+}) {
+  const options = buildShoppingDateSelectOptions(
+    selectableShoppingDates,
+    defaultValue,
+  );
+
+  return (
+    <select
+      aria-busy={ariaBusy}
+      className={className}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      name={name}
+      onChange={onChange}
+    >
+      {showEmptyOption ? <option value="">{emptyOptionLabel}</option> : null}
+      {options.map((date) => (
+        <option key={date} value={date}>
+          {formatShoppingDateOptionLabel(date)}
+        </option>
+      ))}
+    </select>
+  );
+}
 
 type ShoppingListItemExpandedProps = {
   actionData?: {
@@ -49,9 +116,8 @@ type ShoppingListItemExpandedProps = {
     sourceType: "FAMILY" | "GENERATED" | "MANUAL";
   };
   manualValues: ManualShoppingItemValues | null;
-  mealPlanEndDate?: string;
-  mealPlanStartDate?: string;
   overrideValues: GeneratedShoppingItemOverrideValues | null;
+  selectableShoppingDates?: string[];
   stores: Array<{ id: string; name: string }>;
   toggleExpectedVersion: string;
 };
@@ -69,9 +135,8 @@ export function ShoppingListItemExpanded({
   isPendingManualSave,
   item,
   manualValues,
-  mealPlanEndDate = "",
-  mealPlanStartDate = "",
   overrideValues,
+  selectableShoppingDates = [],
   stores,
   toggleExpectedVersion,
 }: ShoppingListItemExpandedProps) {
@@ -188,13 +253,10 @@ export function ShoppingListItemExpanded({
 
             <label className="block min-w-0 text-sm font-medium text-slate-700">
               Utsatt til
-              <input
-                className={shoppingDateInputClassName}
+              <ShoppingDateSelect
                 defaultValue={overrideValues.postponedUntilDate}
-                max={mealPlanEndDate}
-                min={mealPlanStartDate}
                 name="postponedUntilDate"
-                type="date"
+                selectableShoppingDates={selectableShoppingDates}
               />
             </label>
 
@@ -297,13 +359,11 @@ export function ShoppingListItemExpanded({
 
                 <label className="block min-w-0 text-sm font-medium text-slate-700">
                   Handledato
-                  <input
-                    className={shoppingDateInputClassName}
+                  <ShoppingDateSelect
                     defaultValue={manualValues.buyOnDate}
-                    max={mealPlanEndDate}
-                    min={mealPlanStartDate}
+                    emptyOptionLabel="Ingen handledato"
                     name="buyOnDate"
-                    type="date"
+                    selectableShoppingDates={selectableShoppingDates}
                   />
                 </label>
               </div>

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -65,6 +65,7 @@ import {
   reopenMealPlan,
   saveMealPlanEntries,
   updateMealPlan,
+  unionMealPlanDateRanges,
   validateMealPlanRange,
 } from "./meal-plan.server";
 
@@ -1271,5 +1272,55 @@ describe("meal-plan.server", () => {
       warning:
         "Noen middager ble valgt flere ganger fordi det var for fa oppskrifter igjen.",
     });
+  });
+});
+
+describe("unionMealPlanDateRanges", () => {
+  it("returns the same dates as getMealPlanDateRange for a single plan", () => {
+    expect(
+      unionMealPlanDateRanges([
+        {
+          endDate: new Date("2026-05-18T00:00:00.000Z"),
+          startDate: new Date("2026-05-15T00:00:00.000Z"),
+        },
+      ]),
+    ).toEqual(["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"]);
+  });
+
+  it("deduplicates overlapping plan ranges", () => {
+    expect(
+      unionMealPlanDateRanges([
+        {
+          endDate: new Date("2026-05-17T00:00:00.000Z"),
+          startDate: new Date("2026-05-15T00:00:00.000Z"),
+        },
+        {
+          endDate: new Date("2026-05-18T00:00:00.000Z"),
+          startDate: new Date("2026-05-17T00:00:00.000Z"),
+        },
+      ]),
+    ).toEqual(["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"]);
+  });
+
+  it("unions adjacent non-overlapping plans without gap dates", () => {
+    expect(
+      unionMealPlanDateRanges([
+        {
+          endDate: new Date("2026-05-17T00:00:00.000Z"),
+          startDate: new Date("2026-05-15T00:00:00.000Z"),
+        },
+        {
+          endDate: new Date("2026-05-21T00:00:00.000Z"),
+          startDate: new Date("2026-05-19T00:00:00.000Z"),
+        },
+      ]),
+    ).toEqual([
+      "2026-05-15",
+      "2026-05-16",
+      "2026-05-17",
+      "2026-05-19",
+      "2026-05-20",
+      "2026-05-21",
+    ]);
   });
 });

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -180,6 +180,20 @@ export function getMealPlanDateRange(startDate: Date, endDate: Date) {
   return dates;
 }
 
+export function unionMealPlanDateRanges(
+  plans: Array<{ endDate: Date; startDate: Date }>,
+) {
+  const dateSet = new Set<string>();
+
+  for (const plan of plans) {
+    for (const date of getMealPlanDateRange(plan.startDate, plan.endDate)) {
+      dateSet.add(date);
+    }
+  }
+
+  return [...dateSet].sort();
+}
+
 export function validateMealPlanRange(
   startDate: string,
   endDate: string,

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -37,6 +37,7 @@ const {
       },
       mealPlan: {
         findFirst: vi.fn(),
+        findMany: vi.fn(),
         update: vi.fn(),
         updateMany: vi.fn(),
       },
@@ -123,6 +124,12 @@ describe("shopping-write.server", () => {
       userId: "user-1",
     });
     dbMock.mealPlan.findFirst.mockResolvedValue(mockMealPlan);
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        endDate: mockMealPlan.endDate,
+        startDate: mockMealPlan.startDate,
+      },
+    ]);
     dbMock.mealPlan.updateMany.mockResolvedValue({ count: 1 });
     dbMock.manualShoppingItem.updateMany.mockResolvedValue({ count: 1 });
     dbMock.manualShoppingItem.deleteMany.mockResolvedValue({ count: 1 });
@@ -150,7 +157,7 @@ describe("shopping-write.server", () => {
 
     expect(result).toEqual({
       fieldErrors: {
-        buyOnDate: "Datoen må ligge innenfor ukeplanens aktive periode.",
+        buyOnDate: "Datoen må ligge innenfor en av familiens ukeplaner.",
         categoryId: "Velg en kategori.",
         name: "Skriv inn et varenavn.",
       },
@@ -204,6 +211,47 @@ describe("shopping-write.server", () => {
         quantity: "6 stk",
         updatedByUserId: "user-1",
       },
+    });
+  });
+
+  it("accepts a buyOnDate from another family meal plan range", async () => {
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+      },
+      {
+        endDate: new Date("2026-05-25T00:00:00.000Z"),
+        startDate: new Date("2026-05-22T00:00:00.000Z"),
+      },
+    ]);
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-produce",
+    });
+    dbMock.store.findFirst.mockResolvedValue(null);
+
+    const result = await createManualShoppingItem({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+      values: {
+        buyOnDate: "2026-05-23",
+        categoryId: "category-produce",
+        name: "Bananer",
+        note: "",
+        preferredStoreId: "",
+        quantity: "",
+      },
+    });
+
+    expect(result).toEqual({
+      status: "CREATED",
+    });
+    expect(dbMock.manualShoppingItem.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        buyOnDate: new Date("2026-05-23T00:00:00.000Z"),
+        mealPlanId: "meal-plan-1",
+      }),
     });
   });
 
@@ -536,6 +584,40 @@ describe("shopping-write.server", () => {
         activeShoppingDate: new Date("2026-05-17T00:00:00.000Z"),
         updatedByUserId: "user-1",
       },
+      where: {
+        id: "meal-plan-1",
+        updatedAt: mockMealPlan.updatedAt,
+      },
+    });
+  });
+
+  it("accepts an active shopping date from another family meal plan range", async () => {
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+      },
+      {
+        endDate: new Date("2026-05-25T00:00:00.000Z"),
+        startDate: new Date("2026-05-22T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await updateActiveShoppingDate({
+      activeShoppingDate: "2026-05-23",
+      expectedMealPlanUpdatedAt: mockMealPlan.updatedAt.toISOString(),
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.mealPlan.updateMany).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        activeShoppingDate: new Date("2026-05-23T00:00:00.000Z"),
+      }),
       where: {
         id: "meal-plan-1",
         updatedAt: mockMealPlan.updatedAt,

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -1275,12 +1275,11 @@ export async function updateActiveShoppingDate({
   }
 
   const normalizedDate = activeShoppingDate.trim();
-  const validation = validateOptionalDateInRange(
-    normalizedDate,
-    mealPlan.startDate,
-    mealPlan.endDate,
-    "Velg en gyldig handledato.",
-  );
+  const validation = await validateOptionalDateInFamilyMealPlans({
+    familyId,
+    invalidMessage: "Velg en gyldig handledato.",
+    value: normalizedDate,
+  });
 
   if (!validation.ok) {
     return {
@@ -1410,7 +1409,7 @@ async function getScopedMealPlan({
 
 async function validateManualShoppingItemValues({
   familyId,
-  mealPlan,
+  mealPlan: _mealPlan,
   values,
 }: {
   familyId: string;
@@ -1432,12 +1431,11 @@ async function validateManualShoppingItemValues({
     fieldErrors.categoryId = "Velg en kategori.";
   }
 
-  const buyOnDateValidation = validateOptionalDateInRange(
-    normalizedValues.buyOnDate,
-    mealPlan.startDate,
-    mealPlan.endDate,
-    "Velg en gyldig handledato.",
-  );
+  const buyOnDateValidation = await validateOptionalDateInFamilyMealPlans({
+    familyId,
+    invalidMessage: "Velg en gyldig handledato.",
+    value: normalizedValues.buyOnDate,
+  });
 
   if (!buyOnDateValidation.ok) {
     fieldErrors.buyOnDate = buyOnDateValidation.fieldError;
@@ -1489,7 +1487,7 @@ async function validateManualShoppingItemValues({
 
 async function validateGeneratedShoppingItemOverrideValues({
   familyId,
-  mealPlan,
+  mealPlan: _mealPlan,
   values,
 }: {
   familyId: string;
@@ -1502,12 +1500,11 @@ async function validateGeneratedShoppingItemOverrideValues({
 }) {
   const normalizedValues = normalizeGeneratedShoppingItemOverrideValues(values);
   const fieldErrors: GeneratedShoppingItemOverrideFieldErrors = {};
-  const postponedDateValidation = validateOptionalDateInRange(
-    normalizedValues.postponedUntilDate,
-    mealPlan.startDate,
-    mealPlan.endDate,
-    "Velg en gyldig dato innenfor ukeplanen.",
-  );
+  const postponedDateValidation = await validateOptionalDateInFamilyMealPlans({
+    familyId,
+    invalidMessage: "Velg en gyldig dato innenfor ukeplanen.",
+    value: normalizedValues.postponedUntilDate,
+  });
 
   if (!postponedDateValidation.ok) {
     fieldErrors.postponedUntilDate = postponedDateValidation.fieldError;
@@ -1743,12 +1740,15 @@ async function resolveScopedStoreId(preferredStoreId: string, familyId: string) 
   return store?.id ?? null;
 }
 
-function validateOptionalDateInRange(
-  value: string,
-  startDate: Date,
-  endDate: Date,
-  invalidMessage: string,
-) {
+async function validateOptionalDateInFamilyMealPlans({
+  familyId,
+  invalidMessage,
+  value,
+}: {
+  familyId: string;
+  invalidMessage: string;
+  value: string;
+}) {
   if (!value) {
     return {
       date: null,
@@ -1765,9 +1765,25 @@ function validateOptionalDateInRange(
     };
   }
 
-  if (parsedDate.getTime() < startDate.getTime() || parsedDate.getTime() > endDate.getTime()) {
+  const mealPlans = await db.mealPlan.findMany({
+    select: {
+      endDate: true,
+      startDate: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  const isWithinAnyPlan = mealPlans.some(
+    (plan) =>
+      parsedDate.getTime() >= plan.startDate.getTime() &&
+      parsedDate.getTime() <= plan.endDate.getTime(),
+  );
+
+  if (!isWithinAnyPlan) {
     return {
-      fieldError: "Datoen må ligge innenfor ukeplanens aktive periode.",
+      fieldError: "Datoen må ligge innenfor en av familiens ukeplaner.",
       ok: false as const,
     };
   }

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -20,6 +20,7 @@ const {
         },
         mealPlan: {
           findFirst: vi.fn(),
+          findMany: vi.fn(),
         },
         store: {
           findMany: vi.fn(),
@@ -88,6 +89,12 @@ describe("shopping.server", () => {
     });
     dbMock.userStorePreference.findUnique.mockResolvedValue(null);
     dbMock.familyShoppingItem.findMany.mockResolvedValue([]);
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+      },
+    ]);
     dbMock.ingredientCategory.findMany.mockResolvedValue([
       {
         displayName: "Brod",
@@ -377,6 +384,12 @@ describe("shopping.server", () => {
       },
     ]);
     expect(result.visibleDates).toEqual(["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"]);
+    expect(result.selectableShoppingDates).toEqual([
+      "2026-05-15",
+      "2026-05-16",
+      "2026-05-17",
+      "2026-05-18",
+    ]);
     expect(result.projectedItems.map((item) => item.name)).toEqual([
       "Paprika",
       "Yoghurt",
@@ -1351,6 +1364,12 @@ describe("shopping.server", () => {
       checkedCount: 0,
       totalCount: 1,
     });
+    expect(result.selectableShoppingDates).toEqual([
+      "2026-05-15",
+      "2026-05-16",
+      "2026-05-17",
+      "2026-05-18",
+    ]);
   });
 
   it("includes all items from the shopping date through the end of the meal plan", async () => {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -4,7 +4,10 @@ import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import { findMealPlanCoveringDate } from "./meal-plan-for-date.server";
-import { getMealPlanDateRange } from "./meal-plan.server";
+import {
+  getMealPlanDateRange,
+  unionMealPlanDateRanges,
+} from "./meal-plan.server";
 import { getFamilyShoppingListMode } from "./shopping-preference.server";
 import {
   getFamilyStockMatchSet,
@@ -338,20 +341,31 @@ export async function getMealPlanShoppingData({
     });
   }
 
-  const [stores, categories, stockMatchSet] = await Promise.all([
-    db.store.findMany({
-      orderBy: [{ name: "asc" }],
-      select: shoppingStoreSelect,
-      where: {
-        OR: [{ familyId: null }, { familyId }],
-      },
-    }),
-    db.ingredientCategory.findMany({
-      orderBy: [{ displayName: "asc" }],
-      select: shoppingCategorySelect,
-    }),
-    getFamilyStockMatchSet(familyId),
-  ]);
+  const [stores, categories, stockMatchSet, familyMealPlanRanges] =
+    await Promise.all([
+      db.store.findMany({
+        orderBy: [{ name: "asc" }],
+        select: shoppingStoreSelect,
+        where: {
+          OR: [{ familyId: null }, { familyId }],
+        },
+      }),
+      db.ingredientCategory.findMany({
+        orderBy: [{ displayName: "asc" }],
+        select: shoppingCategorySelect,
+      }),
+      getFamilyStockMatchSet(familyId),
+      db.mealPlan.findMany({
+        orderBy: [{ startDate: "asc" }, { id: "asc" }],
+        select: {
+          endDate: true,
+          startDate: true,
+        },
+        where: {
+          familyId,
+        },
+      }),
+    ]);
 
   const includeDespiteStockKeys = buildIncludeDespiteStockKeys(
     mealPlan.shoppingOverrides,
@@ -412,6 +426,7 @@ export async function getMealPlanShoppingData({
       name: store.name,
     })),
     userRole: membership.role,
+    selectableShoppingDates: unionMealPlanDateRanges(familyMealPlanRanges),
     visibleDates: getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate),
   };
 }
@@ -735,7 +750,7 @@ export async function getMealPlanStoreModeData({
     userId,
   });
 
-  const [mealPlan, stores, selectedStorePreference, stockMatchSet] =
+  const [mealPlan, stores, selectedStorePreference, stockMatchSet, familyMealPlanRanges] =
     await Promise.all([
       db.mealPlan.findFirst({
         select: shoppingMealPlanSelect,
@@ -763,6 +778,16 @@ export async function getMealPlanStoreModeData({
         },
       }),
       getFamilyStockMatchSet(familyId),
+      db.mealPlan.findMany({
+        orderBy: [{ startDate: "asc" }, { id: "asc" }],
+        select: {
+          endDate: true,
+          startDate: true,
+        },
+        where: {
+          familyId,
+        },
+      }),
     ]);
 
   if (!mealPlan) {
@@ -856,6 +881,7 @@ export async function getMealPlanStoreModeData({
       name: store.name,
     })),
     userRole: membership.role,
+    selectableShoppingDates: unionMealPlanDateRanges(familyMealPlanRanges),
     visibleDates: getMealPlanDateRange(mealPlan.startDate, mealPlan.endDate),
   };
 }

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -260,6 +260,16 @@ describe("family meal plan shopping route", () => {
         },
       ],
       userRole: "ADMIN",
+      selectableShoppingDates: [
+        "2026-05-15",
+        "2026-05-16",
+        "2026-05-17",
+        "2026-05-18",
+        "2026-05-22",
+        "2026-05-23",
+        "2026-05-24",
+        "2026-05-25",
+      ],
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
     });
 
@@ -413,6 +423,16 @@ describe("family meal plan shopping route", () => {
         },
       ],
       userRole: "ADMIN",
+      selectableShoppingDates: [
+        "2026-05-15",
+        "2026-05-16",
+        "2026-05-17",
+        "2026-05-18",
+        "2026-05-22",
+        "2026-05-23",
+        "2026-05-24",
+        "2026-05-25",
+      ],
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
     });
   });
@@ -477,6 +497,7 @@ describe("family meal plan shopping route", () => {
       storeGroups: [],
       stores: [],
       userRole: "ADMIN",
+      selectableShoppingDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
     });
 

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -15,8 +15,8 @@ import {
 } from "../lib/shopping-display";
 import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
 import {
+  ShoppingDateSelect,
   ShoppingListItemExpanded,
-  shoppingDateInputClassName,
 } from "../components/shopping-list-item-expanded";
 import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
@@ -176,6 +176,7 @@ export async function loader({
     ),
     stores: result.stores,
     userRole: result.userRole,
+    selectableShoppingDates: result.selectableShoppingDates,
     visibleDates: result.visibleDates,
   };
 }
@@ -1005,13 +1006,11 @@ export default function FamilyMealPlanShoppingRoute({
 
                   <label className="block min-w-0 text-sm font-medium text-slate-700">
                     Handledato
-                    <input
-                      className={shoppingDateInputClassName}
+                    <ShoppingDateSelect
                       defaultValue={addManualValues.buyOnDate}
-                      max={loaderData.mealPlan.endDate}
-                      min={loaderData.mealPlan.startDate}
+                      emptyOptionLabel="Ingen handledato"
                       name="buyOnDate"
-                      type="date"
+                      selectableShoppingDates={loaderData.selectableShoppingDates}
                     />
                   </label>
                 </div>
@@ -1262,9 +1261,9 @@ export default function FamilyMealPlanShoppingRoute({
                             isPendingManualSave,
                             item,
                             manualValues,
-                            mealPlanEndDate: loaderData.mealPlan.endDate,
-                            mealPlanStartDate: loaderData.mealPlan.startDate,
                             overrideValues,
+                            selectableShoppingDates:
+                              loaderData.selectableShoppingDates,
                             stores: loaderData.stores,
                             toggleExpectedVersion:
                               getToggleExpectedVersion(item),

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -168,6 +168,14 @@ describe("family meal plan store mode route", () => {
         },
       ],
       userRole: "ADMIN",
+      selectableShoppingDates: [
+        "2026-05-15",
+        "2026-05-16",
+        "2026-05-17",
+        "2026-05-18",
+        "2026-05-22",
+        "2026-05-23",
+      ],
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
     });
 
@@ -196,6 +204,14 @@ describe("family meal plan store mode route", () => {
       },
     ]);
     expect(result.activeShoppingDate).toBe("2026-05-16");
+    expect(result.selectableShoppingDates).toEqual([
+      "2026-05-15",
+      "2026-05-16",
+      "2026-05-17",
+      "2026-05-18",
+      "2026-05-22",
+      "2026-05-23",
+    ]);
     expect(result.mealPlan.activeShoppingDate).toBe("2026-05-16");
     expect(result.dueSectionGroups[0]?.items[0]).toEqual(
       expect.objectContaining({

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-router";
 
 import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
+import { ShoppingDateSelect } from "../components/shopping-list-item-expanded";
 import { StoreModeDeprioritizeBoughtToggle } from "../components/store-mode-deprioritize-bought-toggle";
 import { StoreModeShoppingItemCard } from "../components/store-mode-shopping-item-card";
 import { StoreModeShoppingViewToggle } from "../components/store-mode-shopping-view-toggle";
@@ -155,6 +156,7 @@ export async function loader({
     progress: result.progress,
     recentManualItems,
     selectedStore: result.selectedStore,
+    selectableShoppingDates: result.selectableShoppingDates,
     stores: result.stores,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
@@ -364,18 +366,15 @@ export default function FamilyMealPlanStoreModeRoute({
     () => loaderData.dueSectionGroups.flatMap((section) => section.items),
     [loaderData.dueSectionGroups],
   );
-  const {
-    displayItemsBySourceKey,
-    handleToggle,
-    syncBannerMessage,
-  } = useStoreModeToggleSync({
-    activeShoppingDate: loaderData.activeShoppingDate,
-    familyId: loaderData.family.id,
-    loaderItems: loaderDueItems,
-    mealPlanId: loaderData.mealPlan.id,
-    revalidate: revalidator.revalidate,
-    toggleFetcher,
-  });
+  const { displayItemsBySourceKey, handleToggle, syncBannerMessage } =
+    useStoreModeToggleSync({
+      activeShoppingDate: loaderData.activeShoppingDate,
+      familyId: loaderData.family.id,
+      loaderItems: loaderDueItems,
+      mealPlanId: loaderData.mealPlan.id,
+      revalidate: revalidator.revalidate,
+      toggleFetcher,
+    });
   const displayDueItems = useMemo(
     () =>
       loaderDueItems.map(
@@ -413,8 +412,8 @@ export default function FamilyMealPlanStoreModeRoute({
       }),
     [loaderData.family.id, loaderData.mealPlan.id],
   );
-  const [shoppingView, setShoppingView] = useState<StoreModeShoppingView>(
-    () => readStoreModeShoppingView(viewStorageKey),
+  const [shoppingView, setShoppingView] = useState<StoreModeShoppingView>(() =>
+    readStoreModeShoppingView(viewStorageKey),
   );
   const [deprioritizeBought, setDeprioritizeBought] = useState(() =>
     readStoreModeDeprioritizeBought(deprioritizeBoughtStorageKey),
@@ -443,13 +442,13 @@ export default function FamilyMealPlanStoreModeRoute({
   }, [deprioritizeBoughtStorageKey]);
   type StoreModeDisplayItem = (typeof displayDueItems)[number];
   type StoreModeDisplaySection = (typeof displaySectionGroups)[number];
-  const { activeSections, boughtItems } = useMemo((): {
-    activeSections: StoreModeDisplaySection[];
-    boughtItems: StoreModeDisplayItem[];
-  } => partitionStoreModeSections(displaySectionGroups, deprioritizeBought), [
-    deprioritizeBought,
-    displaySectionGroups,
-  ]);
+  const { activeSections, boughtItems } = useMemo(
+    (): {
+      activeSections: StoreModeDisplaySection[];
+      boughtItems: StoreModeDisplayItem[];
+    } => partitionStoreModeSections(displaySectionGroups, deprioritizeBought),
+    [deprioritizeBought, displaySectionGroups],
+  );
   const noticeContent = loaderData.notice
     ? getStoreModeNoticeContent(loaderData.notice)
     : null;
@@ -610,7 +609,7 @@ export default function FamilyMealPlanStoreModeRoute({
                   type="hidden"
                   value={loaderData.mealPlan.updatedAt}
                 />
-                <select
+                <ShoppingDateSelect
                   aria-busy={isSavingShoppingDate}
                   className={storeModeSelectClass}
                   defaultValue={activeShoppingDateValue}
@@ -619,13 +618,9 @@ export default function FamilyMealPlanStoreModeRoute({
                   onChange={(event) => {
                     submitSelectForm(event, activeShoppingDateValue, submit);
                   }}
-                >
-                  {loaderData.visibleDates.map((date) => (
-                    <option key={date} value={date}>
-                      {formatDateLabel(date)}
-                    </option>
-                  ))}
-                </select>
+                  selectableShoppingDates={loaderData.selectableShoppingDates}
+                  showEmptyOption={false}
+                />
                 {actionData?.intent === "update-active-shopping-date" &&
                 actionData.activeShoppingDateFieldErrors?.activeShoppingDate ? (
                   <p className="text-sm text-rose-600">
@@ -687,8 +682,8 @@ export default function FamilyMealPlanStoreModeRoute({
                   Alt er krysset av
                 </h3>
                 <p className="mt-3 text-sm leading-6 text-stone-600">
-                  Du har handlet alle varene for denne turen. Kjøpte varer ligger
-                  nedenfor hvis du vil se eller endre dem.
+                  Du har handlet alle varene for denne turen. Kjøpte varer
+                  ligger nedenfor hvis du vil se eller endre dem.
                 </p>
               </article>
             ) : null}
@@ -806,11 +801,11 @@ export function ErrorBoundary({ error }: { error: unknown }) {
 }
 
 function serializeProjectedShoppingItem(
-  item: Awaited<
-    ReturnType<typeof getMealPlanStoreModeData>
-  >["laterItems"][number] | Awaited<
-    ReturnType<typeof getMealPlanStoreModeData>
-  >["dueSectionGroups"][number]["items"][number],
+  item:
+    | Awaited<ReturnType<typeof getMealPlanStoreModeData>>["laterItems"][number]
+    | Awaited<
+        ReturnType<typeof getMealPlanStoreModeData>
+      >["dueSectionGroups"][number]["items"][number],
 ) {
   if (item.sourceType === "FAMILY") {
     return item;
@@ -897,7 +892,9 @@ function buildStoreModeRedirect({
   return Response.redirect(url, 302);
 }
 
-function StoreModeItemGrid<TItem extends ComponentProps<typeof StoreModeShoppingItemCard>["item"]>({
+function StoreModeItemGrid<
+  TItem extends ComponentProps<typeof StoreModeShoppingItemCard>["item"],
+>({
   items,
   layout,
   onToggleItem,


### PR DESCRIPTION
## Summary
- Expose `selectableShoppingDates` (union of all family meal plan ranges) in meal-plan shopping and store mode loaders.
- Replace date inputs with `ShoppingDateSelect` for Handledato, Utsatt til, add-manual form, and store mode handledato picker.
- Validate shopping-related dates server-side against any family meal plan range via `validateOptionalDateInFamilyMealPlans`.

## Related issue
Closes #114

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual: two meal plans with non-overlapping ranges — set Handledato on shopping page and handledato in store mode to a date from the other plan; confirm save succeeds

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (272 tests)
- npm run typecheck