### PR TITLE
Redesign family home with Oversikt and Familie tabs

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,32 @@
 
 ## Current Objective
 
-Issue #121 on branch `issue/121-client-side-quick-add`: client-side quick-add for manual shopping items without full page refresh. Shipped via PR.
+Issue #125 on branch `issue/125-family-home-tabs`: family home with Oversikt/Familie tabs — ready for PR merge.
 
 ## Completed
 
-- `ManualShoppingQuickAdd` uses dedicated `useFetcher` instead of `useSubmit`; inline validation errors; `onQuickAddSuccess` callback.
-- Quick-add actions return JSON `{ ok: true, item, recentManualItem }` instead of 302 redirects (meal-plan shopping, family shopping, store mode).
-- Write layer returns projected item after create via `projectCreatedManualShoppingItem` / `projectCreatedFamilyShoppingItem`.
-- Shared modules: `shopping-serialize.ts`, `shopping-quick-add.ts`, `shopping-list-client.ts`, `use-debounced-revalidate.ts`.
-- Parent routes maintain local list state and debounced background revalidation.
+- Two-tab family route (`Oversikt` / `Familie`) with URL `?tab=familie`.
+- Oversikt: 3 recent meal plans (muted when past), weekly dinner menu per day (Mon–Sun), store-mode + Alltid på listen links.
+- Familie: Din tilgang, Familiekode, Medlemmer (unchanged permissions); member-remove redirects to Familie tab.
+- Helpers: `meal-plan-week.ts`, `meal-plan-display.ts`, `family-home.server.ts`, `family-home-tabs.tsx`.
 
 ## Files To Read First
 
-- `app/components/manual-shopping-quick-add.tsx`
-- `app/lib/shopping-list-client.ts`
-- `app/routes/family-meal-plan-shopping.tsx`
-- `app/routes/family-shopping.tsx`
-- `app/routes/family-meal-plan-store-mode.tsx`
+- `app/routes/family.tsx`
+- `app/lib/family-home.server.ts`
+- `app/components/family-home-tabs.tsx`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (282 tests, 49 files)
+- `npm run test:run` — passed (297 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual QA after merge: rapid adds on all three surfaces; no scroll jitter on mobile dock.
+- Manual QA after merge: tab keyboard nav; past-plan muted styling; week grid on mobile vs desktop.
 
 ## Next Step
 
-Merge PR (Closes #121) after review/CI.
+Merge PR (Closes #125) after review/CI.

--- a/app/components/family-home-tabs.tsx
+++ b/app/components/family-home-tabs.tsx
@@ -1,0 +1,143 @@
+import { type ReactNode, useCallback, useId, useRef } from "react";
+import { Link, useLocation } from "react-router";
+
+export type FamilyHomeTab = "familie" | "oversikt";
+
+const TAB_ORDER: FamilyHomeTab[] = ["oversikt", "familie"];
+
+function buildTabHref(pathname: string, search: string, tab: FamilyHomeTab) {
+  const params = new URLSearchParams(search);
+
+  if (tab === "oversikt") {
+    params.delete("tab");
+  } else {
+    params.set("tab", tab);
+  }
+
+  const query = params.toString();
+
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+function tabTriggerClassName(isActive: boolean) {
+  return isActive
+    ? "rounded-2xl bg-slate-950 px-4 py-2.5 text-sm font-medium text-white shadow-sm"
+    : "rounded-2xl px-4 py-2.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-950";
+}
+
+export function FamilyHomeTabs({
+  activeTab,
+  familiePanel,
+  oversiktPanel,
+}: {
+  activeTab: FamilyHomeTab;
+  familiePanel: ReactNode;
+  oversiktPanel: ReactNode;
+}) {
+  const location = useLocation();
+  const tabListId = useId();
+  const tabRefs = useRef<Partial<Record<FamilyHomeTab, HTMLAnchorElement | null>>>({});
+
+  const focusTab = useCallback((tab: FamilyHomeTab) => {
+    tabRefs.current[tab]?.focus();
+  }, []);
+
+  const handleTabKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLAnchorElement>, tab: FamilyHomeTab) => {
+      const currentIndex = TAB_ORDER.indexOf(tab);
+
+      if (currentIndex === -1) {
+        return;
+      }
+
+      let nextTab: FamilyHomeTab | null = null;
+
+      if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+        nextTab = TAB_ORDER[(currentIndex + 1) % TAB_ORDER.length] ?? null;
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+        nextTab =
+          TAB_ORDER[(currentIndex - 1 + TAB_ORDER.length) % TAB_ORDER.length] ?? null;
+      } else if (event.key === "Home") {
+        nextTab = TAB_ORDER[0] ?? null;
+      } else if (event.key === "End") {
+        nextTab = TAB_ORDER[TAB_ORDER.length - 1] ?? null;
+      }
+
+      if (!nextTab) {
+        return;
+      }
+
+      event.preventDefault();
+      focusTab(nextTab);
+    },
+    [focusTab],
+  );
+
+  const tabs: { href: string; id: string; label: string; panelId: string; tab: FamilyHomeTab }[] =
+    [
+      {
+        href: buildTabHref(location.pathname, location.search, "oversikt"),
+        id: `${tabListId}-oversikt-tab`,
+        label: "Oversikt",
+        panelId: `${tabListId}-oversikt-panel`,
+        tab: "oversikt",
+      },
+      {
+        href: buildTabHref(location.pathname, location.search, "familie"),
+        id: `${tabListId}-familie-tab`,
+        label: "Familie",
+        panelId: `${tabListId}-familie-panel`,
+        tab: "familie",
+      },
+    ];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div
+        aria-label="Familieoversikt"
+        className="inline-flex w-fit max-w-full flex-wrap gap-2 rounded-[28px] bg-white p-2 shadow-sm ring-1 ring-slate-200"
+        role="tablist"
+      >
+        {tabs.map(({ href, id, label, panelId, tab }) => {
+          const isActive = activeTab === tab;
+
+          return (
+            <Link
+              key={tab}
+              ref={(element) => {
+                tabRefs.current[tab] = element;
+              }}
+              aria-controls={panelId}
+              aria-selected={isActive}
+              className={tabTriggerClassName(isActive)}
+              id={id}
+              onKeyDown={(event) => handleTabKeyDown(event, tab)}
+              role="tab"
+              tabIndex={isActive ? 0 : -1}
+              to={href}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+
+      {tabs.map(({ id, panelId, tab }) => {
+        const isActive = activeTab === tab;
+
+        return (
+          <section
+            key={tab}
+            aria-labelledby={id}
+            className={isActive ? "flex flex-col gap-6" : "hidden"}
+            id={panelId}
+            role="tabpanel"
+            tabIndex={0}
+          >
+            {tab === "oversikt" ? oversiktPanel : familiePanel}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/lib/family-home.server.test.ts
+++ b/app/lib/family-home.server.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./db.server", () => ({
+  db: {
+    mealPlan: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: vi.fn(),
+}));
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { getFamilyWeekDinnerMenu } from "./family-home.server";
+
+describe("getFamilyWeekDinnerMenu", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns dinner labels for each day in the current week", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T12:00:00.000Z"));
+
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      id: "membership-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+
+    vi.mocked(db.mealPlan.findMany).mockResolvedValue([
+      {
+        endDate: new Date("2026-06-07T00:00:00.000Z"),
+        entries: [
+          {
+            date: new Date("2026-06-04T00:00:00.000Z"),
+            note: null,
+            recipe: { title: "Taco" },
+            recipeId: "recipe-1",
+          },
+          {
+            date: new Date("2026-06-05T00:00:00.000Z"),
+            note: "Restemat",
+            recipe: null,
+            recipeId: null,
+          },
+        ],
+        id: "meal-plan-1",
+        startDate: new Date("2026-06-01T00:00:00.000Z"),
+        title: "Uke 23",
+      },
+    ] as never);
+
+    const result = await getFamilyWeekDinnerMenu({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(result).toHaveLength(7);
+    expect(result[3]).toMatchObject({
+      date: "2026-06-04",
+      isToday: true,
+      mealPlanId: "meal-plan-1",
+      mealPlanTitle: "Uke 23",
+      menuLabel: "Taco",
+    });
+    expect(result[4]).toMatchObject({
+      date: "2026-06-05",
+      menuLabel: "Restemat",
+    });
+    expect(result[0]).toMatchObject({
+      date: "2026-06-01",
+      menuLabel: "Ikke planlagt",
+    });
+    expect(result[6]).toMatchObject({
+      date: "2026-06-07",
+      menuLabel: "Ikke planlagt",
+      mealPlanId: "meal-plan-1",
+    });
+  });
+});

--- a/app/lib/family-home.server.ts
+++ b/app/lib/family-home.server.ts
@@ -1,0 +1,98 @@
+import { MealType } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import {
+  formatShortDateLabel,
+  formatWeekdayLabel,
+  getDinnerMenuLabel,
+} from "./meal-plan-display";
+import { formatDateOnly, isPlanDateToday } from "./meal-plan-dates";
+import {
+  getCalendarWeekBounds,
+  getCalendarWeekDates,
+} from "./meal-plan-week";
+
+export type FamilyWeekDayMenu = {
+  date: string;
+  dateLabel: string;
+  isToday: boolean;
+  mealPlanId: string | null;
+  mealPlanTitle: string | null;
+  menuLabel: string;
+  weekdayLabel: string;
+};
+
+export async function getFamilyWeekDinnerMenu({
+  familyId,
+  referenceDate = new Date(),
+  userId,
+}: {
+  familyId: string;
+  referenceDate?: Date;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const weekBounds = getCalendarWeekBounds(referenceDate);
+  const weekDates = getCalendarWeekDates(weekBounds);
+  const weekStartDate = new Date(`${weekBounds.weekStart}T00:00:00.000Z`);
+  const weekEndDate = new Date(`${weekBounds.weekEnd}T00:00:00.000Z`);
+
+  const mealPlans = await db.mealPlan.findMany({
+    orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
+    select: {
+      endDate: true,
+      entries: {
+        select: {
+          date: true,
+          note: true,
+          recipe: {
+            select: {
+              title: true,
+            },
+          },
+          recipeId: true,
+        },
+        where: {
+          mealType: MealType.DINNER,
+        },
+      },
+      id: true,
+      startDate: true,
+      title: true,
+    },
+    where: {
+      endDate: {
+        gte: weekStartDate,
+      },
+      familyId,
+      startDate: {
+        lte: weekEndDate,
+      },
+    },
+  });
+
+  return weekDates.map((date) => {
+    const coveringPlan = mealPlans.find(
+      (plan) =>
+        formatDateOnly(plan.startDate) <= date && formatDateOnly(plan.endDate) >= date,
+    );
+    const dinnerEntry = coveringPlan?.entries.find(
+      (entry) => formatDateOnly(entry.date) === date,
+    );
+
+    return {
+      date,
+      dateLabel: formatShortDateLabel(date),
+      isToday: isPlanDateToday(date, referenceDate),
+      mealPlanId: coveringPlan?.id ?? null,
+      mealPlanTitle: coveringPlan?.title ?? null,
+      menuLabel: coveringPlan ? getDinnerMenuLabel(dinnerEntry) : "Ingen ukeplan",
+      weekdayLabel: formatWeekdayLabel(date),
+    } satisfies FamilyWeekDayMenu;
+  });
+}

--- a/app/lib/meal-plan-display.test.ts
+++ b/app/lib/meal-plan-display.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { getDinnerMenuLabel } from "./meal-plan-display";
+
+describe("getDinnerMenuLabel", () => {
+  it("prefers recipe title over note", () => {
+    expect(
+      getDinnerMenuLabel({
+        note: "Takeaway",
+        recipe: { title: "Laks med poteter" },
+        recipeId: "recipe-1",
+      }),
+    ).toBe("Laks med poteter");
+  });
+
+  it("uses trimmed note when recipe is missing", () => {
+    expect(
+      getDinnerMenuLabel({
+        note: "  Pizza  ",
+        recipe: null,
+        recipeId: null,
+      }),
+    ).toBe("Pizza");
+  });
+
+  it("returns default label when entry is empty", () => {
+    expect(getDinnerMenuLabel(null)).toBe("Ikke planlagt");
+  });
+});

--- a/app/lib/meal-plan-display.ts
+++ b/app/lib/meal-plan-display.ts
@@ -1,0 +1,48 @@
+export function formatMealPlanWindow(startDate: string, endDate: string) {
+  const formatter = new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
+
+  return `${formatter.format(new Date(`${startDate}T00:00:00.000Z`))} - ${formatter.format(
+    new Date(`${endDate}T00:00:00.000Z`),
+  )}`;
+}
+
+export function formatWeekdayLabel(date: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    timeZone: "UTC",
+    weekday: "long",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}
+
+export function formatShortDateLabel(date: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00.000Z`));
+}
+
+type DinnerMenuEntry = {
+  note: string | null;
+  recipe?: {
+    title: string;
+  } | null;
+  recipeId: string | null;
+};
+
+export function getDinnerMenuLabel(entry: DinnerMenuEntry | null | undefined) {
+  if (entry?.recipe?.title) {
+    return entry.recipe.title;
+  }
+
+  const trimmedNote = entry?.note?.trim() ?? "";
+
+  if (trimmedNote) {
+    return trimmedNote.length > 48 ? `${trimmedNote.slice(0, 48)}…` : trimmedNote;
+  }
+
+  return "Ikke planlagt";
+}

--- a/app/lib/meal-plan-week.test.ts
+++ b/app/lib/meal-plan-week.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dateRangesOverlap,
+  filterMealPlansOverlappingWeek,
+  getCalendarWeekBounds,
+  getCalendarWeekDates,
+  isMealPlanPast,
+} from "./meal-plan-week";
+
+describe("getCalendarWeekBounds", () => {
+  it("returns Monday through Sunday for a mid-week reference in Oslo", () => {
+    const bounds = getCalendarWeekBounds(
+      new Date("2026-06-04T12:00:00.000Z"),
+      "Europe/Oslo",
+    );
+
+    expect(bounds).toEqual({
+      weekEnd: "2026-06-07",
+      weekStart: "2026-06-01",
+    });
+  });
+});
+
+describe("getCalendarWeekDates", () => {
+  it("lists each date in the week inclusively", () => {
+    expect(
+      getCalendarWeekDates({
+        weekEnd: "2026-06-07",
+        weekStart: "2026-06-01",
+      }),
+    ).toEqual([
+      "2026-06-01",
+      "2026-06-02",
+      "2026-06-03",
+      "2026-06-04",
+      "2026-06-05",
+      "2026-06-06",
+      "2026-06-07",
+    ]);
+  });
+});
+
+describe("isMealPlanPast", () => {
+  it("returns true when the plan ended before today", () => {
+    expect(isMealPlanPast("2026-05-18", "2026-06-04")).toBe(true);
+  });
+
+  it("returns false when the plan ends today or later", () => {
+    expect(isMealPlanPast("2026-06-04", "2026-06-04")).toBe(false);
+    expect(isMealPlanPast("2026-06-10", "2026-06-04")).toBe(false);
+  });
+});
+
+describe("dateRangesOverlap", () => {
+  it("detects overlapping ranges", () => {
+    expect(dateRangesOverlap("2026-06-01", "2026-06-10", "2026-06-05", "2026-06-12")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when ranges do not touch", () => {
+    expect(dateRangesOverlap("2026-05-01", "2026-05-07", "2026-06-01", "2026-06-07")).toBe(
+      false,
+    );
+  });
+
+  it("treats touching end/start as overlap", () => {
+    expect(dateRangesOverlap("2026-05-01", "2026-06-01", "2026-06-01", "2026-06-07")).toBe(
+      true,
+    );
+  });
+});
+
+describe("filterMealPlansOverlappingWeek", () => {
+  const weekBounds = {
+    weekEnd: "2026-06-07",
+    weekStart: "2026-06-01",
+  };
+
+  const plans = [
+    {
+      endDate: "2026-05-20",
+      id: "before",
+      startDate: "2026-05-15",
+    },
+    {
+      endDate: "2026-06-10",
+      id: "spanning",
+      startDate: "2026-05-28",
+    },
+    {
+      endDate: "2026-06-05",
+      id: "inside",
+      startDate: "2026-06-02",
+    },
+    {
+      endDate: "2026-06-12",
+      id: "also-inside",
+      startDate: "2026-06-03",
+    },
+    {
+      endDate: "2026-06-20",
+      id: "after",
+      startDate: "2026-06-15",
+    },
+  ];
+
+  it("returns plans that overlap the week in input order", () => {
+    expect(filterMealPlansOverlappingWeek(plans, weekBounds)).toEqual([
+      plans[1],
+      plans[2],
+      plans[3],
+    ]);
+  });
+
+  it("returns an empty list when no plans overlap", () => {
+    expect(
+      filterMealPlansOverlappingWeek(
+        [
+          {
+            endDate: "2026-05-20",
+            id: "old",
+            startDate: "2026-05-15",
+          },
+        ],
+        weekBounds,
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns an empty list for empty input", () => {
+    expect(filterMealPlansOverlappingWeek([], weekBounds)).toEqual([]);
+  });
+});

--- a/app/lib/meal-plan-week.ts
+++ b/app/lib/meal-plan-week.ts
@@ -1,0 +1,102 @@
+import { formatDateOnly } from "./meal-plan-dates";
+
+const ISO_WEEKDAY_BY_SHORT_LABEL: Record<string, number> = {
+  Fri: 5,
+  Mon: 1,
+  Sat: 6,
+  Sun: 7,
+  Thu: 4,
+  Tue: 2,
+  Wed: 3,
+};
+
+export type CalendarWeekBounds = {
+  weekEnd: string;
+  weekStart: string;
+};
+
+export type DateRange = {
+  endDate: string;
+  startDate: string;
+};
+
+function formatDateOnlyInTimeZone(date: Date, timeZone: string) {
+  return new Intl.DateTimeFormat("en-CA", {
+    day: "2-digit",
+    month: "2-digit",
+    timeZone,
+    year: "numeric",
+  }).format(date);
+}
+
+export function getTodayDateOnly(timeZone = "Europe/Oslo") {
+  return formatDateOnlyInTimeZone(new Date(), timeZone);
+}
+
+export function isMealPlanPast(endDate: string, today = getTodayDateOnly()) {
+  return endDate < today;
+}
+
+function getIsoWeekdayInTimeZone(date: Date, timeZone: string) {
+  const weekday = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short",
+  }).format(date);
+
+  return ISO_WEEKDAY_BY_SHORT_LABEL[weekday] ?? 1;
+}
+
+function addDaysToDateOnly(dateOnly: string, days: number) {
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+
+  return formatDateOnly(date);
+}
+
+export function getCalendarWeekBounds(
+  referenceDate = new Date(),
+  timeZone = "Europe/Oslo",
+): CalendarWeekBounds {
+  const zonedDate = formatDateOnlyInTimeZone(referenceDate, timeZone);
+  const weekday = getIsoWeekdayInTimeZone(referenceDate, timeZone);
+
+  return {
+    weekEnd: addDaysToDateOnly(zonedDate, 7 - weekday),
+    weekStart: addDaysToDateOnly(zonedDate, -(weekday - 1)),
+  };
+}
+
+export function dateRangesOverlap(
+  rangeAStart: string,
+  rangeAEnd: string,
+  rangeBStart: string,
+  rangeBEnd: string,
+) {
+  return rangeAStart <= rangeBEnd && rangeAEnd >= rangeBStart;
+}
+
+export function filterMealPlansOverlappingWeek<T extends DateRange>(
+  plans: T[],
+  weekBounds: CalendarWeekBounds,
+) {
+  return plans.filter((plan) =>
+    dateRangesOverlap(
+      plan.startDate,
+      plan.endDate,
+      weekBounds.weekStart,
+      weekBounds.weekEnd,
+    ),
+  );
+}
+
+export function getCalendarWeekDates(weekBounds: CalendarWeekBounds) {
+  const dates: string[] = [];
+  let current = weekBounds.weekStart;
+
+  while (current <= weekBounds.weekEnd) {
+    dates.push(current);
+    current = addDaysToDateOnly(current, 1);
+  }
+
+  return dates;
+}

--- a/app/routes/family.test.ts
+++ b/app/routes/family.test.ts
@@ -17,8 +17,20 @@ vi.mock("../lib/family.server", () => {
   };
 });
 
+vi.mock("../lib/meal-plan.server", () => {
+  return {
+    listMealPlansForFamily: vi.fn(),
+  };
+});
+
+vi.mock("../lib/family-home.server", () => ({
+  getFamilyWeekDinnerMenu: vi.fn(),
+}));
+
 import { requireUser } from "../lib/auth.server";
+import { getFamilyWeekDinnerMenu } from "../lib/family-home.server";
 import { listFamilyMembers, removeFamilyMember, requireFamilyMembership } from "../lib/family.server";
+import { listMealPlansForFamily } from "../lib/meal-plan.server";
 import { action, loader } from "./family";
 
 const mockUser = {
@@ -28,6 +40,49 @@ const mockUser = {
   isGlobalAdmin: false,
 };
 
+const mockMealPlans = [
+  {
+    activeShoppingDate: new Date("2026-06-03T00:00:00.000Z"),
+    createdAt: new Date("2026-05-20T12:00:00.000Z"),
+    endDate: new Date("2026-06-07T00:00:00.000Z"),
+    id: "meal-plan-1",
+    startDate: new Date("2026-06-01T00:00:00.000Z"),
+    status: "APPROVED" as const,
+    title: "Uke 23",
+    updatedAt: new Date("2026-05-20T12:00:00.000Z"),
+  },
+  {
+    activeShoppingDate: null,
+    createdAt: new Date("2026-05-10T12:00:00.000Z"),
+    endDate: new Date("2026-05-18T00:00:00.000Z"),
+    id: "meal-plan-2",
+    startDate: new Date("2026-05-12T00:00:00.000Z"),
+    status: "DRAFT" as const,
+    title: "Uke 20",
+    updatedAt: new Date("2026-05-10T12:00:00.000Z"),
+  },
+  {
+    activeShoppingDate: null,
+    createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    endDate: new Date("2026-05-08T00:00:00.000Z"),
+    id: "meal-plan-3",
+    startDate: new Date("2026-05-01T00:00:00.000Z"),
+    status: "DRAFT" as const,
+    title: "Uke 18",
+    updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+  },
+  {
+    activeShoppingDate: null,
+    createdAt: new Date("2026-04-20T12:00:00.000Z"),
+    endDate: new Date("2026-04-27T00:00:00.000Z"),
+    id: "meal-plan-4",
+    startDate: new Date("2026-04-20T00:00:00.000Z"),
+    status: "DRAFT" as const,
+    title: "Uke 17",
+    updatedAt: new Date("2026-04-20T12:00:00.000Z"),
+  },
+];
+
 function buildRequest(url = "http://localhost/families/family-1", formData?: FormData) {
   return new Request(url, {
     body: formData,
@@ -35,12 +90,49 @@ function buildRequest(url = "http://localhost/families/family-1", formData?: For
   });
 }
 
+const mockWeekDays = [
+  {
+    date: "2026-06-01",
+    dateLabel: "1. jun.",
+    isToday: false,
+    mealPlanId: "meal-plan-1",
+    mealPlanTitle: "Uke 23",
+    menuLabel: "Ikke planlagt",
+    weekdayLabel: "mandag",
+  },
+  {
+    date: "2026-06-04",
+    dateLabel: "4. jun.",
+    isToday: true,
+    mealPlanId: "meal-plan-1",
+    mealPlanTitle: "Uke 23",
+    menuLabel: "Taco",
+    weekdayLabel: "torsdag",
+  },
+];
+
+function mockMealPlansForFamily() {
+  vi.mocked(listMealPlansForFamily).mockResolvedValue({
+    family: {
+      id: "family-1",
+      name: "Solberg",
+    },
+    mealPlans: mockMealPlans,
+    userRole: "ADMIN",
+  });
+  vi.mocked(getFamilyWeekDinnerMenu).mockResolvedValue(mockWeekDays as never);
+}
+
 describe("family route", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("returns admin-only family data for admins", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T12:00:00.000Z"));
+
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(requireFamilyMembership).mockResolvedValue({
       family: {
@@ -64,12 +156,15 @@ describe("family route", () => {
         },
       },
     ]);
+    mockMealPlansForFamily();
 
     const result = await loader({
       params: {
         familyId: "family-1",
       },
-      request: buildRequest("http://localhost/families/family-1?notice=member-removed"),
+      request: buildRequest(
+        "http://localhost/families/family-1?notice=member-removed&tab=familie",
+      ),
       context: {} as never,
     } as unknown as Parameters<typeof loader>[0]);
 
@@ -78,7 +173,23 @@ describe("family route", () => {
       userId: "user-1",
     });
     expect(listFamilyMembers).toHaveBeenCalledWith("family-1");
-    expect(result).toEqual({
+    expect(listMealPlansForFamily).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result.activeTab).toBe("familie");
+    expect(result.recentMealPlans).toHaveLength(3);
+    expect(result.recentMealPlans.map((mealPlan) => mealPlan.id)).toEqual([
+      "meal-plan-1",
+      "meal-plan-2",
+      "meal-plan-3",
+    ]);
+    expect(getFamilyWeekDinnerMenu).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result.weekDays).toEqual(mockWeekDays);
+    expect(result).toMatchObject({
       family: {
         id: "family-1",
         joinCode: "ABC123",
@@ -101,6 +212,33 @@ describe("family route", () => {
     });
   });
 
+  it("defaults to the oversikt tab when tab is missing", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: {
+        id: "family-1",
+        joinCode: "ABC123",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+      id: "membership-1",
+      role: "ADMIN",
+      userId: "user-1",
+    });
+    vi.mocked(listFamilyMembers).mockResolvedValue([]);
+    mockMealPlansForFamily();
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(),
+      context: {} as never,
+    } as unknown as Parameters<typeof loader>[0]);
+
+    expect(result.activeTab).toBe("oversikt");
+  });
+
   it("hides the join code and member list from regular members", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(requireFamilyMembership).mockResolvedValue({
@@ -114,6 +252,7 @@ describe("family route", () => {
       role: "MEMBER",
       userId: "user-1",
     });
+    mockMealPlansForFamily();
 
     const result = await loader({
       params: {
@@ -125,6 +264,7 @@ describe("family route", () => {
 
     expect(listFamilyMembers).not.toHaveBeenCalled();
     expect(result).toEqual({
+      activeTab: "oversikt",
       family: {
         id: "family-1",
         joinCode: null,
@@ -132,6 +272,30 @@ describe("family route", () => {
       },
       members: [],
       notice: null,
+      recentMealPlans: [
+        {
+          endDate: "2026-06-07",
+          id: "meal-plan-1",
+          startDate: "2026-06-01",
+          status: "APPROVED",
+          title: "Uke 23",
+        },
+        {
+          endDate: "2026-05-18",
+          id: "meal-plan-2",
+          startDate: "2026-05-12",
+          status: "DRAFT",
+          title: "Uke 20",
+        },
+        {
+          endDate: "2026-05-08",
+          id: "meal-plan-3",
+          startDate: "2026-05-01",
+          status: "DRAFT",
+          title: "Uke 18",
+        },
+      ],
+      weekDays: mockWeekDays,
       user: mockUser,
       userRole: "MEMBER",
     });
@@ -190,7 +354,7 @@ describe("family route", () => {
     const response = result as Response;
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe(
-      "http://localhost/families/family-1?notice=member-removed",
+      "http://localhost/families/family-1?notice=member-removed&tab=familie",
     );
   });
 

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -1,14 +1,30 @@
 import { Form, Link, isRouteErrorResponse, useNavigation } from "react-router";
 
 import type { Route } from "./+types/family";
+import { FamilyHomeTabs } from "../components/family-home-tabs";
 import { requireUser } from "../lib/auth.server";
 import {
   listFamilyMembers,
   removeFamilyMember,
   requireFamilyMembership,
 } from "../lib/family.server";
+import { getFamilyWeekDinnerMenu } from "../lib/family-home.server";
+import { formatMealPlanWindow } from "../lib/meal-plan-display";
+import { formatDateOnly } from "../lib/meal-plan-dates";
+import { isMealPlanPast } from "../lib/meal-plan-week";
+import { listMealPlansForFamily } from "../lib/meal-plan.server";
 
 type FamilyNotice = "member-removed";
+
+type FamilyHomeTab = "familie" | "oversikt";
+
+type SerializedMealPlanSummary = {
+  endDate: string;
+  id: string;
+  startDate: string;
+  status: "APPROVED" | "DRAFT";
+  title: string;
+};
 
 interface FamilyActionData {
   formError?: string;
@@ -25,6 +41,16 @@ function getFamilyNotice(request: Request): FamilyNotice | null {
   return null;
 }
 
+function getFamilyHomeTab(request: Request): FamilyHomeTab {
+  const tab = new URL(request.url).searchParams.get("tab");
+
+  if (tab === "familie") {
+    return tab;
+  }
+
+  return "oversikt";
+}
+
 function buildFamilyRedirect({
   request,
   familyId,
@@ -36,6 +62,7 @@ function buildFamilyRedirect({
 }) {
   const url = new URL(`/families/${familyId}`, request.url);
   url.searchParams.set("notice", notice);
+  url.searchParams.set("tab", "familie");
 
   return Response.redirect(url, 302);
 }
@@ -48,6 +75,145 @@ function getFamilyNoticeContent(notice: FamilyNotice) {
         title: "Endringen er lagret",
       };
   }
+}
+
+function serializeMealPlanSummary(
+  mealPlan: Awaited<
+    ReturnType<typeof listMealPlansForFamily>
+  >["mealPlans"][number],
+): SerializedMealPlanSummary {
+  return {
+    endDate: formatDateOnly(mealPlan.endDate),
+    id: mealPlan.id,
+    startDate: formatDateOnly(mealPlan.startDate),
+    status: mealPlan.status,
+    title: mealPlan.title,
+  };
+}
+
+function MealPlanStatusBadge({
+  muted = false,
+  status,
+}: {
+  muted?: boolean;
+  status: SerializedMealPlanSummary["status"];
+}) {
+  if (muted) {
+    return (
+      <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-400 ring-1 ring-slate-100">
+        {status === "APPROVED" ? "Godkjent" : "Utkast"}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={
+        status === "APPROVED"
+          ? "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-emerald-800 ring-1 ring-emerald-200"
+          : "rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200"
+      }
+    >
+      {status === "APPROVED" ? "Godkjent" : "Utkast"}
+    </span>
+  );
+}
+
+function MealPlanLinkCard({
+  familyId,
+  isPast = false,
+  mealPlan,
+}: {
+  familyId: string;
+  isPast?: boolean;
+  mealPlan: SerializedMealPlanSummary;
+}) {
+  return (
+    <Link
+      className={
+        isPast
+          ? "block rounded-[24px] border border-slate-100 bg-slate-50/70 p-5 opacity-80 transition hover:border-slate-200 hover:bg-slate-50"
+          : "block rounded-[24px] border border-slate-200 bg-slate-50 p-5 transition hover:border-slate-300 hover:bg-white"
+      }
+      to={`/families/${familyId}/meal-plans/${mealPlan.id}`}
+    >
+      <div className="flex flex-wrap items-center gap-3">
+        <h3
+          className={
+            isPast
+              ? "text-base font-semibold text-slate-500"
+              : "text-base font-semibold text-slate-950"
+          }
+        >
+          {mealPlan.title}
+        </h3>
+        <MealPlanStatusBadge muted={isPast} status={mealPlan.status} />
+      </div>
+      <p
+        className={
+          isPast
+            ? "mt-2 text-sm leading-6 text-slate-400"
+            : "mt-2 text-sm leading-6 text-slate-600"
+        }
+      >
+        {formatMealPlanWindow(mealPlan.startDate, mealPlan.endDate)}
+      </p>
+    </Link>
+  );
+}
+
+function WeekDayMenuCard({
+  day,
+  familyId,
+}: {
+  day: Awaited<ReturnType<typeof getFamilyWeekDinnerMenu>>[number];
+  familyId: string;
+}) {
+  const content = (
+    <>
+      <p className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500">
+        {day.weekdayLabel}
+      </p>
+      <p className="mt-1 text-sm text-slate-500">{day.dateLabel}</p>
+      <p className="mt-3 text-base font-semibold leading-snug text-slate-950">
+        {day.menuLabel}
+      </p>
+      {day.mealPlanTitle ? (
+        <p className="mt-2 text-xs text-slate-500">{day.mealPlanTitle}</p>
+      ) : null}
+    </>
+  );
+
+  const cardClassName = day.isToday
+    ? "rounded-[24px] border border-emerald-200 bg-emerald-50 p-4 ring-1 ring-emerald-100"
+    : "rounded-[24px] border border-slate-200 bg-slate-50 p-4";
+
+  if (day.mealPlanId) {
+    return (
+      <Link
+        className={`${cardClassName} block transition hover:border-slate-300 hover:bg-white`}
+        to={`/families/${familyId}/meal-plans/${day.mealPlanId}`}
+      >
+        {day.isToday ? (
+          <span className="mb-2 inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-800">
+            I dag
+          </span>
+        ) : null}
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <article className={cardClassName}>
+      {day.isToday ? (
+        <span className="mb-2 inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-800">
+          I dag
+        </span>
+      ) : null}
+      {content}
+    </article>
+  );
 }
 
 export const meta: Route.MetaFunction = () => {
@@ -75,10 +241,26 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     familyId,
     userId: user.id,
   });
-  const members =
-    membership.role === "ADMIN" ? await listFamilyMembers(familyId) : [];
+  const [members, mealPlanResult, weekDays] = await Promise.all([
+    membership.role === "ADMIN"
+      ? listFamilyMembers(familyId)
+      : Promise.resolve([]),
+    listMealPlansForFamily({
+      familyId,
+      userId: user.id,
+    }),
+    getFamilyWeekDinnerMenu({
+      familyId,
+      userId: user.id,
+    }),
+  ]);
+
+  const serializedMealPlans = mealPlanResult.mealPlans.map(
+    serializeMealPlanSummary,
+  );
 
   return {
+    activeTab: getFamilyHomeTab(request),
     family: {
       id: membership.family.id,
       joinCode: membership.role === "ADMIN" ? membership.family.joinCode : null,
@@ -86,8 +268,10 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     },
     members,
     notice: getFamilyNotice(request),
+    recentMealPlans: serializedMealPlans.slice(0, 3),
     user,
     userRole: membership.role,
+    weekDays,
   };
 }
 
@@ -168,6 +352,7 @@ export default function FamilyRoute({
   const isRemovingMember =
     navigation.state === "submitting" && pendingIntent === "remove-member";
   const isAdmin = loaderData.userRole === "ADMIN";
+  const familyId = loaderData.family.id;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -199,169 +384,241 @@ export default function FamilyRoute({
           </section>
         ) : null}
 
-        <section className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
-          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <div className="flex items-center justify-between gap-3">
-              <h2 className="text-lg font-semibold text-slate-950">
-                Din tilgang
-              </h2>
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
-                {isAdmin ? "Admin" : "Medlem"}
-              </span>
-            </div>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
-              {isAdmin
-                ? "Administratorer kan se familiekoden og fjerne vanlige medlemmer ved behov."
-                : "Bare administratorer kan se familiekoden og administrere medlemmer."}
-            </p>
-          </article>
+        <FamilyHomeTabs
+          activeTab={loaderData.activeTab}
+          familiePanel={
+            <>
+              <section className="grid gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
+                <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      Din tilgang
+                    </h2>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
+                      {isAdmin ? "Admin" : "Medlem"}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-600">
+                    {isAdmin
+                      ? "Administratorer kan se familiekoden og fjerne vanlige medlemmer ved behov."
+                      : "Bare administratorer kan se familiekoden og administrere medlemmer."}
+                  </p>
+                </article>
 
-          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">
-              Familiekode
-            </h2>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
-              {loaderData.family.joinCode
-                ? "Del denne koden med personer som skal bli med i familien."
-                : "Familiekoden er bare synlig for administratorer."}
-            </p>
-            <p className="mt-4 text-2xl font-semibold tracking-[0.28em] text-slate-950">
-              {loaderData.family.joinCode ?? "Skjult"}
-            </p>
-          </article>
-        </section>
+                {isAdmin ? (
+                  <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      Familiekode
+                    </h2>
+                    <p className="mt-3 text-sm leading-6 text-slate-600">
+                      Del denne koden med personer som skal bli med i familien.
+                    </p>
+                    <p className="mt-4 text-2xl font-semibold tracking-[0.28em] text-slate-950">
+                      {loaderData.family.joinCode}
+                    </p>
+                  </article>
+                ) : (
+                  <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      Familieinnstillinger
+                    </h2>
+                    <p className="mt-3 text-sm leading-6 text-slate-600">
+                      Familiekode og medlemsadministrasjon er bare tilgjengelig
+                      for administratorer.
+                    </p>
+                  </article>
+                )}
+              </section>
 
-        <section className="grid gap-4 lg:grid-cols-2">
-          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div>
+              {isAdmin ? (
+                <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+                  <div className="flex flex-col gap-2">
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      Medlemmer
+                    </h2>
+                    <p className="text-sm leading-6 text-slate-600">
+                      Du kan fjerne vanlige medlemmer fra familien. Andre
+                      administratorer kan ikke fjernes her.
+                    </p>
+                  </div>
+
+                  <div className="mt-6 grid gap-4">
+                    {loaderData.members.map(
+                      (member: (typeof loaderData.members)[number]) => {
+                        const canRemove = member.role === "MEMBER";
+                        const isPendingRemoval =
+                          isRemovingMember &&
+                          pendingTargetUserId === member.user.id;
+                        const memberError =
+                          actionData?.targetUserId === member.user.id
+                            ? actionData.formError
+                            : undefined;
+
+                        return (
+                          <article
+                            key={member.id}
+                            className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                          >
+                            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                              <div>
+                                <div className="flex flex-wrap items-center gap-3">
+                                  <h3 className="text-base font-semibold text-slate-950">
+                                    {member.user.displayName}
+                                  </h3>
+                                  <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
+                                    {member.role === "ADMIN"
+                                      ? "Admin"
+                                      : "Medlem"}
+                                  </span>
+                                </div>
+                                <p className="mt-2 text-sm leading-6 text-slate-600">
+                                  {member.user.email}
+                                </p>
+                              </div>
+
+                              {canRemove ? (
+                                <Form method="post">
+                                  <input
+                                    name="intent"
+                                    type="hidden"
+                                    value="remove-member"
+                                  />
+                                  <input
+                                    name="targetUserId"
+                                    type="hidden"
+                                    value={member.user.id}
+                                  />
+                                  <button
+                                    className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+                                    disabled={isRemovingMember}
+                                    type="submit"
+                                  >
+                                    {isPendingRemoval
+                                      ? "Fjerner..."
+                                      : "Fjern medlem"}
+                                  </button>
+                                </Form>
+                              ) : null}
+                            </div>
+
+                            {memberError ? (
+                              <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                                {memberError}
+                              </p>
+                            ) : null}
+                          </article>
+                        );
+                      },
+                    )}
+                  </div>
+                </section>
+              ) : null}
+            </>
+          }
+          oversiktPanel={
+            <>
+              <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
                 <h2 className="text-lg font-semibold text-slate-950">
-                  Ukeplaner
+                  Denne uken
                 </h2>
-                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                  Gå videre til familiens ukeplaner for å opprette, velge og
-                  oppdatere planer med start- og sluttdato.
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Middagsmeny for hver dag i inneværende kalenderuke.
                 </p>
-              </div>
 
-              <Link
-                className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
-                to={`/families/${loaderData.family.id}/meal-plans`}
-              >
-                Administrer ukeplaner
-              </Link>
-            </div>
-          </article>
-
-          <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div>
-                <h2 className="text-lg font-semibold text-slate-950">
-                  Alltid på listen
-                </h2>
-                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                  Varer som skal handles uansett ukeplan, for eksempel
-                  batterier eller andre faste behov.
-                </p>
-              </div>
-
-              <Link
-                className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
-                to={`/families/${loaderData.family.id}/shopping`}
-              >
-                Åpne listen
-              </Link>
-            </div>
-          </article>
-        </section>
-
-        {isAdmin ? (
-          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <div className="flex flex-col gap-2">
-              <h2 className="text-lg font-semibold text-slate-950">
-                Medlemmer
-              </h2>
-              <p className="text-sm leading-6 text-slate-600">
-                Du kan fjerne vanlige medlemmer fra familien. Andre
-                administratorer kan ikke fjernes her.
-              </p>
-            </div>
-
-            <div className="mt-6 grid gap-4">
-              {loaderData.members.map(
-                (member: (typeof loaderData.members)[number]) => {
-                  const canRemove = member.role === "MEMBER";
-                  const isPendingRemoval =
-                    isRemovingMember && pendingTargetUserId === member.user.id;
-                  const memberError =
-                    actionData?.targetUserId === member.user.id
-                      ? actionData.formError
-                      : undefined;
-
-                  return (
-                    <article
-                      key={member.id}
-                      className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                {loaderData.weekDays.some((day) => day.mealPlanId) ? (
+                  <div className="mt-6 grid gap-4 md:grid-cols-7">
+                    {loaderData.weekDays.map((day) => (
+                      <WeekDayMenuCard
+                        key={day.date}
+                        day={day}
+                        familyId={familyId}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-6 rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-5 py-4 text-sm leading-6 text-slate-600">
+                    Ingen ukeplaner denne uken.{" "}
+                    <Link
+                      className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500"
+                      to={`/families/${familyId}/meal-plans`}
                     >
-                      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                        <div>
-                          <div className="flex flex-wrap items-center gap-3">
-                            <h3 className="text-base font-semibold text-slate-950">
-                              {member.user.displayName}
-                            </h3>
-                            <span className="rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200">
-                              {member.role === "ADMIN" ? "Admin" : "Medlem"}
-                            </span>
-                          </div>
-                          <p className="mt-2 text-sm leading-6 text-slate-600">
-                            {member.user.email}
-                          </p>
-                        </div>
+                      Opprett eller velg en plan
+                    </Link>
+                    .
+                  </p>
+                )}
+              </section>
 
-                        {canRemove ? (
-                          <Form method="post">
-                            <input
-                              name="intent"
-                              type="hidden"
-                              value="remove-member"
-                            />
-                            <input
-                              name="targetUserId"
-                              type="hidden"
-                              value={member.user.id}
-                            />
-                            <button
-                              className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
-                              disabled={isRemovingMember}
-                              type="submit"
-                            >
-                              {isPendingRemoval ? "Fjerner..." : "Fjern medlem"}
-                            </button>
-                          </Form>
-                        ) : null}
-                      </div>
+              <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+                <h2 className="text-lg font-semibold text-slate-950">
+                  Siste ukeplaner
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  De tre nyeste ukeplanene i familien.
+                </p>
 
-                      {memberError ? (
-                        <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-                          {memberError}
-                        </p>
-                      ) : null}
-                    </article>
-                  );
-                },
-              )}
-            </div>
-          </section>
-        ) : (
-          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-            <h2 className="text-lg font-semibold text-slate-950">Neste steg</h2>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-              Familieadministrasjon ligger hos administratorene. Du kan
-              fortsette videre til resten av den beskyttede appen fra oversikten
-              din.
-            </p>
-          </section>
-        )}
+                {loaderData.recentMealPlans.length > 0 ? (
+                  <div className="mt-6 grid gap-4">
+                    {loaderData.recentMealPlans.map((mealPlan) => (
+                      <MealPlanLinkCard
+                        key={mealPlan.id}
+                        familyId={familyId}
+                        isPast={isMealPlanPast(mealPlan.endDate)}
+                        mealPlan={mealPlan}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-6 rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-5 py-4 text-sm leading-6 text-slate-600">
+                    Ingen ukeplaner ennå. Opprett den første planen for å komme
+                    i gang.
+                  </p>
+                )}
+              </section>
+
+              <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <h2 className="text-lg font-semibold text-slate-950">
+                      Handleliste
+                    </h2>
+                    <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                      Gå rett til handlelisten for dagens eller siste aktive
+                      ukeplan.
+                    </p>
+                  </div>
+
+                  <Link
+                    className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                    to={`/families/${familyId}/store-mode`}
+                  >
+                    Åpne handleliste
+                  </Link>
+                </div>
+
+                <p className="mt-4 text-sm leading-6 text-slate-600">
+                  Trenger du varer uten ukeplan?{" "}
+                  <Link
+                    className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500"
+                    to={`/families/${familyId}/shopping`}
+                  >
+                    Åpne Alltid på listen
+                  </Link>
+                  .
+                </p>
+              </section>
+
+              <p className="text-center text-sm text-slate-600">
+                <Link
+                  className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500"
+                  to={`/families/${familyId}/meal-plans`}
+                >
+                  Administrer ukeplaner
+                </Link>
+              </p>
+            </>
+          }
+        />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Split `/families/:familyId` into **Oversikt** (default) and **Familie** tabs with URL-driven state (`?tab=familie`).
- **Oversikt** shows the three latest meal plans (muted when ended), a Mon–Sun dinner menu for the current week, and quick links to store-mode and Alltid på listen.
- **Familie** keeps access role, join code, and member management; successful member removal opens the Familie tab with the existing notice.

## Related issue
Closes #125

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Open family home as admin: switch tabs, verify week grid and recent plans
- [ ] Open as member: Familie tab shows limited content, no join code leak
- [ ] Remove a member: lands on Familie tab with success notice
- [ ] Past meal plans in Siste ukeplaner appear muted

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck