### PR TITLE
Client-side quick-add for shopping items without page refresh

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,35 @@
 
 ## Current Objective
 
-Issue #119 on branch `issue/119-create-recipe-from-meal-plan`: add an ADMIN-only create-recipe entry point from the meal plan editor, linking to the recipes page with return navigation. Ready for PR review.
+Issue #121 on branch `issue/121-client-side-quick-add`: client-side quick-add for manual shopping items without full page refresh. Shipped via PR.
 
 ## Completed
 
-- Added "Opprett ny oppskrift →" link below "Fyll tomme dager" in `family-meal-plan.tsx`, gated to ADMIN users.
-- Extended `family-recipes.tsx` with `returnTo` query param, `#create-recipe` anchor, back link, and post-create redirect to meal plan.
-- Added `recipe-created` notice on the meal plan page after returning from create.
-- Added action test for `returnTo` redirect path in `family-recipes.test.ts`.
+- `ManualShoppingQuickAdd` uses dedicated `useFetcher` instead of `useSubmit`; inline validation errors; `onQuickAddSuccess` callback.
+- Quick-add actions return JSON `{ ok: true, item, recentManualItem }` instead of 302 redirects (meal-plan shopping, family shopping, store mode).
+- Write layer returns projected item after create via `projectCreatedManualShoppingItem` / `projectCreatedFamilyShoppingItem`.
+- Shared modules: `shopping-serialize.ts`, `shopping-quick-add.ts`, `shopping-list-client.ts`, `use-debounced-revalidate.ts`.
+- Parent routes maintain local list state and debounced background revalidation.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan.tsx` - create link, notice, `buildCreateRecipeHref`
-- `app/routes/family-recipes.tsx` - returnTo loader/action, create section anchor
+- `app/components/manual-shopping-quick-add.tsx`
+- `app/lib/shopping-list-client.ts`
+- `app/routes/family-meal-plan-shopping.tsx`
+- `app/routes/family-shopping.tsx`
+- `app/routes/family-meal-plan-store-mode.tsx`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (277 tests, 48 files)
+- `npm run test:run` — passed (282 tests, 49 files)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual check: ADMIN sees link; MEMBER does not; end-to-end create flow returns to meal plan with new recipe in day selector.
-- New recipe is not auto-selected on a day (out of scope).
+- Manual QA after merge: rapid adds on all three surfaces; no scroll jitter on mobile dock.
 
 ## Next Step
 
-Merge PR (Closes #119) after review/CI.
+Merge PR (Closes #121) after review/CI.

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { useFetcher, useNavigation, useSubmit } from "react-router";
+import { useFetcher } from "react-router";
 
+import type { QuickAddShoppingActionData, QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import { isQuickAddShoppingSuccess } from "../lib/shopping-quick-add";
 import type { RecentManualShoppingItem } from "../lib/shopping.server";
 
 export interface IngredientSearchResult {
@@ -19,6 +21,7 @@ interface ManualShoppingQuickAddProps {
   appearance?: ManualShoppingQuickAddAppearance;
   autoFocus?: boolean;
   ingredientSearchPath: string;
+  onQuickAddSuccess?: (payload: QuickAddShoppingSuccess) => void;
   quickAddIntent?: string;
   recentManualItems: RecentManualShoppingItem[];
   /**
@@ -35,6 +38,7 @@ const MIN_SEARCH_LENGTH = 2;
 const SEARCH_DEBOUNCE_MS = 250;
 const DEFAULT_QUICK_ADD_INTENT = "quick-add-manual-shopping-item";
 const DEFAULT_SEARCH_FETCHER_KEY = "manual-shopping-ingredient-search";
+const DEFAULT_QUICK_ADD_FETCHER_KEY = "manual-shopping-quick-add";
 
 const quickAddStyles = {
   default: {
@@ -45,6 +49,7 @@ const quickAddStyles = {
       "absolute z-10 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg",
     dropdownUp:
       "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg",
+    error: "text-sm text-rose-600",
     input:
       "min-w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100",
     label: "block text-sm font-medium text-slate-700",
@@ -66,6 +71,7 @@ const quickAddStyles = {
       "absolute z-10 max-h-64 w-full overflow-y-auto rounded-2xl border border-stone-200 bg-white py-2 shadow-lg",
     dropdownUp:
       "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-stone-200 bg-white py-2 shadow-lg",
+    error: "text-sm text-rose-600",
     input:
       "min-w-0 flex-1 rounded-2xl border border-stone-300 bg-stone-50 px-4 py-3 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60",
     label: "block text-sm font-medium text-stone-700",
@@ -88,6 +94,7 @@ export function ManualShoppingQuickAdd({
   appearance = "default",
   autoFocus = false,
   ingredientSearchPath,
+  onQuickAddSuccess,
   quickAddIntent = DEFAULT_QUICK_ADD_INTENT,
   recentManualItems,
   revealOnFocus = false,
@@ -95,8 +102,9 @@ export function ManualShoppingQuickAdd({
 }: ManualShoppingQuickAddProps) {
   const styles = quickAddStyles[appearance];
   const listboxId = useId();
-  const navigation = useNavigation();
-  const submit = useSubmit();
+  const quickAddFetcher = useFetcher<QuickAddShoppingActionData>({
+    key: DEFAULT_QUICK_ADD_FETCHER_KEY,
+  });
   const searchFetcher = useFetcher<ManualShoppingQuickAddLoaderSlice>({
     key: searchFetcherKey,
   });
@@ -107,15 +115,24 @@ export function ManualShoppingQuickAdd({
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const lastRequestedQueryRef = useRef<string | null>(null);
+  const lastHandledQuickAddDataRef = useRef<QuickAddShoppingActionData | null>(null);
   const searchFetcherRef = useRef(searchFetcher);
   searchFetcherRef.current = searchFetcher;
-  const pendingIntent = navigation.formData?.get("intent");
-  const isQuickAdding =
-    navigation.state === "submitting" && pendingIntent === quickAddIntent;
-
+  const onQuickAddSuccessRef = useRef(onQuickAddSuccess);
+  onQuickAddSuccessRef.current = onQuickAddSuccess;
+  const isQuickAdding = quickAddFetcher.state !== "idle";
   const trimmedQuery = query.trim();
-  const isSearching =
-    searchFetcher.state === "loading" && trimmedQuery.length >= MIN_SEARCH_LENGTH;
+  const quickAddActionData =
+    quickAddFetcher.data?.intent === quickAddIntent ? quickAddFetcher.data : undefined;
+  const quickAddFormError =
+    quickAddActionData && !isQuickAddShoppingSuccess(quickAddActionData)
+      ? quickAddActionData.formError
+      : undefined;
+  const quickAddNameError =
+    quickAddActionData && !isQuickAddShoppingSuccess(quickAddActionData)
+      ? quickAddActionData.manualFieldErrors?.name ??
+        quickAddActionData.familyFieldErrors?.name
+      : undefined;
 
   function submitQuickAdd(fields: {
     ingredientId?: string;
@@ -137,7 +154,7 @@ export function ManualShoppingQuickAdd({
       formData.set("recentNameNormalized", fields.recentNameNormalized);
     }
 
-    submit(formData, { method: "post" });
+    quickAddFetcher.submit(formData, { method: "post" });
   }
 
   useEffect(() => {
@@ -184,15 +201,20 @@ export function ManualShoppingQuickAdd({
   }, []);
 
   useEffect(() => {
-    if (!isQuickAdding) {
+    if (
+      !isQuickAddShoppingSuccess(quickAddFetcher.data) ||
+      quickAddFetcher.data === lastHandledQuickAddDataRef.current
+    ) {
       return;
     }
 
+    lastHandledQuickAddDataRef.current = quickAddFetcher.data;
     setIsListOpen(false);
     setIsInputFocused(false);
     setQuery("");
     lastRequestedQueryRef.current = null;
-  }, [isQuickAdding]);
+    onQuickAddSuccessRef.current?.(quickAddFetcher.data);
+  }, [quickAddFetcher.data]);
 
   useEffect(() => {
     if (!autoFocus) {
@@ -201,6 +223,9 @@ export function ManualShoppingQuickAdd({
 
     inputRef.current?.focus({ preventScroll: true });
   }, [autoFocus]);
+
+  const isSearching =
+    searchFetcher.state === "loading" && trimmedQuery.length >= MIN_SEARCH_LENGTH;
 
   const hasExactMatch = useMemo(
     () =>
@@ -249,6 +274,9 @@ export function ManualShoppingQuickAdd({
           Søk i ingrediensregisteret, skriv et nytt navn, eller velg en nylig brukt vare.
         </p>
       ) : null}
+
+      {quickAddFormError ? <p className={styles.error}>{quickAddFormError}</p> : null}
+      {quickAddNameError ? <p className={styles.error}>{quickAddNameError}</p> : null}
 
       {revealOnFocus && recentsBlock ? (
         <div

--- a/app/lib/family-shopping-write.server.test.ts
+++ b/app/lib/family-shopping-write.server.test.ts
@@ -14,6 +14,7 @@ const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
       },
       store: {
         findFirst: vi.fn(),
+        findMany: vi.fn(),
       },
     },
     requireFamilyMembershipMock: vi.fn(),
@@ -85,7 +86,10 @@ describe("family-shopping-write.server", () => {
       },
     });
 
-    expect(result).toEqual({ status: "CREATED" });
+    expect(result).toEqual({
+      familyItemId: "family-item-1",
+      status: "CREATED",
+    });
     expect(dbMock.familyShoppingItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -135,6 +139,22 @@ describe("family-shopping-write.server", () => {
       },
     });
     dbMock.familyShoppingItem.create.mockResolvedValue({ id: "family-item-1" });
+    dbMock.store.findMany.mockResolvedValue([]);
+    dbMock.familyShoppingItem.findFirst.mockResolvedValue({
+      category: {
+        displayName: "Annet",
+        id: "category-other",
+      },
+      categoryId: "category-other",
+      checked: false,
+      id: "family-item-1",
+      name: "Batterier",
+      note: null,
+      preferredStore: null,
+      preferredStoreId: null,
+      quantity: "1",
+      updatedAt: new Date("2026-05-31T00:00:00.000Z"),
+    });
 
     const { createQuickFamilyShoppingItem } = await import(
       "./family-shopping-write.server"
@@ -146,6 +166,30 @@ describe("family-shopping-write.server", () => {
       userId: "user-1",
     });
 
-    expect(result).toEqual({ status: "CREATED" });
+    expect(result).toEqual({
+      item: {
+        category: { id: "category-other", name: "Annet" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Batterier",
+        note: null,
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: {
+          displayName: "Annet",
+          sortOrder: expect.any(Number),
+        },
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+      recentManualItem: {
+        categoryId: "category-other",
+        displayName: "Batterier",
+        nameNormalized: "batterier",
+        quantity: "1",
+      },
+      status: "CREATED",
+    });
   });
 });

--- a/app/lib/family-shopping-write.server.ts
+++ b/app/lib/family-shopping-write.server.ts
@@ -7,6 +7,10 @@ import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import {
+  buildRecentManualItemFromProjectedItem,
+  projectCreatedFamilyShoppingItem,
+} from "./shopping.server";
+import {
   resolveQuickAddManualShoppingItemValues,
   type QuickAddManualShoppingItemInput,
 } from "./shopping-write.server";
@@ -71,11 +75,30 @@ export async function createQuickFamilyShoppingItem({
     };
   }
 
-  return createFamilyShoppingItem({
+  const createResult = await createFamilyShoppingItem({
     familyId,
     userId,
     values: resolvedValues.values,
   });
+
+  if (createResult.status !== "CREATED") {
+    return createResult;
+  }
+
+  const item = await projectCreatedFamilyShoppingItem({
+    familyId,
+    familyItemId: createResult.familyItemId,
+  });
+
+  if (!item) {
+    throw new Error("Fant ikke den nylig opprettede familiens handlelinje.");
+  }
+
+  return {
+    item,
+    recentManualItem: buildRecentManualItemFromProjectedItem(item),
+    status: "CREATED" as const,
+  };
 }
 
 export async function createFamilyShoppingItem({
@@ -106,7 +129,7 @@ export async function createFamilyShoppingItem({
   }
 
   try {
-    await db.familyShoppingItem.create({
+    const created = await db.familyShoppingItem.create({
       data: {
         categoryId: validation.values.categoryId,
         familyId,
@@ -128,6 +151,7 @@ export async function createFamilyShoppingItem({
     });
 
     return {
+      familyItemId: created.id,
       status: "CREATED" as const,
     };
   } catch (error) {

--- a/app/lib/shopping-list-client.test.ts
+++ b/app/lib/shopping-list-client.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  insertProjectedItemIntoSectionGroups,
+  insertProjectedItemIntoStoreGroups,
+  mergeQuickAddedItemsIntoList,
+  prependRecentManualItem,
+} from "./shopping-list-client";
+import type { SerializedProjectedShoppingItem } from "./shopping-serialize";
+
+function createFamilyItem(
+  overrides: {
+    category?: { id: string; name: string };
+    checked?: boolean;
+    collaborationVersion?: string;
+    name: string;
+    note?: string | null;
+    preferredStore?: { id: string; name: string } | null;
+    quantity?: string | null;
+    quantityLabel?: string | null;
+    section?: { displayName: string; sortOrder: number };
+    sourceKey: string;
+  },
+): SerializedProjectedShoppingItem {
+  return {
+    category: {
+      id: overrides.category?.id ?? "category-1",
+      name: overrides.category?.name ?? "Meieri",
+    },
+    checked: overrides.checked ?? false,
+    collaborationVersion: overrides.collaborationVersion ?? "2026-05-31T00:00:00.000Z",
+    name: overrides.name,
+    note: overrides.note ?? null,
+    preferredStore: ("preferredStore" in overrides
+      ? overrides.preferredStore
+      : {
+          id: "store-1",
+          name: "Rema",
+        }) as SerializedProjectedShoppingItem["preferredStore"],
+    quantity: overrides.quantity ?? "1",
+    quantityLabel: overrides.quantityLabel ?? "1",
+    section: overrides.section ?? {
+      displayName: "Meieri",
+      sortOrder: 1,
+    },
+    sourceKey: overrides.sourceKey,
+    sourceType: "FAMILY",
+  };
+}
+
+describe("shopping-list-client", () => {
+  it("inserts a new item into an existing store section", () => {
+    const existingItem = createFamilyItem({
+      name: "Brød",
+      sourceKey: "item-1",
+    });
+    const newItem = createFamilyItem({
+      name: "Melk",
+      sourceKey: "item-2",
+    });
+
+    const result = insertProjectedItemIntoStoreGroups(
+      [
+        {
+          store: existingItem.preferredStore,
+          sections: [
+            {
+              category: existingItem.category,
+              displayName: existingItem.section.displayName,
+              items: [existingItem],
+            },
+          ],
+        },
+      ],
+      newItem,
+    );
+
+    expect(result[0]?.sections[0]?.items.map((item) => item.sourceKey)).toEqual([
+      "item-1",
+      "item-2",
+    ]);
+  });
+
+  it("creates a new store group when needed", () => {
+    const newItem = createFamilyItem({
+      name: "Melk",
+      preferredStore: null,
+      sourceKey: "item-2",
+    });
+
+    const result = insertProjectedItemIntoStoreGroups([], newItem);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.store).toBeNull();
+    expect(result[0]?.sections[0]?.items[0]?.sourceKey).toBe("item-2");
+  });
+
+  it("inserts into section groups for store mode", () => {
+    const existingItem = createFamilyItem({
+      name: "Brød",
+      sourceKey: "item-1",
+    });
+    const newItem = createFamilyItem({
+      name: "Melk",
+      sourceKey: "item-2",
+    });
+
+    const result = insertProjectedItemIntoSectionGroups(
+      [
+        {
+          category: existingItem.category,
+          displayName: existingItem.section.displayName,
+          items: [existingItem],
+        },
+      ],
+      newItem,
+    );
+
+    expect(result[0]?.items.map((item) => item.sourceKey)).toEqual([
+      "item-1",
+      "item-2",
+    ]);
+  });
+
+  it("prepends recent manual items without duplicates", () => {
+    const result = prependRecentManualItem(
+      [
+        {
+          categoryId: "category-1",
+          displayName: "Brød",
+          nameNormalized: "brod",
+          quantity: "1",
+        },
+      ],
+      {
+        categoryId: "category-2",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "1",
+      },
+    );
+
+    expect(result.map((item) => item.nameNormalized)).toEqual(["melk", "brod"]);
+  });
+
+  it("merges quick-added items by source key", () => {
+    const loaderItem = createFamilyItem({
+      name: "Brød",
+      sourceKey: "item-1",
+    });
+    const quickAddedItem = createFamilyItem({
+      name: "Melk",
+      sourceKey: "item-2",
+    });
+
+    const result = mergeQuickAddedItemsIntoList([loaderItem], [quickAddedItem]);
+
+    expect(result.map((item) => item.sourceKey)).toEqual(["item-1", "item-2"]);
+  });
+});

--- a/app/lib/shopping-list-client.ts
+++ b/app/lib/shopping-list-client.ts
@@ -1,0 +1,167 @@
+import type { RecentManualShoppingItem } from "./shopping.server";
+import type { SerializedProjectedShoppingItem } from "./shopping-serialize";
+
+export interface SerializedProjectedShoppingSectionGroup {
+  category: {
+    id: string;
+    name: string;
+  };
+  displayName: string;
+  items: SerializedProjectedShoppingItem[];
+}
+
+export interface SerializedProjectedShoppingStoreGroup {
+  sections: SerializedProjectedShoppingSectionGroup[];
+  store: SerializedProjectedShoppingItem["preferredStore"];
+}
+
+function getStoreGroupKey(store: SerializedProjectedShoppingItem["preferredStore"]) {
+  return store?.id ?? "__no-store__";
+}
+
+function getSectionKey(item: SerializedProjectedShoppingItem) {
+  return `${item.category.id}:${item.section.displayName}`;
+}
+
+function compareSerializedItemsByName(
+  left: SerializedProjectedShoppingItem,
+  right: SerializedProjectedShoppingItem,
+) {
+  const nameComparison = left.name.localeCompare(right.name, "nb");
+
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  return left.sourceKey.localeCompare(right.sourceKey, "nb");
+}
+
+function appendItemToSection(
+  section: SerializedProjectedShoppingSectionGroup,
+  item: SerializedProjectedShoppingItem,
+) {
+  if (section.items.some((existingItem) => existingItem.sourceKey === item.sourceKey)) {
+    return section;
+  }
+
+  return {
+    ...section,
+    items: [...section.items, item].sort(compareSerializedItemsByName),
+  };
+}
+
+export function insertProjectedItemIntoStoreGroups(
+  groups: SerializedProjectedShoppingStoreGroup[],
+  item: SerializedProjectedShoppingItem,
+): SerializedProjectedShoppingStoreGroup[] {
+  const storeKey = getStoreGroupKey(item.preferredStore);
+  const sectionKey = getSectionKey(item);
+  const existingStoreGroupIndex = groups.findIndex(
+    (group) => getStoreGroupKey(group.store) === storeKey,
+  );
+
+  if (existingStoreGroupIndex === -1) {
+    return [
+      ...groups,
+      {
+        store: item.preferredStore,
+        sections: [
+          {
+            category: item.category,
+            displayName: item.section.displayName,
+            items: [item],
+          },
+        ],
+      },
+    ];
+  }
+
+  return groups.map((group, index) => {
+    if (index !== existingStoreGroupIndex) {
+      return group;
+    }
+
+    const existingSectionIndex = group.sections.findIndex(
+      (section) =>
+        `${section.category.id}:${section.displayName}` === sectionKey,
+    );
+
+    if (existingSectionIndex === -1) {
+      return {
+        ...group,
+        sections: [
+          ...group.sections,
+          {
+            category: item.category,
+            displayName: item.section.displayName,
+            items: [item],
+          },
+        ],
+      };
+    }
+
+    return {
+      ...group,
+      sections: group.sections.map((section, sectionIndex) =>
+        sectionIndex === existingSectionIndex
+          ? appendItemToSection(section, item)
+          : section,
+      ),
+    };
+  });
+}
+
+export function insertProjectedItemIntoSectionGroups(
+  sections: SerializedProjectedShoppingSectionGroup[],
+  item: SerializedProjectedShoppingItem,
+): SerializedProjectedShoppingSectionGroup[] {
+  const sectionKey = getSectionKey(item);
+  const existingSectionIndex = sections.findIndex(
+    (section) => `${section.category.id}:${section.displayName}` === sectionKey,
+  );
+
+  if (existingSectionIndex === -1) {
+    return [
+      ...sections,
+      {
+        category: item.category,
+        displayName: item.section.displayName,
+        items: [item],
+      },
+    ];
+  }
+
+  return sections.map((section, index) =>
+    index === existingSectionIndex ? appendItemToSection(section, item) : section,
+  );
+}
+
+export function prependRecentManualItem(
+  recents: RecentManualShoppingItem[],
+  recentManualItem: RecentManualShoppingItem,
+  limit = 10,
+): RecentManualShoppingItem[] {
+  return [
+    recentManualItem,
+    ...recents.filter(
+      (item) => item.nameNormalized !== recentManualItem.nameNormalized,
+    ),
+  ].slice(0, limit);
+}
+
+export function mergeQuickAddedItemsIntoList<T extends { sourceKey: string }>(
+  loaderItems: T[],
+  quickAddedItems: T[],
+): T[] {
+  const mergedItems = [...loaderItems];
+
+  for (const item of quickAddedItems) {
+    if (mergedItems.some((existingItem) => existingItem.sourceKey === item.sourceKey)) {
+      continue;
+    }
+
+    mergedItems.push(item);
+  }
+
+  return mergedItems;
+}

--- a/app/lib/shopping-quick-add.ts
+++ b/app/lib/shopping-quick-add.ts
@@ -1,0 +1,32 @@
+import type { FamilyShoppingItemFieldErrors } from "./family-shopping-write.server";
+import type { RecentManualShoppingItem } from "./shopping.server";
+import type { SerializedProjectedShoppingItem } from "./shopping-serialize";
+import type { ManualShoppingItemFieldErrors } from "./shopping-write.server";
+
+export type QuickAddShoppingIntent =
+  | "quick-add-manual-shopping-item"
+  | "quick-add-family-shopping-item";
+
+export type QuickAddShoppingSuccess = {
+  intent: QuickAddShoppingIntent;
+  item: SerializedProjectedShoppingItem;
+  ok: true;
+  recentManualItem: RecentManualShoppingItem;
+};
+
+export type QuickAddShoppingError = {
+  familyFieldErrors?: FamilyShoppingItemFieldErrors;
+  formError?: string;
+  intent: QuickAddShoppingIntent;
+  manualFieldErrors?: ManualShoppingItemFieldErrors;
+};
+
+export type QuickAddShoppingActionData =
+  | QuickAddShoppingSuccess
+  | QuickAddShoppingError;
+
+export function isQuickAddShoppingSuccess(
+  data: QuickAddShoppingActionData | undefined,
+): data is QuickAddShoppingSuccess {
+  return Boolean(data && "ok" in data && data.ok === true);
+}

--- a/app/lib/shopping-serialize.ts
+++ b/app/lib/shopping-serialize.ts
@@ -1,0 +1,34 @@
+import { ShoppingItemSource } from "@prisma/client";
+
+import { formatDateOnly } from "./meal-plan-dates";
+import type { ProjectedShoppingItem } from "./shopping.server";
+
+export function serializeProjectedShoppingItem(item: ProjectedShoppingItem) {
+  if (item.sourceType === "FAMILY") {
+    return item;
+  }
+
+  if (item.sourceType === ShoppingItemSource.GENERATED) {
+    return {
+      ...item,
+      firstDate: formatDateOnly(item.firstDate),
+      lastDate: formatDateOnly(item.lastDate),
+      occurrences: item.occurrences.map((occurrence) => ({
+        ...occurrence,
+        date: formatDateOnly(occurrence.date),
+      })),
+      postponedUntilDate: item.postponedUntilDate
+        ? formatDateOnly(item.postponedUntilDate)
+        : null,
+    };
+  }
+
+  return {
+    ...item,
+    buyOnDate: item.buyOnDate ? formatDateOnly(item.buyOnDate) : null,
+  };
+}
+
+export type SerializedProjectedShoppingItem = ReturnType<
+  typeof serializeProjectedShoppingItem
+>;

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -6,6 +6,7 @@ const {
   getFamilyStockMatchSetMock,
   getStockIngredientsForMealPlanMock,
   loadShoppingMealPlanMock,
+  projectCreatedManualShoppingItemMock,
   requireFamilyMembershipMock,
   transactionMock,
 } = vi.hoisted(() => {
@@ -57,6 +58,7 @@ const {
     getFamilyStockMatchSetMock: vi.fn(),
     getStockIngredientsForMealPlanMock: vi.fn(),
     loadShoppingMealPlanMock: vi.fn(),
+    projectCreatedManualShoppingItemMock: vi.fn(),
     requireFamilyMembershipMock: vi.fn(),
     transactionMock,
   };
@@ -83,8 +85,19 @@ vi.mock("./write-observability.server", () => {
 
 vi.mock("./shopping.server", () => {
   return {
+    buildRecentManualItemFromProjectedItem: (item: {
+      category: { id: string };
+      name: string;
+      quantity: string | null;
+    }) => ({
+      categoryId: item.category.id,
+      displayName: item.name.trim(),
+      nameNormalized: item.name.trim().toLowerCase(),
+      quantity: item.quantity?.trim() || "1",
+    }),
     getStockIngredientsForMealPlan: getStockIngredientsForMealPlanMock,
     loadShoppingMealPlan: loadShoppingMealPlanMock,
+    projectCreatedManualShoppingItem: projectCreatedManualShoppingItemMock,
   };
 });
 
@@ -182,6 +195,9 @@ describe("shopping-write.server", () => {
     dbMock.store.findFirst.mockResolvedValue({
       id: "store-1",
     });
+    dbMock.manualShoppingItem.create.mockResolvedValue({
+      id: "manual-item-1",
+    });
 
     const result = await createManualShoppingItem({
       familyId: "family-1",
@@ -198,6 +214,7 @@ describe("shopping-write.server", () => {
     });
 
     expect(result).toEqual({
+      manualItemId: "manual-item-1",
       status: "CREATED",
     });
     expect(dbMock.manualShoppingItem.create).toHaveBeenCalledWith({
@@ -229,6 +246,9 @@ describe("shopping-write.server", () => {
       id: "category-produce",
     });
     dbMock.store.findFirst.mockResolvedValue(null);
+    dbMock.manualShoppingItem.create.mockResolvedValue({
+      id: "manual-item-2",
+    });
 
     const result = await createManualShoppingItem({
       familyId: "family-1",
@@ -245,6 +265,7 @@ describe("shopping-write.server", () => {
     });
 
     expect(result).toEqual({
+      manualItemId: "manual-item-2",
       status: "CREATED",
     });
     expect(dbMock.manualShoppingItem.create).toHaveBeenCalledWith({
@@ -320,6 +341,24 @@ describe("shopping-write.server", () => {
     dbMock.ingredientCategory.findUnique.mockResolvedValue({
       id: "category-other",
     });
+    dbMock.manualShoppingItem.create.mockResolvedValue({
+      id: "manual-item-3",
+    });
+    projectCreatedManualShoppingItemMock.mockResolvedValue({
+      buyOnDate: null,
+      category: { id: "category-other", name: "Annet" },
+      checked: false,
+      collaborationVersion: "2026-05-31T00:00:00.000Z",
+      name: "Tannkrem",
+      note: null,
+      overrideVersion: "",
+      preferredStore: null,
+      quantity: "1",
+      quantityLabel: "1",
+      section: { displayName: "Annet", sortOrder: 99 },
+      sourceKey: "manual-item-3",
+      sourceType: "MANUAL",
+    });
 
     const result = await createQuickManualShoppingItem({
       familyId: "family-1",
@@ -331,6 +370,27 @@ describe("shopping-write.server", () => {
     });
 
     expect(result).toEqual({
+      item: {
+        buyOnDate: null,
+        category: { id: "category-other", name: "Annet" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Tannkrem",
+        note: null,
+        overrideVersion: "",
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Annet", sortOrder: 99 },
+        sourceKey: "manual-item-3",
+        sourceType: "MANUAL",
+      },
+      recentManualItem: {
+        categoryId: "category-other",
+        displayName: "Tannkrem",
+        nameNormalized: "tannkrem",
+        quantity: "1",
+      },
       status: "CREATED",
     });
     expect(dbMock.manualShoppingItem.create).toHaveBeenCalledWith({

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -9,8 +9,10 @@ import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import {
+  buildRecentManualItemFromProjectedItem,
   getStockIngredientsForMealPlan,
   loadShoppingMealPlan,
+  projectCreatedManualShoppingItem,
 } from "./shopping.server";
 import { getFamilyStockMatchSet } from "./stock.server";
 import { logCollaborationFailure, logCollaborationWrite } from "./write-observability.server";
@@ -80,12 +82,34 @@ export async function createQuickManualShoppingItem({
     };
   }
 
-  return createManualShoppingItem({
+  const createResult = await createManualShoppingItem({
     familyId,
     mealPlanId,
     userId,
     values: resolvedValues.values,
   });
+
+  if (createResult.status !== "CREATED") {
+    return createResult;
+  }
+
+  const item = await projectCreatedManualShoppingItem({
+    familyId,
+    manualItemId: createResult.manualItemId,
+    mealPlanId,
+  });
+
+  if (!item) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  return {
+    item,
+    recentManualItem: buildRecentManualItemFromProjectedItem(item),
+    status: "CREATED" as const,
+  };
 }
 
 export async function createManualShoppingItem({
@@ -126,7 +150,7 @@ export async function createManualShoppingItem({
   }
 
   try {
-    await db.manualShoppingItem.create({
+    const created = await db.manualShoppingItem.create({
       data: {
         buyOnDate: validation.buyOnDate,
         categoryId: validation.values.categoryId,
@@ -150,6 +174,7 @@ export async function createManualShoppingItem({
     });
 
     return {
+      manualItemId: created.id,
       status: "CREATED" as const,
     };
   } catch (error) {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -121,6 +121,10 @@ type FamilyShoppingItemRow = Prisma.FamilyShoppingItemGetPayload<{
   select: typeof familyShoppingItemSelect;
 }>;
 
+type ManualShoppingItemRow = Prisma.ManualShoppingItemGetPayload<{
+  select: typeof manualShoppingItemSelect;
+}>;
+
 export const shoppingMealPlanSelect = Prisma.validator<Prisma.MealPlanSelect>()({
   activeShoppingDate: true,
   endDate: true,
@@ -540,33 +544,104 @@ export function projectFamilyShoppingItems({
 }) {
   const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
 
-  return items.map((item) => {
-    const preferredStore = item.preferredStore;
-    const section = resolveStoreSection({
-      category: {
-        id: item.category.id,
-        name: item.category.displayName,
-      },
-      preferredStore,
+  return items.map((item) =>
+    projectSingleFamilyShoppingItemRow({
+      item,
       storeSectionsByStoreId,
-    });
+    }),
+  );
+}
 
-    return {
-      category: {
-        id: item.category.id,
-        name: item.category.displayName,
+export function buildRecentManualItemFromProjectedItem(
+  item: Pick<ProjectedFamilyShoppingItem | ProjectedManualShoppingItem, "category" | "name" | "quantity">,
+): RecentManualShoppingItem {
+  const displayName = item.name.trim();
+
+  return {
+    categoryId: item.category.id,
+    displayName,
+    nameNormalized: normalizeIngredientCanonicalName(displayName),
+    quantity: item.quantity?.trim() || "1",
+  };
+}
+
+async function loadShoppingStoresForFamily(familyId: string) {
+  return db.store.findMany({
+    orderBy: [{ name: "asc" }],
+    select: shoppingStoreSelect,
+    where: {
+      OR: [{ familyId: null }, { familyId }],
+    },
+  });
+}
+
+export async function projectCreatedManualShoppingItem({
+  familyId,
+  manualItemId,
+  mealPlanId,
+}: {
+  familyId: string;
+  manualItemId: string;
+  mealPlanId: string;
+}) {
+  const [stores, item, override] = await Promise.all([
+    loadShoppingStoresForFamily(familyId),
+    db.manualShoppingItem.findFirst({
+      select: manualShoppingItemSelect,
+      where: {
+        id: manualItemId,
+        mealPlan: {
+          familyId,
+          id: mealPlanId,
+        },
       },
-      checked: item.checked,
-      collaborationVersion: item.updatedAt.toISOString(),
-      name: item.name,
-      note: item.note,
-      preferredStore,
-      quantity: item.quantity,
-      quantityLabel: buildManualQuantityLabel(item.quantity),
-      section,
-      sourceKey: item.id,
-      sourceType: "FAMILY",
-    } satisfies ProjectedFamilyShoppingItem;
+    }),
+    db.shoppingItemOverride.findFirst({
+      select: shoppingOverrideSelect,
+      where: {
+        mealPlanId,
+        sourceKey: manualItemId,
+        sourceType: ShoppingItemSource.MANUAL,
+      },
+    }),
+  ]);
+
+  if (!item) {
+    return null;
+  }
+
+  return projectSingleManualShoppingItemRow({
+    item,
+    override,
+    stores,
+  });
+}
+
+export async function projectCreatedFamilyShoppingItem({
+  familyId,
+  familyItemId,
+}: {
+  familyId: string;
+  familyItemId: string;
+}) {
+  const [stores, item] = await Promise.all([
+    loadShoppingStoresForFamily(familyId),
+    db.familyShoppingItem.findFirst({
+      select: familyShoppingItemSelect,
+      where: {
+        familyId,
+        id: familyItemId,
+      },
+    }),
+  ]);
+
+  if (!item) {
+    return null;
+  }
+
+  return projectSingleFamilyShoppingItemRow({
+    item,
+    storeSectionsByStoreId: buildStoreSectionsByStoreId(stores),
   });
 }
 
@@ -1130,6 +1205,81 @@ function buildIncludeDespiteStockKeys(overrides: ShoppingOverride[]) {
   );
 }
 
+function projectSingleFamilyShoppingItemRow({
+  item,
+  storeSectionsByStoreId,
+}: {
+  item: FamilyShoppingItemRow;
+  storeSectionsByStoreId: Map<string, Map<string, StoreSectionSummary>>;
+}) {
+  const preferredStore = item.preferredStore;
+  const section = resolveStoreSection({
+    category: {
+      id: item.category.id,
+      name: item.category.displayName,
+    },
+    preferredStore,
+    storeSectionsByStoreId,
+  });
+
+  return {
+    category: {
+      id: item.category.id,
+      name: item.category.displayName,
+    },
+    checked: item.checked,
+    collaborationVersion: item.updatedAt.toISOString(),
+    name: item.name,
+    note: item.note,
+    preferredStore,
+    quantity: item.quantity,
+    quantityLabel: buildManualQuantityLabel(item.quantity),
+    section,
+    sourceKey: item.id,
+    sourceType: "FAMILY",
+  } satisfies ProjectedFamilyShoppingItem;
+}
+
+function projectSingleManualShoppingItemRow({
+  item,
+  override,
+  stores,
+}: {
+  item: ManualShoppingItemRow;
+  override?: ShoppingOverride | null;
+  stores: ShoppingStore[];
+}) {
+  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
+  const preferredStore = item.preferredStore;
+  const section = resolveStoreSection({
+    category: {
+      id: item.category.id,
+      name: item.category.displayName,
+    },
+    preferredStore,
+    storeSectionsByStoreId,
+  });
+
+  return {
+    buyOnDate: item.buyOnDate,
+    category: {
+      id: item.category.id,
+      name: item.category.displayName,
+    },
+    checked: override?.checked ?? false,
+    collaborationVersion: item.updatedAt?.toISOString() ?? "",
+    name: item.name,
+    note: item.note,
+    overrideVersion: override?.updatedAt?.toISOString() ?? "",
+    preferredStore,
+    quantity: item.quantity,
+    quantityLabel: buildManualQuantityLabel(item.quantity),
+    section,
+    sourceKey: item.id,
+    sourceType: ShoppingItemSource.MANUAL,
+  } satisfies ProjectedManualShoppingItem;
+}
+
 function projectManualShoppingItems({
   mealPlan,
   stores,
@@ -1137,43 +1287,18 @@ function projectManualShoppingItems({
   mealPlan: ShoppingMealPlan;
   stores: ShoppingStore[];
 }) {
-  const storeSectionsByStoreId = buildStoreSectionsByStoreId(stores);
   const overrideBySourceKey = buildOverrideMap(
     mealPlan.shoppingOverrides,
     ShoppingItemSource.MANUAL,
   );
 
-  return mealPlan.manualShoppingItems.map((item) => {
-    const override = overrideBySourceKey.get(item.id);
-    const preferredStore = item.preferredStore;
-    const section = resolveStoreSection({
-      category: {
-        id: item.category.id,
-        name: item.category.displayName,
-      },
-      preferredStore,
-      storeSectionsByStoreId,
-    });
-
-    return {
-      buyOnDate: item.buyOnDate,
-      category: {
-        id: item.category.id,
-        name: item.category.displayName,
-      },
-      checked: override?.checked ?? false,
-      collaborationVersion: item.updatedAt?.toISOString() ?? "",
-      name: item.name,
-      note: item.note,
-      overrideVersion: override?.updatedAt?.toISOString() ?? "",
-      preferredStore,
-      quantity: item.quantity,
-      quantityLabel: buildManualQuantityLabel(item.quantity),
-      section,
-      sourceKey: item.id,
-      sourceType: ShoppingItemSource.MANUAL,
-    } satisfies ProjectedManualShoppingItem;
-  });
+  return mealPlan.manualShoppingItems.map((item) =>
+    projectSingleManualShoppingItemRow({
+      item,
+      override: overrideBySourceKey.get(item.id),
+      stores,
+    }),
+  );
 }
 
 function buildProjectedStoreGroups(

--- a/app/lib/use-debounced-revalidate.ts
+++ b/app/lib/use-debounced-revalidate.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useDebouncedRevalidate(
+  revalidate: () => void,
+  delayMs = 600,
+) {
+  const timeoutRef = useRef<number | null>(null);
+  const revalidateRef = useRef(revalidate);
+  revalidateRef.current = revalidate;
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = null;
+      revalidateRef.current();
+    }, delayMs);
+  }, [delayMs]);
+}

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -547,9 +547,30 @@ describe("family meal plan shopping route", () => {
     expect((response as Response).status).toBe(302);
   });
 
-  it("redirects after a quick-add manual shopping item", async () => {
+  it("returns quick-add success data without redirecting", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(createQuickManualShoppingItem).mockResolvedValue({
+      item: {
+        buyOnDate: null,
+        category: { id: "category-other", name: "Annet" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Tannkrem",
+        note: null,
+        overrideVersion: "",
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Annet", sortOrder: 99 },
+        sourceKey: "manual-item-1",
+        sourceType: "MANUAL",
+      },
+      recentManualItem: {
+        categoryId: "category-other",
+        displayName: "Tannkrem",
+        nameNormalized: "tannkrem",
+        quantity: "1",
+      },
       status: "CREATED",
     });
 
@@ -557,7 +578,7 @@ describe("family meal plan shopping route", () => {
     formData.set("intent", "quick-add-manual-shopping-item");
     formData.set("name", "Tannkrem");
 
-    const response = await action({
+    const result = await action({
       params: {
         familyId: "family-1",
         mealPlanId: "meal-plan-1",
@@ -578,8 +599,31 @@ describe("family meal plan shopping route", () => {
       mealPlanId: "meal-plan-1",
       userId: "user-1",
     });
-    expect(response).toBeInstanceOf(Response);
-    expect((response as Response).status).toBe(302);
+    expect(result).toEqual({
+      intent: "quick-add-manual-shopping-item",
+      item: {
+        buyOnDate: null,
+        category: { id: "category-other", name: "Annet" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Tannkrem",
+        note: null,
+        overrideVersion: "",
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Annet", sortOrder: 99 },
+        sourceKey: "manual-item-1",
+        sourceType: "MANUAL",
+      },
+      ok: true,
+      recentManualItem: {
+        categoryId: "category-other",
+        displayName: "Tannkrem",
+        nameNormalized: "tannkrem",
+        quantity: "1",
+      },
+    });
   });
 
   it("returns manual item validation errors from the server module", async () => {

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1,9 +1,11 @@
 import { ShoppingItemSource } from "@prisma/client";
+import { useCallback, useEffect, useState } from "react";
 import {
   Form,
   Link,
   isRouteErrorResponse,
   useNavigation,
+  useRevalidator,
   type MetaFunction,
 } from "react-router";
 
@@ -20,8 +22,15 @@ import {
 } from "../components/shopping-list-item-expanded";
 import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
+  insertProjectedItemIntoStoreGroups,
+  prependRecentManualItem,
+} from "../lib/shopping-list-client";
+import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import { serializeProjectedShoppingItem } from "../lib/shopping-serialize";
+import {
   getMealPlanShoppingData,
   listRecentManualShoppingItemsForFamily,
+  type RecentManualShoppingItem,
 } from "../lib/shopping.server";
 import { toggleFamilyShoppingItemChecked } from "../lib/family-shopping-write.server";
 import {
@@ -39,6 +48,7 @@ import {
   type ManualShoppingItemFieldErrors,
   type ManualShoppingItemValues,
 } from "../lib/shopping-write.server";
+import { useDebouncedRevalidate } from "../lib/use-debounced-revalidate";
 
 type ShoppingNotice =
   | "generated-shopping-item-excluded"
@@ -67,13 +77,16 @@ interface ShoppingActionData {
   formError?: string;
   generatedOverrideFieldErrors?: GeneratedShoppingItemOverrideFieldErrors;
   intent?: ShoppingIntent;
+  item?: QuickAddShoppingSuccess["item"];
   itemTarget?: {
     sourceKey: string;
     sourceType: ShoppingItemSource;
   };
   manualFieldErrors?: ManualShoppingItemFieldErrors;
   manualValues?: ManualShoppingItemValues;
+  ok?: true;
   overrideValues?: GeneratedShoppingItemOverrideValues;
+  recentManualItem?: RecentManualShoppingItem;
 }
 
 interface FamilyMealPlanShoppingRouteProps {
@@ -249,12 +262,12 @@ export async function action({
       } satisfies ShoppingActionData;
     }
 
-    return buildShoppingRedirect({
-      familyId,
-      mealPlanId,
-      notice: "manual-shopping-item-added",
-      request,
-    });
+    return {
+      intent,
+      item: serializeProjectedShoppingItem(result.item),
+      ok: true,
+      recentManualItem: result.recentManualItem,
+    } satisfies ShoppingActionData;
   }
 
   if (intent === "update-manual-shopping-item") {
@@ -594,18 +607,40 @@ export default function FamilyMealPlanShoppingRoute({
   loaderData,
 }: FamilyMealPlanShoppingRouteProps) {
   const navigation = useNavigation();
+  const revalidator = useRevalidator();
+  const scheduleRevalidate = useDebouncedRevalidate(revalidator.revalidate);
   const pendingIntent = navigation.formData?.get("intent");
   const pendingSourceKey = getPendingSourceKey(navigation.formData);
+  const [storeGroups, setStoreGroups] = useState(loaderData.storeGroups);
+  const [recentManualItems, setRecentManualItems] = useState(
+    loaderData.recentManualItems,
+  );
   const addManualValues =
-    (actionData?.intent === "add-manual-shopping-item" ||
-      actionData?.intent === "quick-add-manual-shopping-item") &&
-    actionData.manualValues
+    actionData?.intent === "add-manual-shopping-item" && actionData.manualValues
       ? actionData.manualValues
       : defaultManualShoppingItemValues;
   const ingredientSearchPath = `/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}/shopping/ingredient-search`;
   const noticeContent = loaderData.notice
     ? getShoppingNoticeContent(loaderData.notice)
     : null;
+
+  useEffect(() => {
+    setStoreGroups(loaderData.storeGroups);
+    setRecentManualItems(loaderData.recentManualItems);
+  }, [loaderData.recentManualItems, loaderData.storeGroups]);
+
+  const handleQuickAddSuccess = useCallback(
+    (payload: QuickAddShoppingSuccess) => {
+      setStoreGroups((currentGroups) =>
+        insertProjectedItemIntoStoreGroups(currentGroups, payload.item),
+      );
+      setRecentManualItems((currentRecents) =>
+        prependRecentManualItem(currentRecents, payload.recentManualItem),
+      );
+      scheduleRevalidate();
+    },
+    [scheduleRevalidate],
+  );
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -909,13 +944,7 @@ export default function FamilyMealPlanShoppingRoute({
               </p>
             </div>
 
-            {actionData?.intent === "quick-add-manual-shopping-item" &&
-            actionData.formError ? (
-              <p className="mt-4 text-sm text-rose-600">
-                {actionData.formError}
-              </p>
-            ) : null}
-            {actionData?.intent === "quick-add-manual-shopping-item" &&
+            {actionData?.intent === "add-manual-shopping-item" &&
             actionData.manualFieldErrors?.name ? (
               <p className="mt-2 text-sm text-rose-600">
                 {actionData.manualFieldErrors.name}
@@ -925,7 +954,8 @@ export default function FamilyMealPlanShoppingRoute({
             <div className="mt-6">
               <ManualShoppingQuickAdd
                 ingredientSearchPath={ingredientSearchPath}
-                recentManualItems={loaderData.recentManualItems}
+                onQuickAddSuccess={handleQuickAddSuccess}
+                recentManualItems={recentManualItems}
               />
             </div>
 
@@ -1157,9 +1187,9 @@ export default function FamilyMealPlanShoppingRoute({
           </section>
         ) : null}
 
-        {loaderData.storeGroups.length ? (
+        {storeGroups.length ? (
           <section className="grid gap-6">
-            {loaderData.storeGroups.map((group) => (
+            {storeGroups.map((group) => (
               <article
                 key={group.store?.id ?? "no-store"}
                 className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200"
@@ -1459,38 +1489,6 @@ function requireRouteParam(value: string | undefined, message: string) {
   }
 
   return value;
-}
-
-function serializeProjectedShoppingItem(
-  item: Awaited<
-    ReturnType<typeof getMealPlanShoppingData>
-  >["projectedItems"][number] | Awaited<
-    ReturnType<typeof getMealPlanShoppingData>
-  >["familyStoreGroups"][number]["sections"][number]["items"][number],
-) {
-  if (item.sourceType === "FAMILY") {
-    return item;
-  }
-
-  if (item.sourceType === ShoppingItemSource.GENERATED) {
-    return {
-      ...item,
-      firstDate: formatDateOnly(item.firstDate),
-      lastDate: formatDateOnly(item.lastDate),
-      occurrences: item.occurrences.map((occurrence) => ({
-        ...occurrence,
-        date: formatDateOnly(occurrence.date),
-      })),
-      postponedUntilDate: item.postponedUntilDate
-        ? formatDateOnly(item.postponedUntilDate)
-        : null,
-    };
-  }
-
-  return {
-    ...item,
-    buyOnDate: item.buyOnDate ? formatDateOnly(item.buyOnDate) : null,
-  };
 }
 
 function parseExpectedUpdatedAt(formData: FormData) {

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -262,7 +262,7 @@ describe("family meal plan store mode route", () => {
     });
   });
 
-  it("redirects after a family quick-add", async () => {
+  it("returns quick-add success data without redirecting", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
       ingredientId: "ingredient-1",
@@ -270,6 +270,25 @@ describe("family meal plan store mode route", () => {
       recentNameNormalized: "",
     });
     vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
+      item: {
+        category: { id: "category-dairy", name: "Meieri" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Melk",
+        note: null,
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Meieri", sortOrder: 1 },
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+      recentManualItem: {
+        categoryId: "category-dairy",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "1",
+      },
       status: "CREATED",
     });
 
@@ -294,10 +313,29 @@ describe("family meal plan store mode route", () => {
       },
       userId: "user-1",
     });
-    expect(result).toBeInstanceOf(Response);
-    expect((result as Response).headers.get("Location")).toBe(
-      "http://localhost/families/family-1/meal-plans/meal-plan-1/store-mode?notice=family-shopping-item-added",
-    );
+    expect(result).toEqual({
+      intent: "quick-add-family-shopping-item",
+      item: {
+        category: { id: "category-dairy", name: "Meieri" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Melk",
+        note: null,
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Meieri", sortOrder: 1 },
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+      ok: true,
+      recentManualItem: {
+        categoryId: "category-dairy",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "1",
+      },
+    });
   });
 
   it("returns quick-add validation errors without redirecting", async () => {

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -35,8 +35,15 @@ import {
   writeStoreModeShoppingView,
 } from "../lib/shopping-store-mode-client";
 import {
+  insertProjectedItemIntoSectionGroups,
+  prependRecentManualItem,
+} from "../lib/shopping-list-client";
+import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import { serializeProjectedShoppingItem } from "../lib/shopping-serialize";
+import {
   getMealPlanStoreModeData,
   listRecentManualShoppingItemsForFamily,
+  type RecentManualShoppingItem,
 } from "../lib/shopping.server";
 import {
   toggleShoppingItemChecked,
@@ -62,6 +69,7 @@ import {
   STORE_MODE_SYNC_PROGRESS_MESSAGE,
   useStoreModeToggleSync,
 } from "../lib/use-store-mode-toggle-sync";
+import { useDebouncedRevalidate } from "../lib/use-debounced-revalidate";
 
 type StoreModeNotice =
   | "active-shopping-date-updated"
@@ -83,7 +91,9 @@ interface StoreModeActionData {
   activeShoppingDateValue?: string;
   formError?: string;
   intent?: StoreModeIntent;
+  item?: QuickAddShoppingSuccess["item"];
   ok?: boolean;
+  recentManualItem?: RecentManualShoppingItem;
   selectedStoreFieldErrors?: {
     selectedStoreId?: string;
   };
@@ -259,12 +269,12 @@ export async function action({
       } satisfies StoreModeActionData;
     }
 
-    return buildStoreModeRedirect({
-      familyId,
-      mealPlanId,
-      notice: "family-shopping-item-added",
-      request,
-    });
+    return {
+      intent,
+      item: serializeProjectedShoppingItem(result.item),
+      ok: true,
+      recentManualItem: result.recentManualItem,
+    } satisfies StoreModeActionData;
   }
 
   if (intent === "toggle-family-shopping-item-checked") {
@@ -354,17 +364,43 @@ export default function FamilyMealPlanStoreModeRoute({
   const navigation = useNavigation();
   const submit = useSubmit();
   const revalidator = useRevalidator();
+  const scheduleRevalidate = useDebouncedRevalidate(revalidator.revalidate);
   const toggleFetcher = useFetcher<StoreModeActionData>();
   const pendingIntent = navigation.formData?.get("intent");
+  const [dueSectionGroups, setDueSectionGroups] = useState(
+    loaderData.dueSectionGroups,
+  );
+  const [recentManualItems, setRecentManualItems] = useState(
+    loaderData.recentManualItems,
+  );
   const isSavingStore =
     navigation.state === "submitting" &&
     pendingIntent === "update-selected-store";
   const isSavingShoppingDate =
     navigation.state === "submitting" &&
     pendingIntent === "update-active-shopping-date";
+
+  useEffect(() => {
+    setDueSectionGroups(loaderData.dueSectionGroups);
+    setRecentManualItems(loaderData.recentManualItems);
+  }, [loaderData.dueSectionGroups, loaderData.recentManualItems]);
+
+  const handleQuickAddSuccess = useCallback(
+    (payload: QuickAddShoppingSuccess) => {
+      setDueSectionGroups((currentSections) =>
+        insertProjectedItemIntoSectionGroups(currentSections, payload.item),
+      );
+      setRecentManualItems((currentRecents) =>
+        prependRecentManualItem(currentRecents, payload.recentManualItem),
+      );
+      scheduleRevalidate();
+    },
+    [scheduleRevalidate],
+  );
+
   const loaderDueItems = useMemo(
-    () => loaderData.dueSectionGroups.flatMap((section) => section.items),
-    [loaderData.dueSectionGroups],
+    () => dueSectionGroups.flatMap((section) => section.items),
+    [dueSectionGroups],
   );
   const { displayItemsBySourceKey, handleToggle, syncBannerMessage } =
     useStoreModeToggleSync({
@@ -388,13 +424,13 @@ export default function FamilyMealPlanStoreModeRoute({
   );
   const displaySectionGroups = useMemo(
     () =>
-      loaderData.dueSectionGroups.map((section) => ({
+      dueSectionGroups.map((section) => ({
         ...section,
         items: section.items.map(
           (item) => displayItemsBySourceKey.get(item.sourceKey) ?? item,
         ),
       })),
-    [displayItemsBySourceKey, loaderData.dueSectionGroups],
+    [displayItemsBySourceKey, dueSectionGroups],
   );
   const viewStorageKey = useMemo(
     () =>
@@ -463,10 +499,6 @@ export default function FamilyMealPlanStoreModeRoute({
       ? actionData.activeShoppingDateValue
       : loaderData.activeShoppingDate;
   const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
-  const quickAddFormError =
-    actionData?.intent === "quick-add-family-shopping-item"
-      ? actionData.formError
-      : undefined;
   const generalFormError =
     actionData?.formError &&
     actionData.intent !== "quick-add-family-shopping-item"
@@ -753,14 +785,12 @@ export default function FamilyMealPlanStoreModeRoute({
       <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3">
         <div className="pointer-events-auto mx-auto max-w-4xl">
           <div className={storeModeQuickAddDockClass}>
-            {quickAddFormError ? (
-              <p className="mb-3 text-sm text-rose-600">{quickAddFormError}</p>
-            ) : null}
             <ManualShoppingQuickAdd
               appearance="store-mode"
               ingredientSearchPath={ingredientSearchPath}
+              onQuickAddSuccess={handleQuickAddSuccess}
               quickAddIntent="quick-add-family-shopping-item"
-              recentManualItems={loaderData.recentManualItems}
+              recentManualItems={recentManualItems}
               revealOnFocus
             />
           </div>
@@ -798,38 +828,6 @@ export function ErrorBoundary({ error }: { error: unknown }) {
       </div>
     </main>
   );
-}
-
-function serializeProjectedShoppingItem(
-  item:
-    | Awaited<ReturnType<typeof getMealPlanStoreModeData>>["laterItems"][number]
-    | Awaited<
-        ReturnType<typeof getMealPlanStoreModeData>
-      >["dueSectionGroups"][number]["items"][number],
-) {
-  if (item.sourceType === "FAMILY") {
-    return item;
-  }
-
-  if (item.sourceType === ShoppingItemSource.GENERATED) {
-    return {
-      ...item,
-      firstDate: formatDateOnly(item.firstDate),
-      lastDate: formatDateOnly(item.lastDate),
-      occurrences: item.occurrences.map((occurrence) => ({
-        ...occurrence,
-        date: formatDateOnly(occurrence.date),
-      })),
-      postponedUntilDate: item.postponedUntilDate
-        ? formatDateOnly(item.postponedUntilDate)
-        : null,
-    };
-  }
-
-  return {
-    ...item,
-    buyOnDate: item.buyOnDate ? formatDateOnly(item.buyOnDate) : null,
-  };
 }
 
 function getStoreModeNotice(request: Request): StoreModeNotice | null {

--- a/app/routes/family-shopping.test.ts
+++ b/app/routes/family-shopping.test.ts
@@ -159,7 +159,7 @@ describe("family shopping route", () => {
     expect((response as Response).status).toBe(302);
   });
 
-  it("redirects after a family quick-add", async () => {
+  it("returns quick-add success data without redirecting", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
       ingredientId: "ingredient-1",
@@ -167,6 +167,25 @@ describe("family shopping route", () => {
       recentNameNormalized: "",
     });
     vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
+      item: {
+        category: { id: "category-dairy", name: "Meieri" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Melk",
+        note: null,
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Meieri", sortOrder: 1 },
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+      recentManualItem: {
+        categoryId: "category-dairy",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "1",
+      },
       status: "CREATED",
     });
 
@@ -174,7 +193,7 @@ describe("family shopping route", () => {
     formData.set("intent", "quick-add-family-shopping-item");
     formData.set("name", "Melk");
 
-    const response = await action({
+    const result = await action({
       params: { familyId: "family-1" },
       request: new Request("http://localhost/families/family-1/shopping", {
         body: formData,
@@ -191,10 +210,29 @@ describe("family shopping route", () => {
       },
       userId: "user-1",
     });
-    expect(response).toBeInstanceOf(Response);
-    expect((response as Response).headers.get("Location")).toBe(
-      "http://localhost/families/family-1/shopping?notice=family-shopping-item-added",
-    );
+    expect(result).toEqual({
+      intent: "quick-add-family-shopping-item",
+      item: {
+        category: { id: "category-dairy", name: "Meieri" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Melk",
+        note: null,
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Meieri", sortOrder: 1 },
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+      ok: true,
+      recentManualItem: {
+        categoryId: "category-dairy",
+        displayName: "Melk",
+        nameNormalized: "melk",
+        quantity: "1",
+      },
+    });
   });
 
   it("returns quick-add validation errors without redirecting", async () => {

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -1,9 +1,11 @@
 import { ShoppingItemSource } from "@prisma/client";
+import { useCallback, useEffect, useState } from "react";
 import {
   Form,
   Link,
   isRouteErrorResponse,
   useNavigation,
+  useRevalidator,
   type MetaFunction,
 } from "react-router";
 
@@ -34,11 +36,21 @@ import {
 } from "../lib/shopping-preference-write.server";
 import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
+  insertProjectedItemIntoStoreGroups,
+  prependRecentManualItem,
+} from "../lib/shopping-list-client";
+import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import {
+  serializeProjectedShoppingItem,
+  type SerializedProjectedShoppingItem,
+} from "../lib/shopping-serialize";
+import {
   getFamilyShoppingData,
   listRecentManualShoppingItemsForFamily,
-  type ProjectedShoppingItem,
+  type RecentManualShoppingItem,
 } from "../lib/shopping.server";
 import { toggleShoppingItemChecked } from "../lib/shopping-write.server";
+import { useDebouncedRevalidate } from "../lib/use-debounced-revalidate";
 
 type FamilyShoppingNotice =
   | "family-shopping-item-added"
@@ -61,9 +73,12 @@ interface FamilyShoppingActionData {
   familyValues?: FamilyShoppingItemValues;
   formError?: string;
   intent?: FamilyShoppingIntent;
+  item?: QuickAddShoppingSuccess["item"];
   itemTarget?: {
     sourceKey: string;
   };
+  ok?: true;
+  recentManualItem?: RecentManualShoppingItem;
 }
 
 const defaultFamilyShoppingItemValues: FamilyShoppingItemValues = {
@@ -119,10 +134,7 @@ export async function loader({
     storeGroups: result.storeGroups.map((group) => ({
       sections: group.sections.map((section) => ({
         ...section,
-        items: section.items.map((item) => ({
-          ...item,
-          collaborationVersion: item.collaborationVersion,
-        })),
+        items: section.items.map(serializeProjectedShoppingItem),
       })),
       store: group.store,
     })),
@@ -259,11 +271,12 @@ export async function action({
       } satisfies FamilyShoppingActionData;
     }
 
-    return buildFamilyShoppingRedirect({
-      familyId,
-      notice: "family-shopping-item-added",
-      request,
-    });
+    return {
+      intent,
+      item: serializeProjectedShoppingItem(result.item),
+      ok: true,
+      recentManualItem: result.recentManualItem,
+    } satisfies FamilyShoppingActionData;
   }
 
   if (intent === "update-family-shopping-item") {
@@ -411,7 +424,13 @@ export default function FamilyShoppingRoute({
   loaderData: Awaited<ReturnType<typeof loader>>;
 }) {
   const navigation = useNavigation();
+  const revalidator = useRevalidator();
+  const scheduleRevalidate = useDebouncedRevalidate(revalidator.revalidate);
   const isLg = useIsLgViewport();
+  const [storeGroups, setStoreGroups] = useState(loaderData.storeGroups);
+  const [recentManualItems, setRecentManualItems] = useState(
+    loaderData.recentManualItems,
+  );
   const noticeContent =
     loaderData.notice !== null
       ? getFamilyShoppingNoticeContent(loaderData.notice)
@@ -419,19 +438,35 @@ export default function FamilyShoppingRoute({
   const pendingIntent = navigation.formData?.get("intent");
   const pendingSourceKey = getPendingSourceKey(navigation.formData);
   const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
-  const quickAddFormError =
-    actionData?.intent === "quick-add-family-shopping-item"
-      ? actionData.formError
-      : undefined;
   const generalFormError =
     actionData?.formError &&
     actionData.intent !== "quick-add-family-shopping-item"
       ? actionData.formError
       : undefined;
+
+  useEffect(() => {
+    setStoreGroups(loaderData.storeGroups);
+    setRecentManualItems(loaderData.recentManualItems);
+  }, [loaderData.recentManualItems, loaderData.storeGroups]);
+
+  const handleQuickAddSuccess = useCallback(
+    (payload: QuickAddShoppingSuccess) => {
+      setStoreGroups((currentGroups) =>
+        insertProjectedItemIntoStoreGroups(currentGroups, payload.item),
+      );
+      setRecentManualItems((currentRecents) =>
+        prependRecentManualItem(currentRecents, payload.recentManualItem),
+      );
+      scheduleRevalidate();
+    },
+    [scheduleRevalidate],
+  );
+
   const quickAddProps = {
     ingredientSearchPath,
+    onQuickAddSuccess: handleQuickAddSuccess,
     quickAddIntent: "quick-add-family-shopping-item" as const,
-    recentManualItems: loaderData.recentManualItems,
+    recentManualItems,
   };
   const addFamilyValues =
     actionData?.intent === "add-family-shopping-item" && actionData.familyValues
@@ -608,17 +643,9 @@ export default function FamilyShoppingRoute({
             </p>
 
             {isLg ? (
-              <>
-                {quickAddFormError ? (
-                  <p className="mt-4 text-sm text-rose-600">
-                    {quickAddFormError}
-                  </p>
-                ) : null}
-
-                <div className="mt-6">
-                  <ManualShoppingQuickAdd {...quickAddProps} />
-                </div>
-              </>
+              <div className="mt-6">
+                <ManualShoppingQuickAdd {...quickAddProps} />
+              </div>
             ) : null}
 
             <details
@@ -677,9 +704,9 @@ export default function FamilyShoppingRoute({
           </article>
         </section>
 
-        {loaderData.storeGroups.length ? (
+        {storeGroups.length ? (
           <section className="grid gap-6">
-            {loaderData.storeGroups.map((group) => (
+            {storeGroups.map((group) => (
               <article
                 key={group.store?.id ?? "no-store"}
                 className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200"
@@ -732,9 +759,6 @@ export default function FamilyShoppingRoute({
         <div className="pointer-events-none fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom))] z-40 px-4 pt-3">
           <div className="pointer-events-auto mx-auto max-w-5xl">
             <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200">
-              {quickAddFormError ? (
-                <p className="mb-3 text-sm text-rose-600">{quickAddFormError}</p>
-              ) : null}
               <ManualShoppingQuickAdd
                 {...quickAddProps}
                 autoFocus
@@ -822,7 +846,9 @@ function getFamilyShoppingNotice(
   return null;
 }
 
-function formatCompactShoppingSourceLineForItem(item: ProjectedShoppingItem) {
+function formatCompactShoppingSourceLineForItem(
+  item: SerializedProjectedShoppingItem,
+) {
   if (item.sourceType === "GENERATED") {
     return formatCompactShoppingSourceLine({
       occurrenceCount: item.occurrenceCount,
@@ -864,7 +890,7 @@ function parseMealPlanShoppingItemSource(value: FormDataEntryValue | null) {
   return null;
 }
 
-function getFamilyShoppingSourceBadge(item: ProjectedShoppingItem) {
+function getFamilyShoppingSourceBadge(item: SerializedProjectedShoppingItem) {
   if (item.sourceType === "FAMILY") {
     return {
       className: "rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800",
@@ -946,7 +972,7 @@ function renderFamilyShoppingListItem({
   actionData?: FamilyShoppingActionData;
   categories: Awaited<ReturnType<typeof loader>>["categories"];
   familyId: string;
-  item: ProjectedShoppingItem;
+  item: SerializedProjectedShoppingItem;
   navigation: ReturnType<typeof useNavigation>;
   pendingIntent: FormDataEntryValue | null | undefined;
   pendingSourceKey: string | null;


### PR DESCRIPTION
## Summary
- Replace full-page quick-add submissions with a fetcher that returns a projected item and merges it into local list state immediately
- Apply the same pattern on meal-plan shopping, family shopping, and store mode so rapid adds no longer cause page jitter or scroll jumps
- Add shared serialization, list-merge helpers, and debounced background revalidation for eventual consistency

## Related issue
Closes #121

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: add 3–5 items rapidly on meal-plan shopping, family shopping (desktop + mobile dock), and store mode — list grows in place without navigation flash

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck