### PR TITLE
Add create-recipe entry point from meal plan editor

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,29 +2,32 @@
 
 ## Current Objective
 
-Issue #118 on branch `issue/118-recipe-link-selector`: add a "Se oppskrift" link from each meal plan day row that reflects the currently selected recipe, including unsaved dropdown changes. Ready for PR review.
+Issue #119 on branch `issue/119-create-recipe-from-meal-plan`: add an ADMIN-only create-recipe entry point from the meal plan editor, linking to the recipes page with return navigation. Ready for PR review.
 
 ## Completed
 
-- Made the recipe selector in `MealPlanDayRow` controlled with local state synced via `useEffect` on `entry.recipeId`.
-- Added conditional "Se oppskrift" link beneath the selector, styled like "Eksporter dag (.ics)", linking to `/families/:familyId/recipes/:recipeId`.
+- Added "Opprett ny oppskrift →" link below "Fyll tomme dager" in `family-meal-plan.tsx`, gated to ADMIN users.
+- Extended `family-recipes.tsx` with `returnTo` query param, `#create-recipe` anchor, back link, and post-create redirect to meal plan.
+- Added `recipe-created` notice on the meal plan page after returning from create.
+- Added action test for `returnTo` redirect path in `family-recipes.test.ts`.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan.tsx` - `MealPlanDayRow` controlled select and recipe link
+- `app/routes/family-meal-plan.tsx` - create link, notice, `buildCreateRecipeHref`
+- `app/routes/family-recipes.tsx` - returnTo loader/action, create section anchor
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (276 tests, 48 files)
+- `npm run test:run` — passed (277 tests, 48 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual check: change recipe in dropdown without saving and confirm link updates; clear selection and confirm link hides.
-- Out of scope: live summary blurb/tags still reflect saved `entry.recipeId` only.
+- Manual check: ADMIN sees link; MEMBER does not; end-to-end create flow returns to meal plan with new recipe in day selector.
+- New recipe is not auto-selected on a day (out of scope).
 
 ## Next Step
 
-Merge PR (Closes #118) after review/CI.
+Merge PR (Closes #119) after review/CI.

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -39,7 +39,8 @@ type MealPlanNotice =
   | "meal-plan-feedback-addressed"
   | "meal-plan-reopened"
   | "meal-plan-shared"
-  | "meal-plan-updated";
+  | "meal-plan-updated"
+  | "recipe-created";
 type MealPlanIntent =
   | "approve-meal-plan"
   | "auto-fill-meal-plan-entries"
@@ -527,6 +528,7 @@ export default function FamilyMealPlanRoute({
   }).length;
   const canAutoFillEntries =
     loaderData.mealPlan.status === "DRAFT" && emptyDayCount > 0;
+  const canManageRecipes = loaderData.userRole === "ADMIN";
   const titleValue = actionData?.values?.title ?? loaderData.mealPlan.title;
   const startDateValue =
     actionData?.values?.startDate ?? loaderData.mealPlan.startDate;
@@ -781,6 +783,18 @@ export default function FamilyMealPlanRoute({
                   : "Fyll tomme dager"}
               </button>
             </Form>
+
+            {canManageRecipes ? (
+              <Link
+                className="mt-3 inline-flex w-full items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-medium text-slate-900 transition hover:bg-slate-50"
+                to={buildCreateRecipeHref(
+                  loaderData.family.id,
+                  loaderData.mealPlan.id,
+                )}
+              >
+                Opprett ny oppskrift →
+              </Link>
+            ) : null}
           </article>
 
           <article className="min-w-0 w-full rounded-[28px] bg-white p-4 shadow-sm ring-1 ring-slate-200 sm:p-6">
@@ -971,7 +985,8 @@ function getMealPlanNotice(request: Request): MealPlanNotice | null {
     notice === "meal-plan-feedback-addressed" ||
     notice === "meal-plan-reopened" ||
     notice === "meal-plan-shared" ||
-    notice === "meal-plan-updated"
+    notice === "meal-plan-updated" ||
+    notice === "recipe-created"
   ) {
     return notice;
   }
@@ -1093,7 +1108,19 @@ function getMealPlanNoticeContent(
         description: "Endringene i navn og datointervall ble lagret.",
         title: "Ukeplan oppdatert",
       };
+    case "recipe-created":
+      return {
+        description:
+          "Oppskriften er tilgjengelig i middagsvelgeren for hver dag.",
+        title: "Oppskrift opprettet",
+      };
   }
+}
+
+function buildCreateRecipeHref(familyId: string, mealPlanId: string) {
+  const returnTo = `/families/${familyId}/meal-plans/${mealPlanId}`;
+
+  return `/families/${familyId}/recipes?returnTo=${encodeURIComponent(returnTo)}#create-recipe`;
 }
 
 interface MealPlanRecipeOption {

--- a/app/routes/family-recipes.test.ts
+++ b/app/routes/family-recipes.test.ts
@@ -137,4 +137,48 @@ describe("family recipes route", () => {
       "http://localhost/families/family-1/recipes/recipe-new?notice=recipe-created",
     );
   });
+
+  it("redirects to returnTo after create when provided", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseFamilyRecipeValues).mockReturnValue({
+      defaultServings: "",
+      description: "",
+      ingredients: [
+        {
+          amount: "",
+          categoryId: "category-dairy",
+          displayName: "Melk",
+          preferredStoreId: "",
+          unit: "",
+        },
+      ],
+      prepMinutes: "",
+      tags: "",
+      title: "Familiepai",
+    });
+    vi.mocked(createFamilyRecipe).mockResolvedValue({
+      recipe: {
+        id: "recipe-new",
+        title: "Familiepai",
+      },
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-recipe");
+    formData.set(
+      "returnTo",
+      "/families/family-1/meal-plans/meal-plan-1",
+    );
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: buildRequest("http://localhost/families/family-1/recipes", formData),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/meal-plan-1?notice=recipe-created",
+    );
+  });
 });

--- a/app/routes/family-recipes.tsx
+++ b/app/routes/family-recipes.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { Form, Link, isRouteErrorResponse, useNavigation } from "react-router";
 
-import { requireUser } from "../lib/auth.server";
+import { requireUser, getSafeRedirectTo } from "../lib/auth.server";
 import {
   filterRecipeList,
   hasActiveRecipeSearch,
@@ -62,6 +62,10 @@ export async function loader({
     familyRecipes: result.familyRecipes,
     globalRecipes: result.globalRecipes,
     notice: getRecipesNotice(request),
+    returnTo: getSafeRedirectTo(
+      new URL(request.url).searchParams.get("returnTo"),
+      "",
+    ),
     userRole: result.userRole,
   };
 }
@@ -94,6 +98,15 @@ export async function action({
         createValues: result.values,
         intent,
       } satisfies RecipesActionData;
+    }
+
+    const returnTo = getSafeRedirectTo(String(formData.get("returnTo") ?? ""), "");
+
+    if (returnTo) {
+      const url = new URL(returnTo, request.url);
+      url.searchParams.set("notice", "recipe-created");
+
+      return Response.redirect(url, 302);
     }
 
     const url = new URL(
@@ -169,6 +182,14 @@ export default function FamilyRecipesRoute({
             </div>
 
             <div className="flex flex-wrap gap-3">
+              {loaderData.returnTo ? (
+                <Link
+                  className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                  to={loaderData.returnTo}
+                >
+                  Tilbake til ukeplan
+                </Link>
+              ) : null}
               <Link
                 className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
                 to={`/families/${loaderData.family.id}/meal-plans`}
@@ -204,7 +225,10 @@ export default function FamilyRecipesRoute({
         ) : null}
 
         {canManageRecipes ? (
-          <section className="rounded-[28px] border-2 border-emerald-200 bg-white p-6 shadow-sm ring-1 ring-emerald-100">
+          <section
+            className="rounded-[28px] border-2 border-emerald-200 bg-white p-6 shadow-sm ring-1 ring-emerald-100"
+            id="create-recipe"
+          >
             <div className="flex flex-col gap-2">
               <span className="inline-flex w-fit rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
                 Familie — ny oppskrift
@@ -221,6 +245,13 @@ export default function FamilyRecipesRoute({
             <Form className="mt-6 space-y-4" method="post">
               <input name="intent" type="hidden" value="create-recipe" />
               <input name="ingredientIndex" type="hidden" value="0" />
+              {loaderData.returnTo ? (
+                <input
+                  name="returnTo"
+                  type="hidden"
+                  value={loaderData.returnTo}
+                />
+              ) : null}
               <label className="block text-sm font-medium text-slate-700">
                 Oppskriftstittel
                 <input


### PR DESCRIPTION
## Summary
- Add an ADMIN-only "Opprett ny oppskrift →" link below "Fyll tomme dager" on the meal plan editor, linking to the existing recipes create form.
- Support `returnTo` navigation so users can return to the meal plan after creation, with a success notice and refreshed recipe options in day selectors.

## Related issue
Closes #119

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] ADMIN sees create link on meal plan; MEMBER does not
- [ ] Click link → recipes page scrolled to create form with "Tilbake til ukeplan"
- [ ] Create recipe → redirects back to meal plan with notice; new recipe in day selector
- [ ] Direct recipes page create (no returnTo) still redirects to recipe detail

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck