### PR TITLE
Add recipe link from meal plan day selector

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,18 +2,16 @@
 
 ## Current Objective
 
-Issue #116 on branch `issue/116-last-day-shopping-items`: fix store-mode trip filtering so merged generated items appear when any occurrence falls within the active shopping window (especially last-day trips). Ready for PR review.
+Issue #118 on branch `issue/118-recipe-link-selector`: add a "Se oppskrift" link from each meal plan day row that reflects the currently selected recipe, including unsaved dropdown changes. Ready for PR review.
 
 ## Completed
 
-- Added occurrence-aware date helpers for generated shopping items in `shopping.server.ts`.
-- Refactored `isProjectedItemPast`, `isProjectedItemInStoreModeTrip`, and `isProjectedItemBeforeShoppingDate` to use effective occurrence dates instead of merged `firstDate`.
-- Added four regression tests in `shopping.server.test.ts` for last-day merge, postponement, mid-week guard, and past-only exclusion.
+- Made the recipe selector in `MealPlanDayRow` controlled with local state synced via `useEffect` on `entry.recipeId`.
+- Added conditional "Se oppskrift" link beneath the selector, styled like "Eksporter dag (.ics)", linking to `/families/:familyId/recipes/:recipeId`.
 
 ## Files To Read First
 
-- `app/lib/shopping.server.ts` - occurrence-aware store mode trip filters
-- `app/lib/shopping.server.test.ts` - new `getMealPlanStoreModeData` regression cases
+- `app/routes/family-meal-plan.tsx` - `MealPlanDayRow` controlled select and recipe link
 
 ## Validation
 
@@ -24,9 +22,9 @@ Issue #116 on branch `issue/116-last-day-shopping-items`: fix store-mode trip fi
 
 ## Open Items
 
-- Manual check: create a multi-day plan with shared ingredients; set Handledato to last day in store mode and confirm full ingredient set appears in trip list.
-- Out of scope: pantry/stock filtering and cross-plan manual `buyOnDate` behavior unchanged.
+- Manual check: change recipe in dropdown without saving and confirm link updates; clear selection and confirm link hides.
+- Out of scope: live summary blurb/tags still reflect saved `entry.recipeId` only.
 
 ## Next Step
 
-Merge PR (Closes #116) after review/CI.
+Merge PR (Closes #118) after review/CI.

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import {
   Form,
   Link,
@@ -1592,6 +1593,12 @@ function MealPlanDayRow({
   mealPlanId: string;
   recipes: MealPlanRecipeOption[];
 }) {
+  const [selectedRecipeId, setSelectedRecipeId] = useState(entry.recipeId);
+
+  useEffect(() => {
+    setSelectedRecipeId(entry.recipeId);
+  }, [entry.recipeId]);
+
   const selectedRecipe =
     recipes.find((recipe) => recipe.id === entry.recipeId) ?? null;
   const mealLabel = getMealDaySummaryLabel(entry, selectedRecipe);
@@ -1655,8 +1662,9 @@ function MealPlanDayRow({
           Oppskrift
           <select
             className="mt-2 box-border w-full max-w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-            defaultValue={entry.recipeId}
             name={`recipeId:${date}`}
+            onChange={(event) => setSelectedRecipeId(event.target.value)}
+            value={selectedRecipeId}
           >
             <option value="">Velg middag</option>
             {recipes.map((recipe) => (
@@ -1665,6 +1673,14 @@ function MealPlanDayRow({
               </option>
             ))}
           </select>
+          {selectedRecipeId ? (
+            <Link
+              className="mt-2 inline-flex w-full items-center justify-center rounded-2xl bg-white px-4 py-2 text-sm font-medium text-slate-700 ring-1 ring-slate-200 transition hover:bg-slate-100"
+              to={`/families/${familyId}/recipes/${selectedRecipeId}`}
+            >
+              Se oppskrift
+            </Link>
+          ) : null}
         </label>
 
         <label className="block min-w-0 text-sm font-medium text-slate-700">


### PR DESCRIPTION
## Summary
- Add a "Se oppskrift" link beneath each day's recipe selector on the meal plan editor
- Link reflects the currently selected recipe immediately, including unsaved dropdown changes, via a controlled select with local state

## Related issue
Closes #118

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Open draft meal plan with saved recipe → link navigates to recipe detail
- [ ] Change recipe without saving → link updates immediately
- [ ] Select "Velg middag" → link hides
- [ ] Save entries → link still correct after reload

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (276 tests)
- npm run typecheck