### PR TITLE
Redirect authenticated /login visits to /app

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,32 @@
 
 ## Current Objective
 
-Issue #129 on branch `issue/129-mobile-quick-add-feedback`: improve mobile quick-add feedback so newly added items are easy to find.
+Issue #130 on branch `issue/130-redirect-authenticated-users-app`: redirect authenticated users away from `/login` to `/app`.
 
 ## Completed
 
-- Added quick-add feedback helper to scroll to the newly added item using `sourceKey` targeting.
-- Updated store mode and family shopping quick-add flows to set and clear `recentlyAddedSourceKey` after success.
-- Added full-row/card highlight state for recently added items and smooth fade back to baseline using `transition-colors duration-250`.
-- Tuned highlight lifecycle to remain visible briefly before clearing, and ensured clearing still runs even if scroll targeting does not find an element.
+- Extended `requireAnonymous` to support an explicit authenticated redirect target.
+- Updated login route loader and action to force authenticated traffic to `/app`.
+- Added login loader coverage for unauthenticated safe `redirectTo` handling and authenticated redirect behavior.
+- Added action assertions to ensure login route calls the anonymous guard with `/app` override.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx` — quick-add success handling, highlight timeout, and item-grid highlight wiring
-- `app/routes/family-shopping.tsx` — quick-add success handling and highlighted row styling
-- `app/components/store-mode-shopping-item-card.tsx` — mutually exclusive visual state classes for highlight/checked/normal
-- `app/lib/shopping-quick-add-feedback.client.ts` — DOM selector and conditional scroll helper
+- `app/lib/auth.server.ts` - anonymous/authenticated route guard behavior
+- `app/routes/login.tsx` - login loader/action guard wiring
+- `app/routes/login.test.ts` - loader and action coverage for redirect behavior
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (298 tests)
+- `npm run test:run` — passed (300 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual QA on mobile viewport: verify quick-add row/card highlight is noticeable and fade-back feels natural in both store mode and family shopping.
-- Decide if highlight dwell time (`900ms`) should be adjusted after product review.
+- Optional manual verification: while authenticated, visit `/login` directly and confirm immediate redirect to `/app`.
 
 ## Next Step
 
-Push branch, open PR, and request UI/UX review focused on mobile quick-add confirmation behavior.
+Commit branch changes, push, and open PR with `Closes #130`.

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -94,15 +94,23 @@ export async function requireUser(request: Request) {
   return user;
 }
 
-export async function requireAnonymous(request: Request) {
+export async function requireAnonymous(
+  request: Request,
+  options?: {
+    authenticatedRedirectTo?: string;
+  },
+) {
   const user = await getCurrentUser(request);
 
   if (!user) {
     return;
   }
 
+  const authenticatedRedirectTo = options?.authenticatedRedirectTo;
   const url = new URL(request.url);
-  const redirectTo = getSafeRedirectTo(url.searchParams.get("redirectTo"));
+  const redirectTo = authenticatedRedirectTo
+    ? getSafeRedirectTo(authenticatedRedirectTo)
+    : getSafeRedirectTo(url.searchParams.get("redirectTo"));
 
   throw redirect(redirectTo);
 }

--- a/app/routes/login.test.ts
+++ b/app/routes/login.test.ts
@@ -12,7 +12,48 @@ vi.mock("../lib/auth.server", async () => {
 });
 
 import { loginUser, requireAnonymous, signInUser } from "../lib/auth.server";
-import { action } from "./login";
+import { action, loader } from "./login";
+
+describe("login route loader", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a safe redirect target for unauthenticated users", async () => {
+    vi.mocked(requireAnonymous).mockResolvedValue(undefined);
+
+    const result = await loader({
+      params: {},
+      request: new Request("http://localhost/login?redirectTo=%2Ffamilies%2Ffamily-1"),
+      context: {} as never,
+    } as unknown as Parameters<typeof loader>[0]);
+
+    expect(requireAnonymous).toHaveBeenCalledWith(expect.any(Request), {
+      authenticatedRedirectTo: "/app",
+    });
+    expect(result).toEqual({
+      redirectTo: "/families/family-1",
+    });
+  });
+
+  it("forces authenticated users to /app before rendering login", async () => {
+    const redirectResponse = new Response(null, {
+      headers: {
+        Location: "/app",
+      },
+      status: 302,
+    });
+    vi.mocked(requireAnonymous).mockRejectedValue(redirectResponse);
+
+    await expect(
+      loader({
+        params: {},
+        request: new Request("http://localhost/login?redirectTo=%2Ffamilies%2Ffamily-1"),
+        context: {} as never,
+      } as unknown as Parameters<typeof loader>[0]),
+    ).rejects.toBe(redirectResponse);
+  });
+});
 
 describe("login route action", () => {
   afterEach(() => {
@@ -20,6 +61,8 @@ describe("login route action", () => {
   });
 
   it("returns field errors when required fields are missing", async () => {
+    vi.mocked(requireAnonymous).mockResolvedValue(undefined);
+
     const request = new Request("http://localhost/login", {
       body: new FormData(),
       method: "POST",
@@ -66,6 +109,9 @@ describe("login route action", () => {
         email: "test@example.com",
       },
     });
+    expect(requireAnonymous).toHaveBeenCalledWith(request, {
+      authenticatedRedirectTo: "/app",
+    });
   });
 
   it("creates a session and redirects on successful login", async () => {
@@ -105,6 +151,9 @@ describe("login route action", () => {
       redirectTo: "/app",
       request,
       userId: "user-1",
+    });
+    expect(requireAnonymous).toHaveBeenCalledWith(request, {
+      authenticatedRedirectTo: "/app",
     });
     expect(result).toBe(redirectResponse);
   });

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -12,7 +12,7 @@ export const meta: Route.MetaFunction = () => {
 };
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await requireAnonymous(request);
+  await requireAnonymous(request, { authenticatedRedirectTo: "/app" });
 
   const url = new URL(request.url);
 
@@ -22,7 +22,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await requireAnonymous(request);
+  await requireAnonymous(request, { authenticatedRedirectTo: "/app" });
 
   const formData = await request.formData();
   const email = String(formData.get("email") ?? "");


### PR DESCRIPTION
## Summary
- Force authenticated requests to `/login` to redirect to `/app` in both loader and action flows.
- Extend the anonymous guard with an explicit authenticated redirect option so login can enforce deterministic behavior without changing other routes.
- Add login route loader coverage plus action assertions to lock in redirect behavior.

## Related issue
Closes #130

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual checks (list any UI/flow checks performed)

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck