### PR TITLE
Fix missing last-day shopping items for merged ingredients

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,31 @@
 
 ## Current Objective
 
-Issue #114 on branch `issue/114-handledato-multi-plan`: allow Handledato and related shopping-date fields across all family meal plan date ranges (shopping page + store mode). Ready for PR merge.
+Issue #116 on branch `issue/116-last-day-shopping-items`: fix store-mode trip filtering so merged generated items appear when any occurrence falls within the active shopping window (especially last-day trips). Ready for PR review.
 
 ## Completed
 
-- Added `unionMealPlanDateRanges` and `selectableShoppingDates` in shopping/store-mode loaders.
-- Replaced date inputs with `ShoppingDateSelect` on meal-plan shopping (Handledato, Utsatt til, add-manual form).
-- Store mode **Velg handledato** uses the same union via `ShoppingDateSelect`.
-- Server validation via `validateOptionalDateInFamilyMealPlans` for manual buy dates, generated postpone dates, and active shopping date.
+- Added occurrence-aware date helpers for generated shopping items in `shopping.server.ts`.
+- Refactored `isProjectedItemPast`, `isProjectedItemInStoreModeTrip`, and `isProjectedItemBeforeShoppingDate` to use effective occurrence dates instead of merged `firstDate`.
+- Added four regression tests in `shopping.server.test.ts` for last-day merge, postponement, mid-week guard, and past-only exclusion.
 
 ## Files To Read First
 
-- `app/lib/meal-plan.server.ts` - `unionMealPlanDateRanges`
-- `app/components/shopping-list-item-expanded.tsx` - `ShoppingDateSelect` component
-- `app/lib/shopping-write.server.ts` - family-wide date validation
-- `app/routes/family-meal-plan-store-mode.tsx` - store mode handledato picker
+- `app/lib/shopping.server.ts` - occurrence-aware store mode trip filters
+- `app/lib/shopping.server.test.ts` - new `getMealPlanStoreModeData` regression cases
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (272 tests, 48 files)
+- `npm run test:run` — passed (276 tests, 48 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual check: two meal plans with non-overlapping ranges; set Handledato / store mode handledato to a date from the other plan and confirm save + display.
-- Known side effect: cross-plan `buyOnDate` on a plan may not appear in that plan's store-mode trip filtering (out of scope for #114).
+- Manual check: create a multi-day plan with shared ingredients; set Handledato to last day in store mode and confirm full ingredient set appears in trip list.
+- Out of scope: pantry/stock filtering and cross-plan manual `buyOnDate` behavior unchanged.
 
 ## Next Step
 
-Merge PR (Closes #114) after review/CI.
+Merge PR (Closes #116) after review/CI.

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -1597,6 +1597,351 @@ describe("shopping.server", () => {
     ).toEqual(["Paprika"]);
     expect(result.laterItems.map((item) => item.name)).toEqual([]);
   });
+
+  it("includes merged cross-day ingredients on a last-day-only shopping trip", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-18T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Løk",
+                id: "ingredient-1",
+                ingredientId: "canonical-onion",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Fredag",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-18T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "2",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Løk",
+                id: "ingredient-2",
+                ingredientId: "canonical-onion",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+              {
+                amount: "1",
+                category: { id: "category-dairy", name: "Meieri" },
+                categoryId: "category-dairy",
+                displayName: "Krem",
+                id: "ingredient-3",
+                ingredientId: "canonical-cream",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 2,
+                unit: "dl",
+              },
+            ],
+            title: "Mandag",
+          },
+          recipeId: "recipe-2",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Ukehandel",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: "family-1",
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-1",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-dairy",
+            displayName: "Meieri",
+            id: "section-2",
+            sortOrder: 2,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(
+      result.dueSectionGroups
+        .flatMap((section) => section.items.map((item) => item.name))
+        .sort(),
+    ).toEqual(["Krem", "Løk"]);
+    expect(result.laterItems.map((item) => item.name)).toEqual([]);
+  });
+
+  it("includes a postponed generated item when postponedUntilDate matches the last-day trip", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-18T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Paprika",
+                id: "ingredient-1",
+                ingredientId: "canonical-paprika",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Fredag",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [
+        {
+          checked: false,
+          excludedFromList: false,
+          includeDespiteStock: false,
+          note: null,
+          postponedUntilDate: new Date("2026-05-18T00:00:00.000Z"),
+          preferredStore: null,
+          preferredStoreId: null,
+          sourceKey: "entry-1:ingredient-1",
+          sourceType: "GENERATED",
+          updatedAt: new Date("2026-05-15T10:00:00.000Z"),
+        },
+      ],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Ukehandel",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: "family-1",
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-1",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(
+      result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name)),
+    ).toEqual(["Paprika"]);
+    expect(result.laterItems.map((item) => item.name)).toEqual([]);
+  });
+
+  it("keeps merged cross-day ingredients on the trip when today is after the first occurrence", async () => {
+    vi.setSystemTime(new Date("2026-05-16T09:30:45.000Z"));
+
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-18T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Løk",
+                id: "ingredient-1",
+                ingredientId: "canonical-onion",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Fredag",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-18T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "2",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Løk",
+                id: "ingredient-2",
+                ingredientId: "canonical-onion",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Mandag",
+          },
+          recipeId: "recipe-2",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Ukehandel",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: "family-1",
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-1",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(
+      result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name)),
+    ).toEqual(["Løk"]);
+    expect(result.laterItems.map((item) => item.name)).toEqual([]);
+  });
+
+  it("does not pull generated items into the trip when all effective dates are in the past", async () => {
+    vi.setSystemTime(new Date("2026-05-18T09:30:45.000Z"));
+
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-18T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-produce", name: "Frukt og gront" },
+                categoryId: "category-produce",
+                displayName: "Løk",
+                id: "ingredient-1",
+                ingredientId: "canonical-onion",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "stk",
+              },
+            ],
+            title: "Fredag",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Ukehandel",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: "family-1",
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-produce",
+            displayName: "Frukt og gront",
+            id: "section-1",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(
+      result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name)),
+    ).toEqual([]);
+    expect(result.laterItems.map((item) => item.name)).toEqual([]);
+  });
   });
 
   it("excludes stock ingredients from generated shopping items and exposes a stock summary", async () => {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -840,6 +840,7 @@ export async function getMealPlanStoreModeData({
       isProjectedItemBeforeShoppingDate(
         item,
         activeShoppingDate,
+        mealPlan.endDate,
         todayAtUtcMidnight,
       ),
     )
@@ -1567,10 +1568,79 @@ function getUtcToday(referenceDate = new Date()) {
   );
 }
 
+function getGeneratedEffectiveDates(item: ProjectedGeneratedShoppingItem) {
+  if (item.postponedUntilDate) {
+    return [item.postponedUntilDate];
+  }
+
+  return item.occurrences.map((occurrence) => occurrence.date);
+}
+
+function isDateOnOrAfterToday(date: Date, todayAtUtcMidnight: Date) {
+  return date.getTime() >= todayAtUtcMidnight.getTime();
+}
+
+function isGeneratedItemFullyPast(
+  item: ProjectedGeneratedShoppingItem,
+  todayAtUtcMidnight: Date,
+) {
+  const effectiveDates = getGeneratedEffectiveDates(item);
+
+  return effectiveDates.every(
+    (date) => date.getTime() < todayAtUtcMidnight.getTime(),
+  );
+}
+
+function isGeneratedItemInTripWindow(
+  item: ProjectedGeneratedShoppingItem,
+  activeShoppingDate: Date,
+  endDate: Date,
+  todayAtUtcMidnight: Date,
+) {
+  return getGeneratedEffectiveDates(item).some(
+    (date) =>
+      date.getTime() >= activeShoppingDate.getTime() &&
+      date.getTime() <= endDate.getTime() &&
+      isDateOnOrAfterToday(date, todayAtUtcMidnight),
+  );
+}
+
+function isGeneratedItemBeforeShoppingDate(
+  item: ProjectedGeneratedShoppingItem,
+  activeShoppingDate: Date,
+  endDate: Date,
+  todayAtUtcMidnight: Date,
+) {
+  if (isGeneratedItemFullyPast(item, todayAtUtcMidnight)) {
+    return false;
+  }
+
+  if (
+    isGeneratedItemInTripWindow(
+      item,
+      activeShoppingDate,
+      endDate,
+      todayAtUtcMidnight,
+    )
+  ) {
+    return false;
+  }
+
+  return getGeneratedEffectiveDates(item).some(
+    (date) =>
+      isDateOnOrAfterToday(date, todayAtUtcMidnight) &&
+      date.getTime() < activeShoppingDate.getTime(),
+  );
+}
+
 function isProjectedItemPast(
   item: ProjectedShoppingItem,
   todayAtUtcMidnight: Date,
 ) {
+  if (item.sourceType === "GENERATED") {
+    return isGeneratedItemFullyPast(item, todayAtUtcMidnight);
+  }
+
   const relevantDate = getProjectedItemRelevantDate(item);
 
   if (!relevantDate) {
@@ -1586,6 +1656,15 @@ function isProjectedItemInStoreModeTrip(
   endDate: Date,
   todayAtUtcMidnight: Date,
 ) {
+  if (item.sourceType === "GENERATED") {
+    return isGeneratedItemInTripWindow(
+      item,
+      activeShoppingDate,
+      endDate,
+      todayAtUtcMidnight,
+    );
+  }
+
   if (isProjectedItemPast(item, todayAtUtcMidnight)) {
     return false;
   }
@@ -1605,8 +1684,18 @@ function isProjectedItemInStoreModeTrip(
 function isProjectedItemBeforeShoppingDate(
   item: ProjectedShoppingItem,
   activeShoppingDate: Date,
+  endDate: Date,
   todayAtUtcMidnight: Date,
 ) {
+  if (item.sourceType === "GENERATED") {
+    return isGeneratedItemBeforeShoppingDate(
+      item,
+      activeShoppingDate,
+      endDate,
+      todayAtUtcMidnight,
+    );
+  }
+
   if (isProjectedItemPast(item, todayAtUtcMidnight)) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Store mode trip filtering now uses occurrence-aware dates for generated items instead of merged `firstDate`
- Shared ingredients that appear on both earlier days and the last day are included when Handledato is set to the plan end date
- Added regression tests for last-day merge, postponement, mid-week guard, and past-only exclusion

## Related issue
Closes #116

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual: multi-day plan with shared ingredients; set Handledato to last day in store mode and confirm full trip list

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (276 tests)
- npm run typecheck