### PR TITLE
Improve mobile quick-add feedback visibility

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,18 +2,21 @@
 
 ## Current Objective
 
-Issue #127 on branch `issue/127-store-mode-header`: consolidate butikkmodus header — ready for PR review.
+Issue #129 on branch `issue/129-mobile-quick-add-feedback`: improve mobile quick-add feedback so newly added items are easy to find.
 
 ## Completed
 
-- Moved store and shopping-date selects into the meta strip; removed **Butikk og handledato** `<details>` panel and duplicate static store/date text.
-- Added compact `storeModeMetaStoreSelectClass` / `storeModeMetaDateSelectClass` in store-mode theme.
-- Optional `aria-label` on `ShoppingDateSelect` for header accessibility.
+- Added quick-add feedback helper to scroll to the newly added item using `sourceKey` targeting.
+- Updated store mode and family shopping quick-add flows to set and clear `recentlyAddedSourceKey` after success.
+- Added full-row/card highlight state for recently added items and smooth fade back to baseline using `transition-colors duration-250`.
+- Tuned highlight lifecycle to remain visible briefly before clearing, and ensured clearing still runs even if scroll targeting does not find an element.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx` — meta strip layout and inline forms
-- `app/lib/store-mode-theme.ts` — compact select tokens
+- `app/routes/family-meal-plan-store-mode.tsx` — quick-add success handling, highlight timeout, and item-grid highlight wiring
+- `app/routes/family-shopping.tsx` — quick-add success handling and highlighted row styling
+- `app/components/store-mode-shopping-item-card.tsx` — mutually exclusive visual state classes for highlight/checked/normal
+- `app/lib/shopping-quick-add-feedback.client.ts` — DOM selector and conditional scroll helper
 
 ## Validation
 
@@ -24,8 +27,9 @@ Issue #127 on branch `issue/127-store-mode-header`: consolidate butikkmodus head
 
 ## Open Items
 
-- Manual QA: change store/date from header; narrow viewport wrap; validation errors near controls.
+- Manual QA on mobile viewport: verify quick-add row/card highlight is noticeable and fade-back feels natural in both store mode and family shopping.
+- Decide if highlight dwell time (`900ms`) should be adjusted after product review.
 
 ## Next Step
 
-Merge PR (Closes #127) after review/CI.
+Push branch, open PR, and request UI/UX review focused on mobile quick-add confirmation behavior.

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -41,6 +41,7 @@ export type StoreModeShoppingItemCardItem =
   | StoreModeShoppingItemCardFamily;
 
 interface StoreModeShoppingItemCardProps {
+  isRecentlyAdded?: boolean;
   item: StoreModeShoppingItemCardItem;
   layout: StoreModeShoppingView;
   onToggle: () => void;
@@ -50,6 +51,7 @@ interface StoreModeShoppingItemCardProps {
 const badgeClass = "rounded-full px-2 py-0.5 text-[11px] font-medium leading-4";
 
 export function StoreModeShoppingItemCard({
+  isRecentlyAdded = false,
   item,
   layout: _layout,
   onToggle,
@@ -58,9 +60,12 @@ export function StoreModeShoppingItemCard({
   const quantityBadge = formatGeneratedQuantityBadge(item);
   const shouldAutoOpenDetails = shouldAutoOpenStoreModeDetails(item);
 
-  const cardShellClass = item.checked
-    ? "relative flex h-full min-h-[44px] flex-col rounded-2xl border border-red-200 bg-red-50 p-2.5 transition-colors duration-150"
-    : "relative flex h-full min-h-[44px] flex-col rounded-2xl border border-stone-200 bg-stone-50 p-2.5 transition-colors duration-150";
+  const cardStateClass = isRecentlyAdded
+    ? "border-emerald-300 bg-emerald-100"
+    : item.checked
+      ? "border-red-200 bg-red-50"
+      : "border-stone-200 bg-stone-50";
+  const cardShellClass = `relative flex h-full min-h-[44px] flex-col rounded-2xl border p-2.5 transition-colors duration-250 ${cardStateClass}`;
 
   const toggleOverlayClass = item.checked
     ? "absolute inset-0 z-0 cursor-pointer touch-manipulation rounded-[inherit] transition hover:bg-red-100 active:bg-red-200"
@@ -71,7 +76,10 @@ export function StoreModeShoppingItemCard({
     : "text-sm font-semibold leading-5 text-stone-950";
 
   return (
-    <div className={`block h-full min-w-0 ${cardShellClass}`}>
+    <div
+      className={`scroll-mb-44 block h-full min-w-0 ${cardShellClass}`}
+      data-shopping-source-key={item.sourceKey}
+    >
       <button
         aria-label={
           item.checked

--- a/app/lib/shopping-quick-add-feedback.client.ts
+++ b/app/lib/shopping-quick-add-feedback.client.ts
@@ -1,0 +1,35 @@
+const QUICK_ADD_ITEM_SELECTOR_ATTRIBUTE = "data-shopping-source-key";
+
+function escapeAttributeValue(value: string) {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+export function buildShoppingItemSourceSelector(sourceKey: string) {
+  return `[${QUICK_ADD_ITEM_SELECTOR_ATTRIBUTE}="${escapeAttributeValue(sourceKey)}"]`;
+}
+
+export function shouldScrollItemIntoView(element: HTMLElement) {
+  const rect = element.getBoundingClientRect();
+  const viewportHeight = window.innerHeight;
+
+  return rect.top < 0 || rect.bottom > viewportHeight;
+}
+
+export function scrollToShoppingItem(sourceKey: string) {
+  const selector = buildShoppingItemSourceSelector(sourceKey);
+  const item = document.querySelector<HTMLElement>(selector);
+
+  if (!item) {
+    return false;
+  }
+
+  if (shouldScrollItemIntoView(item)) {
+    item.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
+  }
+
+  return true;
+}

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -39,6 +39,7 @@ import {
   prependRecentManualItem,
 } from "../lib/shopping-list-client";
 import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import { scrollToShoppingItem } from "../lib/shopping-quick-add-feedback.client";
 import { serializeProjectedShoppingItem } from "../lib/shopping-serialize";
 import {
   getMealPlanStoreModeData,
@@ -374,6 +375,9 @@ export default function FamilyMealPlanStoreModeRoute({
   const [recentManualItems, setRecentManualItems] = useState(
     loaderData.recentManualItems,
   );
+  const [recentlyAddedSourceKey, setRecentlyAddedSourceKey] = useState<
+    string | null
+  >(null);
   const isSavingStore =
     navigation.state === "submitting" &&
     pendingIntent === "update-selected-store";
@@ -394,10 +398,29 @@ export default function FamilyMealPlanStoreModeRoute({
       setRecentManualItems((currentRecents) =>
         prependRecentManualItem(currentRecents, payload.recentManualItem),
       );
+      setRecentlyAddedSourceKey(payload.item.sourceKey);
       scheduleRevalidate();
     },
     [scheduleRevalidate],
   );
+
+  useEffect(() => {
+    if (!recentlyAddedSourceKey) {
+      return;
+    }
+
+    scrollToShoppingItem(recentlyAddedSourceKey);
+
+    const clearHighlightTimeoutId = window.setTimeout(() => {
+      setRecentlyAddedSourceKey((current) =>
+        current === recentlyAddedSourceKey ? null : current,
+      );
+    }, 900);
+
+    return () => {
+      window.clearTimeout(clearHighlightTimeoutId);
+    };
+  }, [dueSectionGroups, recentlyAddedSourceKey]);
 
   const loaderDueItems = useMemo(
     () => dueSectionGroups.flatMap((section) => section.items),
@@ -668,6 +691,7 @@ export default function FamilyMealPlanStoreModeRoute({
                     items={section.items}
                     layout={shoppingView}
                     onToggleItem={handleToggle}
+                    recentlyAddedSourceKey={recentlyAddedSourceKey}
                     selectedStoreId={loaderData.selectedStore?.id}
                   />
                 </article>
@@ -698,6 +722,7 @@ export default function FamilyMealPlanStoreModeRoute({
                   items={boughtItems}
                   layout={shoppingView}
                   onToggleItem={handleToggle}
+                  recentlyAddedSourceKey={recentlyAddedSourceKey}
                   selectedStoreId={loaderData.selectedStore?.id}
                 />
               </details>
@@ -860,11 +885,13 @@ function StoreModeItemGrid<
   items,
   layout,
   onToggleItem,
+  recentlyAddedSourceKey,
   selectedStoreId,
 }: {
   items: TItem[];
   layout: StoreModeShoppingView;
   onToggleItem: (item: TItem) => void;
+  recentlyAddedSourceKey: string | null;
   selectedStoreId?: string;
 }) {
   return (
@@ -878,6 +905,7 @@ function StoreModeItemGrid<
       {items.map((item) => (
         <StoreModeShoppingItemCard
           key={item.sourceKey}
+          isRecentlyAdded={recentlyAddedSourceKey === item.sourceKey}
           item={item}
           layout={layout}
           onToggle={() => onToggleItem(item)}

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -40,6 +40,7 @@ import {
   prependRecentManualItem,
 } from "../lib/shopping-list-client";
 import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import { scrollToShoppingItem } from "../lib/shopping-quick-add-feedback.client";
 import {
   serializeProjectedShoppingItem,
   type SerializedProjectedShoppingItem,
@@ -191,7 +192,9 @@ export async function action({
   if (intent === "toggle-meal-plan-shopping-item-checked") {
     const mealPlanId = String(formData.get("mealPlanId") ?? "").trim();
     const sourceKey = String(formData.get("sourceKey") ?? "").trim();
-    const sourceType = parseMealPlanShoppingItemSource(formData.get("sourceType"));
+    const sourceType = parseMealPlanShoppingItemSource(
+      formData.get("sourceType"),
+    );
     const checked = String(formData.get("checked") ?? "") === "true";
 
     if (!mealPlanId || !sourceKey || !sourceType) {
@@ -431,6 +434,9 @@ export default function FamilyShoppingRoute({
   const [recentManualItems, setRecentManualItems] = useState(
     loaderData.recentManualItems,
   );
+  const [recentlyAddedSourceKey, setRecentlyAddedSourceKey] = useState<
+    string | null
+  >(null);
   const noticeContent =
     loaderData.notice !== null
       ? getFamilyShoppingNoticeContent(loaderData.notice)
@@ -457,10 +463,29 @@ export default function FamilyShoppingRoute({
       setRecentManualItems((currentRecents) =>
         prependRecentManualItem(currentRecents, payload.recentManualItem),
       );
+      setRecentlyAddedSourceKey(payload.item.sourceKey);
       scheduleRevalidate();
     },
     [scheduleRevalidate],
   );
+
+  useEffect(() => {
+    if (!recentlyAddedSourceKey) {
+      return;
+    }
+
+    scrollToShoppingItem(recentlyAddedSourceKey);
+
+    const clearHighlightTimeoutId = window.setTimeout(() => {
+      setRecentlyAddedSourceKey((current) =>
+        current === recentlyAddedSourceKey ? null : current,
+      );
+    }, 900);
+
+    return () => {
+      window.clearTimeout(clearHighlightTimeoutId);
+    };
+  }, [recentlyAddedSourceKey, storeGroups]);
 
   const quickAddProps = {
     ingredientSearchPath,
@@ -546,11 +571,7 @@ export default function FamilyShoppingRoute({
                     type="hidden"
                     value="set-family-shopping-list-mode"
                   />
-                  <input
-                    name="listMode"
-                    type="hidden"
-                    value="GLOBAL"
-                  />
+                  <input name="listMode" type="hidden" value="GLOBAL" />
                   <button
                     className={`rounded-2xl px-5 py-3 text-sm font-medium transition ${
                       loaderData.activeListMode === "GLOBAL"
@@ -572,11 +593,7 @@ export default function FamilyShoppingRoute({
                     type="hidden"
                     value="set-family-shopping-list-mode"
                   />
-                  <input
-                    name="listMode"
-                    type="hidden"
-                    value="COMBINED"
-                  />
+                  <input name="listMode" type="hidden" value="COMBINED" />
                   <button
                     className={`rounded-2xl px-5 py-3 text-sm font-medium transition ${
                       loaderData.activeListMode === "COMBINED"
@@ -732,8 +749,10 @@ export default function FamilyShoppingRoute({
                             navigation,
                             pendingIntent,
                             pendingSourceKey,
+                            recentlyAddedSourceKey,
                             stores: loaderData.stores,
-                            todayMealPlanId: loaderData.todayMealPlan?.id ?? null,
+                            todayMealPlanId:
+                              loaderData.todayMealPlan?.id ?? null,
                           }),
                         )}
                       </div>
@@ -893,20 +912,23 @@ function parseMealPlanShoppingItemSource(value: FormDataEntryValue | null) {
 function getFamilyShoppingSourceBadge(item: SerializedProjectedShoppingItem) {
   if (item.sourceType === "FAMILY") {
     return {
-      className: "rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800",
+      className:
+        "rounded-full bg-violet-100 px-3 py-1 text-xs font-medium text-violet-800",
       label: "Global",
     };
   }
 
   if (item.sourceType === "GENERATED") {
     return {
-      className: "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800",
+      className:
+        "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800",
       label: "Ukeplan",
     };
   }
 
   return {
-    className: "rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700",
+    className:
+      "rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-700",
     label: "Ukeplan · Manuell",
   };
 }
@@ -966,6 +988,7 @@ function renderFamilyShoppingListItem({
   navigation,
   pendingIntent,
   pendingSourceKey,
+  recentlyAddedSourceKey,
   stores,
   todayMealPlanId,
 }: {
@@ -976,6 +999,7 @@ function renderFamilyShoppingListItem({
   navigation: ReturnType<typeof useNavigation>;
   pendingIntent: FormDataEntryValue | null | undefined;
   pendingSourceKey: string | null;
+  recentlyAddedSourceKey: string | null;
   stores: Awaited<ReturnType<typeof loader>>["stores"];
   todayMealPlanId: string | null;
 }) {
@@ -1009,15 +1033,18 @@ function renderFamilyShoppingListItem({
             quantity: item.quantity ?? "",
           }
         : null;
+  const rowStateClass =
+    recentlyAddedSourceKey === item.sourceKey
+      ? "border-emerald-300 bg-emerald-100"
+      : item.checked
+        ? "border-slate-200 bg-slate-100 opacity-80"
+        : "border-slate-200 bg-slate-50";
 
   return (
     <article
       key={item.sourceKey}
-      className={`rounded-[24px] border p-4 ${
-        item.checked
-          ? "border-slate-200 bg-slate-100 opacity-80"
-          : "border-slate-200 bg-slate-50"
-      }`}
+      className={`scroll-mb-44 rounded-[24px] border p-4 transition-colors duration-250 ${rowStateClass}`}
+      data-shopping-source-key={item.sourceKey}
     >
       <div className="flex flex-wrap items-center gap-2">
         <h4


### PR DESCRIPTION
## Summary
- Scroll to the newly quick-added shopping item using `sourceKey` targeting so users can immediately find where it was inserted.
- Add a temporary full-row/card highlight for quick-added items and fade it back with `transition-colors` to confirm add success without extra UI chrome.
- Apply the behavior in both family shopping mobile quick-add and meal-plan store mode quick-add, plus update handoff context for follow-up QA.

## Related issue
Closes #129

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual checks on mobile viewport for scroll positioning and highlight/fade feel

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck