### PR TITLE
Fix mobile quick-add focus overflow on shopping docks

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,33 @@
 
 ## Current Objective
 
-Issue #130 on branch `issue/130-redirect-authenticated-users-app`: redirect authenticated users away from `/login` to `/app`.
+Issue #132 on branch `issue/132-mobile-quick-add-overflow`: prevent mobile horizontal overflow when focusing `ManualShoppingQuickAdd` while keeping quick-add focus behavior usable.
 
 ## Completed
 
-- Extended `requireAnonymous` to support an explicit authenticated redirect target.
-- Updated login route loader and action to force authenticated traffic to `/app`.
-- Added login loader coverage for unauthenticated safe `redirectTo` handling and authenticated redirect behavior.
-- Added action assertions to ensure login route calls the anonymous guard with `/app` override.
+- Hardened `ManualShoppingQuickAdd` container sizing to enforce `min-w-0`/`max-w-full` and clipped horizontal overflow in focus/reveal states.
+- Updated quick-add input flex behavior (`w-0` with `flex-1`) in both default and store-mode styles to prevent intrinsic width growth on mobile.
+- Added scoped overflow guards to mobile fixed quick-add docks in family shopping and store-mode routes.
+- Updated store-mode quick-add dock theme class to include width/overflow constraints for safe reuse.
 
 ## Files To Read First
 
-- `app/lib/auth.server.ts` - anonymous/authenticated route guard behavior
-- `app/routes/login.tsx` - login loader/action guard wiring
-- `app/routes/login.test.ts` - loader and action coverage for redirect behavior
+- `app/components/manual-shopping-quick-add.tsx` - core quick-add focus/reveal layout constraints and input sizing
+- `app/routes/family-shopping.tsx` - mobile fixed quick-add dock wrapper constraints
+- `app/routes/family-meal-plan-store-mode.tsx` - store-mode mobile dock wrapper constraints
+- `app/lib/store-mode-theme.ts` - shared store-mode quick-add dock class
 
 ## Validation
 
-- `npm run prisma:generate` — passed
-- `npm run lint` — passed
-- `npm run test:run` — passed (300 tests)
-- `npm run typecheck` — passed
+- `npm run prisma:generate` - passed
+- `npm run lint` - passed
+- `npm run test:run` - passed (52 files, 300 tests)
+- `npm run typecheck` - passed
 
 ## Open Items
 
-- Optional manual verification: while authenticated, visit `/login` directly and confirm immediate redirect to `/app`.
+- Manual QA still recommended on real mobile viewport/Safari: focus quick-add, type, and verify no horizontal scrollbar appears and focus/caret remains visible.
 
 ## Next Step
 
-Commit branch changes, push, and open PR with `Closes #130`.
+Commit branch changes, push, and open PR with `Closes #132`.

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -51,7 +51,7 @@ const quickAddStyles = {
       "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg",
     error: "text-sm text-rose-600",
     input:
-      "min-w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100",
+      "min-w-0 w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100",
     label: "block text-sm font-medium text-slate-700",
     option:
       "flex w-full items-center justify-between px-4 py-3 text-left text-sm text-slate-900 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60",
@@ -73,7 +73,7 @@ const quickAddStyles = {
       "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-stone-200 bg-white py-2 shadow-lg",
     error: "text-sm text-rose-600",
     input:
-      "min-w-0 flex-1 rounded-2xl border border-stone-300 bg-stone-50 px-4 py-3 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60",
+      "min-w-0 w-0 flex-1 rounded-2xl border border-stone-300 bg-stone-50 px-4 py-3 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60",
     label: "block text-sm font-medium text-stone-700",
     option:
       "flex w-full items-center justify-between px-4 py-3 text-left text-sm text-stone-900 transition hover:bg-stone-50 disabled:cursor-not-allowed disabled:opacity-60",
@@ -262,7 +262,7 @@ export function ManualShoppingQuickAdd({
     ) : null;
 
   return (
-    <div className="flex flex-col gap-3" ref={containerRef}>
+    <div className="flex min-w-0 max-w-full flex-col gap-3 overflow-x-clip" ref={containerRef}>
       <label
         className={revealOnFocus ? "sr-only" : styles.label}
         htmlFor={`${listboxId}-input`}
@@ -281,18 +281,18 @@ export function ManualShoppingQuickAdd({
       {revealOnFocus && recentsBlock ? (
         <div
           aria-hidden={!isExpanded}
-          className={`grid transition-[grid-template-rows,opacity,transform] duration-200 ease-out ${
+          className={`grid min-w-0 max-w-full transition-[grid-template-rows,opacity,transform] duration-200 ease-out ${
             isExpanded
               ? "translate-y-0 grid-rows-[1fr] opacity-100"
               : "pointer-events-none -translate-y-1 grid-rows-[0fr] opacity-0"
           }`}
         >
-          <div className="overflow-hidden">{recentsBlock}</div>
+          <div className="min-w-0 overflow-hidden">{recentsBlock}</div>
         </div>
       ) : null}
 
-      <div className="relative">
-        <div className="flex gap-2">
+      <div className="relative min-w-0 max-w-full">
+        <div className="flex min-w-0 max-w-full gap-2">
           <input
             aria-autocomplete="list"
             aria-controls={showDropdown ? listboxId : undefined}

--- a/app/lib/store-mode-theme.ts
+++ b/app/lib/store-mode-theme.ts
@@ -38,7 +38,7 @@ export const storeModeLaterChipClass =
   "rounded-full bg-stone-100 px-3 py-1.5 text-xs font-medium text-stone-700";
 
 export const storeModeQuickAddDockClass =
-  "rounded-[28px] bg-white p-4 shadow-2xl ring-2 ring-store-accent";
+  "min-w-0 max-w-full overflow-x-clip rounded-[28px] bg-white p-4 shadow-2xl ring-2 ring-store-accent";
 
 export type StoreModeBannerTone = "success" | "sync" | "error";
 

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -771,8 +771,8 @@ export default function FamilyMealPlanStoreModeRoute({
         </section>
       </div>
 
-      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3">
-        <div className="pointer-events-auto mx-auto max-w-4xl">
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 overflow-x-clip px-4 pb-4 pt-3">
+        <div className="pointer-events-auto mx-auto max-w-4xl min-w-0">
           <div className={storeModeQuickAddDockClass}>
             <ManualShoppingQuickAdd
               appearance="store-mode"

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -775,9 +775,9 @@ export default function FamilyShoppingRoute({
       </div>
 
       {!isLg ? (
-        <div className="pointer-events-none fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom))] z-40 px-4 pt-3">
-          <div className="pointer-events-auto mx-auto max-w-5xl">
-            <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200">
+        <div className="pointer-events-none fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom))] z-40 overflow-x-clip px-4 pt-3">
+          <div className="pointer-events-auto mx-auto max-w-5xl min-w-0">
+            <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200 overflow-x-clip">
               <ManualShoppingQuickAdd
                 {...quickAddProps}
                 autoFocus


### PR DESCRIPTION
## Summary
- Constrain `ManualShoppingQuickAdd` layout and input sizing to prevent focus-driven horizontal overflow on narrow viewports.
- Add scoped overflow guards to the mobile fixed quick-add docks in family shopping and store mode.
- Update handoff snapshot for issue #132 with validation and remaining manual QA note.

## Related issue
Closes #132

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual checks (mobile viewport focus/caret/no horizontal scrollbar in family shopping and store mode)

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck