### PR TITLE
Consolidate store-mode header into meta strip

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,30 @@
 
 ## Current Objective
 
-Issue #125 on branch `issue/125-family-home-tabs`: family home with Oversikt/Familie tabs — ready for PR merge.
+Issue #127 on branch `issue/127-store-mode-header`: consolidate butikkmodus header — ready for PR review.
 
 ## Completed
 
-- Two-tab family route (`Oversikt` / `Familie`) with URL `?tab=familie`.
-- Oversikt: 3 recent meal plans (muted when past), weekly dinner menu per day (Mon–Sun), store-mode + Alltid på listen links.
-- Familie: Din tilgang, Familiekode, Medlemmer (unchanged permissions); member-remove redirects to Familie tab.
-- Helpers: `meal-plan-week.ts`, `meal-plan-display.ts`, `family-home.server.ts`, `family-home-tabs.tsx`.
+- Moved store and shopping-date selects into the meta strip; removed **Butikk og handledato** `<details>` panel and duplicate static store/date text.
+- Added compact `storeModeMetaStoreSelectClass` / `storeModeMetaDateSelectClass` in store-mode theme.
+- Optional `aria-label` on `ShoppingDateSelect` for header accessibility.
 
 ## Files To Read First
 
-- `app/routes/family.tsx`
-- `app/lib/family-home.server.ts`
-- `app/components/family-home-tabs.tsx`
+- `app/routes/family-meal-plan-store-mode.tsx` — meta strip layout and inline forms
+- `app/lib/store-mode-theme.ts` — compact select tokens
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (297 tests)
+- `npm run test:run` — passed (298 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual QA after merge: tab keyboard nav; past-plan muted styling; week grid on mobile vs desktop.
+- Manual QA: change store/date from header; narrow viewport wrap; validation errors near controls.
 
 ## Next Step
 
-Merge PR (Closes #125) after review/CI.
+Merge PR (Closes #127) after review/CI.

--- a/app/components/shopping-list-item-expanded.tsx
+++ b/app/components/shopping-list-item-expanded.tsx
@@ -39,6 +39,7 @@ function formatShoppingDateOptionLabel(value: string) {
 
 export function ShoppingDateSelect({
   "aria-busy": ariaBusy,
+  "aria-label": ariaLabel,
   className = shoppingDateInputClassName,
   defaultValue,
   disabled = false,
@@ -49,6 +50,7 @@ export function ShoppingDateSelect({
   showEmptyOption = true,
 }: {
   "aria-busy"?: boolean;
+  "aria-label"?: string;
   className?: string;
   defaultValue: string;
   disabled?: boolean;
@@ -66,6 +68,7 @@ export function ShoppingDateSelect({
   return (
     <select
       aria-busy={ariaBusy}
+      aria-label={ariaLabel}
       className={className}
       defaultValue={defaultValue}
       disabled={disabled}

--- a/app/lib/store-mode-theme.test.ts
+++ b/app/lib/store-mode-theme.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { getStoreModeBannerClass } from "./store-mode-theme";
+import {
+  getStoreModeBannerClass,
+  storeModeMetaDateSelectClass,
+  storeModeMetaStoreSelectClass,
+  storeModeSelectClass,
+} from "./store-mode-theme";
 
 describe("store-mode-theme", () => {
   it("returns distinct banner classes per tone", () => {
@@ -12,5 +17,12 @@ describe("store-mode-theme", () => {
     expect(sync).toContain("amber");
     expect(error).toContain("rose");
     expect(success).not.toBe(sync);
+  });
+
+  it("uses compact auto-width meta selects distinct from full-width selects", () => {
+    expect(storeModeMetaStoreSelectClass).toContain("w-auto");
+    expect(storeModeMetaStoreSelectClass).not.toContain("w-full");
+    expect(storeModeMetaDateSelectClass).toContain("max-w-[9rem]");
+    expect(storeModeSelectClass).toContain("w-full");
   });
 });

--- a/app/lib/store-mode-theme.ts
+++ b/app/lib/store-mode-theme.ts
@@ -24,6 +24,13 @@ export const storeModeAccentBarClass =
 export const storeModeSelectClass =
   "w-full rounded-2xl border border-stone-300 bg-white px-4 py-3 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60 disabled:cursor-wait disabled:bg-stone-50";
 
+const storeModeMetaSelectBase =
+  "min-w-0 w-auto truncate rounded-xl border border-stone-300 bg-white px-3 py-1.5 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60 disabled:cursor-wait disabled:bg-stone-50";
+
+export const storeModeMetaStoreSelectClass = `${storeModeMetaSelectBase} max-w-[11rem]`;
+
+export const storeModeMetaDateSelectClass = `${storeModeMetaSelectBase} max-w-[9rem]`;
+
 export const storeModeCountChipClass =
   "rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600";
 

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -55,6 +55,8 @@ import {
   storeModeAccentBarClass,
   storeModeCountChipClass,
   storeModeLaterChipClass,
+  storeModeMetaDateSelectClass,
+  storeModeMetaStoreSelectClass,
   storeModeMetaStripClass,
   storeModeMutedPanelClass,
   storeModePageClass,
@@ -62,7 +64,6 @@ import {
   storeModeProgressPillClass,
   storeModeQuickAddDockClass,
   storeModeSectionCardClass,
-  storeModeSelectClass,
   storeModeSurfaceCardClass,
 } from "../lib/store-mode-theme";
 import {
@@ -515,15 +516,63 @@ export default function FamilyMealPlanStoreModeRoute({
           <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
             ·
           </span>
-          <span className="truncate text-stone-600">
-            {loaderData.selectedStore?.name ?? "Ingen butikk"}
-          </span>
-          <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
-            ·
-          </span>
-          <span className="truncate text-stone-600">
-            {formatDateLabel(loaderData.activeShoppingDate)}
-          </span>
+          <Form className="inline-flex min-w-0 flex-col gap-1" method="post">
+            <input name="intent" type="hidden" value="update-selected-store" />
+            <select
+              aria-busy={isSavingStore}
+              aria-label="Velg butikk"
+              className={storeModeMetaStoreSelectClass}
+              defaultValue={selectedStoreValue}
+              disabled={isSavingStore}
+              name="selectedStoreId"
+              onChange={(event) => {
+                submitSelectForm(event, selectedStoreValue, submit);
+              }}
+            >
+              {loaderData.stores.map((store) => (
+                <option key={store.id} value={store.id}>
+                  {store.name}
+                </option>
+              ))}
+            </select>
+            {actionData?.intent === "update-selected-store" &&
+            actionData.selectedStoreFieldErrors?.selectedStoreId ? (
+              <p className="text-sm text-rose-600">
+                {actionData.selectedStoreFieldErrors.selectedStoreId}
+              </p>
+            ) : null}
+          </Form>
+          <Form className="inline-flex min-w-0 flex-col gap-1" method="post">
+            <input
+              name="intent"
+              type="hidden"
+              value="update-active-shopping-date"
+            />
+            <input
+              name="mealPlanUpdatedAt"
+              type="hidden"
+              value={loaderData.mealPlan.updatedAt}
+            />
+            <ShoppingDateSelect
+              aria-busy={isSavingShoppingDate}
+              aria-label="Velg handledato"
+              className={storeModeMetaDateSelectClass}
+              defaultValue={activeShoppingDateValue}
+              disabled={isSavingShoppingDate}
+              name="activeShoppingDate"
+              onChange={(event) => {
+                submitSelectForm(event, activeShoppingDateValue, submit);
+              }}
+              selectableShoppingDates={loaderData.selectableShoppingDates}
+              showEmptyOption={false}
+            />
+            {actionData?.intent === "update-active-shopping-date" &&
+            actionData.activeShoppingDateFieldErrors?.activeShoppingDate ? (
+              <p className="text-sm text-rose-600">
+                {actionData.activeShoppingDateFieldErrors.activeShoppingDate}
+              </p>
+            ) : null}
+          </Form>
           <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
             ·
           </span>
@@ -581,91 +630,6 @@ export default function FamilyMealPlanStoreModeRoute({
             <p className="mt-2 text-sm leading-6">{generalFormError}</p>
           </section>
         ) : null}
-
-        <details className={storeModeSectionCardClass}>
-          <summary className="cursor-pointer text-sm font-medium text-stone-800">
-            Butikk og handledato
-            <span className="ml-2 font-normal text-stone-500">
-              {loaderData.selectedStore?.name ?? "Ingen butikk"} ·{" "}
-              {formatDateLabel(loaderData.activeShoppingDate)}
-            </span>
-          </summary>
-          <div className="mt-4 grid gap-4 sm:grid-cols-2">
-            <article>
-              <h2 className="text-base font-semibold text-stone-950">
-                Velg butikk
-              </h2>
-              <Form className="mt-4 space-y-3" method="post">
-                <input
-                  name="intent"
-                  type="hidden"
-                  value="update-selected-store"
-                />
-                <select
-                  aria-busy={isSavingStore}
-                  className={storeModeSelectClass}
-                  defaultValue={selectedStoreValue}
-                  disabled={isSavingStore}
-                  name="selectedStoreId"
-                  onChange={(event) => {
-                    submitSelectForm(event, selectedStoreValue, submit);
-                  }}
-                >
-                  {loaderData.stores.map((store) => (
-                    <option key={store.id} value={store.id}>
-                      {store.name}
-                    </option>
-                  ))}
-                </select>
-                {actionData?.intent === "update-selected-store" &&
-                actionData.selectedStoreFieldErrors?.selectedStoreId ? (
-                  <p className="text-sm text-rose-600">
-                    {actionData.selectedStoreFieldErrors.selectedStoreId}
-                  </p>
-                ) : null}
-              </Form>
-            </article>
-
-            <article>
-              <h2 className="text-base font-semibold text-stone-950">
-                Velg handledato
-              </h2>
-              <Form className="mt-4 space-y-3" method="post">
-                <input
-                  name="intent"
-                  type="hidden"
-                  value="update-active-shopping-date"
-                />
-                <input
-                  name="mealPlanUpdatedAt"
-                  type="hidden"
-                  value={loaderData.mealPlan.updatedAt}
-                />
-                <ShoppingDateSelect
-                  aria-busy={isSavingShoppingDate}
-                  className={storeModeSelectClass}
-                  defaultValue={activeShoppingDateValue}
-                  disabled={isSavingShoppingDate}
-                  name="activeShoppingDate"
-                  onChange={(event) => {
-                    submitSelectForm(event, activeShoppingDateValue, submit);
-                  }}
-                  selectableShoppingDates={loaderData.selectableShoppingDates}
-                  showEmptyOption={false}
-                />
-                {actionData?.intent === "update-active-shopping-date" &&
-                actionData.activeShoppingDateFieldErrors?.activeShoppingDate ? (
-                  <p className="text-sm text-rose-600">
-                    {
-                      actionData.activeShoppingDateFieldErrors
-                        .activeShoppingDate
-                    }
-                  </p>
-                ) : null}
-              </Form>
-            </article>
-          </div>
-        </details>
 
         {displaySectionGroups.length > 0 ? (
           <section className="grid gap-4">


### PR DESCRIPTION
## Summary
- Moves store and shopping-date selects into the top butikkmodus meta strip so plan title, controls, progress, and links live in one row.
- Removes the redundant **Butikk og handledato** collapsible panel and duplicate static store/date text.
- Adds compact meta-strip select styles and optional `aria-label` on `ShoppingDateSelect` for accessibility.

## Related issue
Closes #127

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: change store and date from header; confirm list updates and notices
- [ ] Manual: narrow viewport — controls wrap, links remain reachable
- [ ] Manual: trigger date validation error — message appears near header control

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (298 tests)
- npm run typecheck