### PR TITLE
Add quantity entry to shopping quick add

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,33 +2,34 @@
 
 ## Current Objective
 
-Issue #132 on branch `issue/132-mobile-quick-add-overflow`: prevent mobile horizontal overflow when focusing `ManualShoppingQuickAdd` while keeping quick-add focus behavior usable.
+Issue #136 on branch `issue/136-quick-add-quantity`: support quantity directly in quick add and provide a store-mode card entry that pre-fills the docked quick add flow.
 
 ## Completed
 
-- Hardened `ManualShoppingQuickAdd` container sizing to enforce `min-w-0`/`max-w-full` and clipped horizontal overflow in focus/reveal states.
-- Updated quick-add input flex behavior (`w-0` with `flex-1`) in both default and store-mode styles to prevent intrinsic width growth on mobile.
-- Added scoped overflow guards to mobile fixed quick-add docks in family shopping and store-mode routes.
-- Updated store-mode quick-add dock theme class to include width/overflow constraints for safe reuse.
+- Added compact quantity input to `ManualShoppingQuickAdd` and wired quantity through all quick-add submit paths (enter, button, ingredient match, create option, recents).
+- Extended quick-add parsing/contracts to accept `quantity` for both meal-plan and family/store-mode quick-add intents.
+- Updated quick-add resolver precedence to use explicit quantity first, then recent-item quantity, then default `1`.
+- Added a store-mode card action (`Hurtiglegg til`) that pre-fills/focuses the docked quick add with name and quantity seed.
+- Updated resolver and route tests to cover quantity parsing/forwarding and precedence behavior.
 
 ## Files To Read First
 
-- `app/components/manual-shopping-quick-add.tsx` - core quick-add focus/reveal layout constraints and input sizing
-- `app/routes/family-shopping.tsx` - mobile fixed quick-add dock wrapper constraints
-- `app/routes/family-meal-plan-store-mode.tsx` - store-mode mobile dock wrapper constraints
-- `app/lib/store-mode-theme.ts` - shared store-mode quick-add dock class
+- `app/components/manual-shopping-quick-add.tsx` - quick-add quantity UI, submit payload, and prefill handling
+- `app/routes/family-meal-plan-store-mode.tsx` - card-triggered prefill wiring into docked quick add
+- `app/components/store-mode-shopping-item-card.tsx` - new store-mode card quick-add action
+- `app/lib/shopping-write.server.ts` - quick-add resolver quantity precedence and input contract
 
 ## Validation
 
 - `npm run prisma:generate` - passed
 - `npm run lint` - passed
-- `npm run test:run` - passed (52 files, 300 tests)
+- `npm run test:run` - passed (52 files, 303 tests)
 - `npm run typecheck` - passed
 
 ## Open Items
 
-- Manual QA still recommended on real mobile viewport/Safari: focus quick-add, type, and verify no horizontal scrollbar appears and focus/caret remains visible.
+- Manual QA recommended for store-mode card quick-add flow on mobile: open card details, trigger `Hurtiglegg til`, verify prefilled values and successful add for quantities like `2` and `4`.
 
 ## Next Step
 
-Commit branch changes, push, and open PR with `Closes #132`.
+Commit branch changes, push, and open PR with `Closes #136`.

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -32,6 +32,11 @@ interface ManualShoppingQuickAddProps {
    */
   revealOnFocus?: boolean;
   searchFetcherKey?: string;
+  prefillRequest?: {
+    id: string;
+    name: string;
+    quantity?: string | null;
+  } | null;
 }
 
 const MIN_SEARCH_LENGTH = 2;
@@ -62,6 +67,8 @@ const quickAddStyles = {
     searchPending: "px-4 py-2 text-sm text-slate-500",
     submit:
       "inline-flex h-full shrink-0 items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400",
+    quantityInput:
+      "w-24 shrink-0 rounded-2xl border border-slate-300 bg-white px-3 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100",
   },
   "store-mode": {
     createOption:
@@ -84,6 +91,8 @@ const quickAddStyles = {
     searchPending: "px-4 py-2 text-sm text-stone-500",
     submit:
       "inline-flex h-full shrink-0 items-center justify-center rounded-2xl bg-stone-900 px-5 py-3 text-sm font-medium text-white transition hover:bg-stone-800 disabled:cursor-not-allowed disabled:bg-stone-400",
+    quantityInput:
+      "w-24 shrink-0 rounded-2xl border border-stone-300 bg-stone-50 px-3 py-3 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60",
   },
 } as const satisfies Record<
   ManualShoppingQuickAddAppearance,
@@ -99,6 +108,7 @@ export function ManualShoppingQuickAdd({
   recentManualItems,
   revealOnFocus = false,
   searchFetcherKey = DEFAULT_SEARCH_FETCHER_KEY,
+  prefillRequest = null,
 }: ManualShoppingQuickAddProps) {
   const styles = quickAddStyles[appearance];
   const listboxId = useId();
@@ -109,6 +119,7 @@ export function ManualShoppingQuickAdd({
     key: searchFetcherKey,
   });
   const [query, setQuery] = useState("");
+  const [quantity, setQuantity] = useState("");
   const [isListOpen, setIsListOpen] = useState(false);
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [displayedResults, setDisplayedResults] = useState<IngredientSearchResult[]>([]);
@@ -137,6 +148,7 @@ export function ManualShoppingQuickAdd({
   function submitQuickAdd(fields: {
     ingredientId?: string;
     name?: string;
+    quantity?: string;
     recentNameNormalized?: string;
   }) {
     const formData = new FormData();
@@ -152,6 +164,10 @@ export function ManualShoppingQuickAdd({
 
     if (fields.recentNameNormalized) {
       formData.set("recentNameNormalized", fields.recentNameNormalized);
+    }
+
+    if (typeof fields.quantity === "string") {
+      formData.set("quantity", fields.quantity);
     }
 
     quickAddFetcher.submit(formData, { method: "post" });
@@ -212,6 +228,7 @@ export function ManualShoppingQuickAdd({
     setIsListOpen(false);
     setIsInputFocused(false);
     setQuery("");
+    setQuantity("");
     lastRequestedQueryRef.current = null;
     onQuickAddSuccessRef.current?.(quickAddFetcher.data);
   }, [quickAddFetcher.data]);
@@ -223,6 +240,18 @@ export function ManualShoppingQuickAdd({
 
     inputRef.current?.focus({ preventScroll: true });
   }, [autoFocus]);
+
+  useEffect(() => {
+    if (!prefillRequest) {
+      return;
+    }
+
+    setQuery(prefillRequest.name);
+    setQuantity(prefillRequest.quantity?.trim() ?? "");
+    setIsListOpen(false);
+    setIsInputFocused(true);
+    inputRef.current?.focus({ preventScroll: true });
+  }, [prefillRequest]);
 
   const isSearching =
     searchFetcher.state === "loading" && trimmedQuery.length >= MIN_SEARCH_LENGTH;
@@ -250,7 +279,10 @@ export function ManualShoppingQuickAdd({
               className={styles.recentButton}
               disabled={isQuickAdding}
               onClick={() => {
-                submitQuickAdd({ recentNameNormalized: item.nameNormalized });
+                submitQuickAdd({
+                  quantity,
+                  recentNameNormalized: item.nameNormalized,
+                });
               }}
               type="button"
             >
@@ -318,18 +350,35 @@ export function ManualShoppingQuickAdd({
 
               if (event.key === "Enter" && trimmedQuery && !isQuickAdding) {
                 event.preventDefault();
-                submitQuickAdd({ name: trimmedQuery });
+                submitQuickAdd({ name: trimmedQuery, quantity });
               }
             }}
             placeholder="For eksempel melk"
             type="search"
             value={query}
           />
+          <label className="sr-only" htmlFor={`${listboxId}-quantity`}>
+            Mengde
+          </label>
+          <input
+            className={styles.quantityInput}
+            id={`${listboxId}-quantity`}
+            inputMode="text"
+            onChange={(event) => {
+              setQuantity(event.target.value);
+            }}
+            onFocus={() => {
+              setIsInputFocused(true);
+            }}
+            placeholder="Mengde"
+            type="text"
+            value={quantity}
+          />
           <button
             className={styles.submit}
             disabled={!trimmedQuery || isQuickAdding}
             onClick={() => {
-              submitQuickAdd({ name: trimmedQuery });
+              submitQuickAdd({ name: trimmedQuery, quantity });
             }}
             type="button"
           >
@@ -354,7 +403,10 @@ export function ManualShoppingQuickAdd({
                   className={styles.option}
                   disabled={isQuickAdding}
                   onClick={() => {
-                    submitQuickAdd({ ingredientId: ingredient.id });
+                    submitQuickAdd({
+                      ingredientId: ingredient.id,
+                      quantity,
+                    });
                   }}
                   type="button"
                 >
@@ -369,7 +421,7 @@ export function ManualShoppingQuickAdd({
                   className={styles.createOption}
                   disabled={isQuickAdding}
                   onClick={() => {
-                    submitQuickAdd({ name: trimmedQuery });
+                    submitQuickAdd({ name: trimmedQuery, quantity });
                   }}
                   type="button"
                 >

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -44,6 +44,10 @@ interface StoreModeShoppingItemCardProps {
   isRecentlyAdded?: boolean;
   item: StoreModeShoppingItemCardItem;
   layout: StoreModeShoppingView;
+  onQuickAddFromCard?: (item: {
+    name: string;
+    quantityLabel: string | null;
+  }) => void;
   onToggle: () => void;
   selectedStoreId: string | undefined;
 }
@@ -54,6 +58,7 @@ export function StoreModeShoppingItemCard({
   isRecentlyAdded = false,
   item,
   layout: _layout,
+  onQuickAddFromCard,
   onToggle,
   selectedStoreId,
 }: StoreModeShoppingItemCardProps) {
@@ -129,7 +134,7 @@ export function StoreModeShoppingItemCard({
         </div>
 
         <details
-          className="group mt-auto flex w-full min-w-0 flex-col-reverse items-start pointer-events-auto"
+          className="group mt-auto flex w-0 min-w-0 flex-col-reverse items-start pointer-events-auto"
           open={shouldAutoOpenDetails}
         >
           <summary
@@ -152,6 +157,18 @@ export function StoreModeShoppingItemCard({
                 Notat: {item.note}
               </p>
             ) : null}
+            <button
+              className="inline-flex w-fit rounded-full border border-store-accent/40 bg-store-accent-light px-2.5 py-1 text-xs font-medium text-store-accent-text transition hover:border-store-accent hover:bg-store-accent-light/80"
+              onClick={() =>
+                onQuickAddFromCard?.({
+                  name: item.name,
+                  quantityLabel: item.quantityLabel,
+                })
+              }
+              type="button"
+            >
+              Hurtiglegg til
+            </button>
             {item.sourceType === "GENERATED" && item.postponedUntilDate ? (
               <p className="break-words text-xs leading-4 text-amber-800">
                 Utsatt til {formatDateLabel(item.postponedUntilDate)}.

--- a/app/lib/family-shopping-write.server.test.ts
+++ b/app/lib/family-shopping-write.server.test.ts
@@ -37,6 +37,7 @@ vi.mock("./shopping-write.server", () => ({
 import { resolveQuickAddManualShoppingItemValues } from "./shopping-write.server";
 import {
   createFamilyShoppingItem,
+  parseQuickAddFamilyShoppingItemInput,
   toggleFamilyShoppingItemChecked,
 } from "./family-shopping-write.server";
 
@@ -190,6 +191,19 @@ describe("family-shopping-write.server", () => {
         quantity: "1",
       },
       status: "CREATED",
+    });
+  });
+
+  it("parses quick-add input quantity from form data", () => {
+    const formData = new FormData();
+    formData.set("name", "Melk");
+    formData.set("quantity", "4 flasker");
+
+    expect(parseQuickAddFamilyShoppingItemInput(formData)).toEqual({
+      ingredientId: "",
+      name: "Melk",
+      quantity: "4 flasker",
+      recentNameNormalized: "",
     });
   });
 });

--- a/app/lib/family-shopping-write.server.ts
+++ b/app/lib/family-shopping-write.server.ts
@@ -48,6 +48,7 @@ export function parseQuickAddFamilyShoppingItemInput(formData: FormData) {
   return {
     ingredientId: String(formData.get("ingredientId") ?? ""),
     name: String(formData.get("name") ?? ""),
+    quantity: String(formData.get("quantity") ?? ""),
     recentNameNormalized: String(formData.get("recentNameNormalized") ?? ""),
   } satisfies QuickAddManualShoppingItemInput;
 }

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -337,6 +337,69 @@ describe("shopping-write.server", () => {
     });
   });
 
+  it("uses an explicit quick-add quantity for ingredient matches", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.ingredient.findUnique.mockResolvedValue({
+      canonicalName: "Melk",
+      defaultCategoryId: "category-dairy",
+    });
+
+    const result = await resolveQuickAddManualShoppingItemValues({
+      familyId: "family-1",
+      input: {
+        ingredientId: "ingredient-milk",
+        quantity: "4 flasker",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-dairy",
+        name: "Melk",
+        note: "",
+        preferredStoreId: "",
+        quantity: "4 flasker",
+      },
+    });
+  });
+
+  it("prefers explicit quick-add quantity over recent item quantity", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.manualShoppingItem.findMany.mockResolvedValue([
+      {
+        categoryId: "category-bakery",
+        name: "Brød",
+        quantity: "2 stk",
+      },
+    ]);
+
+    const result = await resolveQuickAddManualShoppingItemValues({
+      familyId: "family-1",
+      input: {
+        quantity: "4 stk",
+        recentNameNormalized: "brød",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-bakery",
+        name: "Brød",
+        note: "",
+        preferredStoreId: "",
+        quantity: "4 stk",
+      },
+    });
+  });
+
   it("creates a quick-add manual item with Annet defaults for new names", async () => {
     dbMock.ingredientCategory.findUnique.mockResolvedValue({
       id: "category-other",

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -36,6 +36,7 @@ export interface ManualShoppingItemFieldErrors {
 export interface QuickAddManualShoppingItemInput {
   ingredientId?: string;
   name?: string;
+  quantity?: string;
   recentNameNormalized?: string;
 }
 
@@ -1667,6 +1668,8 @@ export async function resolveQuickAddManualShoppingItemValues({
   }
 
   const ingredientId = input.ingredientId?.trim();
+  const requestedQuantity = input.quantity?.trim();
+  const quantity = requestedQuantity || QUICK_ADD_DEFAULT_QUANTITY;
 
   if (ingredientId) {
     const ingredient = await db.ingredient.findUnique({
@@ -1685,6 +1688,7 @@ export async function resolveQuickAddManualShoppingItemValues({
         values: buildQuickAddManualShoppingItemValues({
           categoryId: ingredient.defaultCategoryId ?? otherCategoryId,
           name: ingredient.canonicalName,
+          quantity,
         }),
       };
     }
@@ -1704,7 +1708,7 @@ export async function resolveQuickAddManualShoppingItemValues({
         values: buildQuickAddManualShoppingItemValues({
           categoryId: recentItem.categoryId,
           name: recentItem.name.trim(),
-          quantity: recentItem.quantity?.trim() || QUICK_ADD_DEFAULT_QUANTITY,
+          quantity: requestedQuantity || recentItem.quantity?.trim() || QUICK_ADD_DEFAULT_QUANTITY,
         }),
       };
     }
@@ -1724,6 +1728,7 @@ export async function resolveQuickAddManualShoppingItemValues({
       values: buildQuickAddManualShoppingItemValues({
         categoryId: otherCategoryId,
         name,
+        quantity,
       }),
     };
   }
@@ -1733,6 +1738,7 @@ export async function resolveQuickAddManualShoppingItemValues({
     values: buildQuickAddManualShoppingItemValues({
       categoryId: otherCategoryId,
       name,
+      quantity,
     }),
   };
 }

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -594,6 +594,7 @@ describe("family meal plan shopping route", () => {
       input: {
         ingredientId: "",
         name: "Tannkrem",
+        quantity: "",
         recentNameNormalized: "",
       },
       mealPlanId: "meal-plan-1",

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1524,6 +1524,7 @@ function parseQuickAddManualShoppingItemInput(formData: FormData) {
   return {
     ingredientId: String(formData.get("ingredientId") ?? ""),
     name: String(formData.get("name") ?? ""),
+    quantity: String(formData.get("quantity") ?? ""),
     recentNameNormalized: String(formData.get("recentNameNormalized") ?? ""),
   };
 }

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -267,6 +267,7 @@ describe("family meal plan store mode route", () => {
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
       ingredientId: "ingredient-1",
       name: "Melk",
+      quantity: "",
       recentNameNormalized: "",
     });
     vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
@@ -309,6 +310,7 @@ describe("family meal plan store mode route", () => {
       input: {
         ingredientId: "ingredient-1",
         name: "Melk",
+        quantity: "",
         recentNameNormalized: "",
       },
       userId: "user-1",
@@ -343,6 +345,7 @@ describe("family meal plan store mode route", () => {
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
       ingredientId: "",
       name: "",
+      quantity: "",
       recentNameNormalized: "",
     });
     vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -375,6 +375,11 @@ export default function FamilyMealPlanStoreModeRoute({
   const [recentManualItems, setRecentManualItems] = useState(
     loaderData.recentManualItems,
   );
+  const [quickAddPrefillRequest, setQuickAddPrefillRequest] = useState<{
+    id: string;
+    name: string;
+    quantity: string | null;
+  } | null>(null);
   const [recentlyAddedSourceKey, setRecentlyAddedSourceKey] = useState<
     string | null
   >(null);
@@ -399,9 +404,21 @@ export default function FamilyMealPlanStoreModeRoute({
         prependRecentManualItem(currentRecents, payload.recentManualItem),
       );
       setRecentlyAddedSourceKey(payload.item.sourceKey);
+      setQuickAddPrefillRequest(null);
       scheduleRevalidate();
     },
     [scheduleRevalidate],
+  );
+
+  const handleQuickAddFromCard = useCallback(
+    (item: { name: string; quantityLabel: string | null }) => {
+      setQuickAddPrefillRequest({
+        id: `${Date.now()}-${item.name}`,
+        name: item.name,
+        quantity: item.quantityLabel,
+      });
+    },
+    [],
   );
 
   useEffect(() => {
@@ -690,6 +707,7 @@ export default function FamilyMealPlanStoreModeRoute({
                   <StoreModeItemGrid
                     items={section.items}
                     layout={shoppingView}
+                    onQuickAddFromCard={handleQuickAddFromCard}
                     onToggleItem={handleToggle}
                     recentlyAddedSourceKey={recentlyAddedSourceKey}
                     selectedStoreId={loaderData.selectedStore?.id}
@@ -721,6 +739,7 @@ export default function FamilyMealPlanStoreModeRoute({
                 <StoreModeItemGrid
                   items={boughtItems}
                   layout={shoppingView}
+                  onQuickAddFromCard={handleQuickAddFromCard}
                   onToggleItem={handleToggle}
                   recentlyAddedSourceKey={recentlyAddedSourceKey}
                   selectedStoreId={loaderData.selectedStore?.id}
@@ -778,6 +797,7 @@ export default function FamilyMealPlanStoreModeRoute({
               appearance="store-mode"
               ingredientSearchPath={ingredientSearchPath}
               onQuickAddSuccess={handleQuickAddSuccess}
+              prefillRequest={quickAddPrefillRequest}
               quickAddIntent="quick-add-family-shopping-item"
               recentManualItems={recentManualItems}
               revealOnFocus
@@ -884,12 +904,14 @@ function StoreModeItemGrid<
 >({
   items,
   layout,
+  onQuickAddFromCard,
   onToggleItem,
   recentlyAddedSourceKey,
   selectedStoreId,
 }: {
   items: TItem[];
   layout: StoreModeShoppingView;
+  onQuickAddFromCard: (item: { name: string; quantityLabel: string | null }) => void;
   onToggleItem: (item: TItem) => void;
   recentlyAddedSourceKey: string | null;
   selectedStoreId?: string;
@@ -908,6 +930,7 @@ function StoreModeItemGrid<
           isRecentlyAdded={recentlyAddedSourceKey === item.sourceKey}
           item={item}
           layout={layout}
+          onQuickAddFromCard={onQuickAddFromCard}
           onToggle={() => onToggleItem(item)}
           selectedStoreId={selectedStoreId}
         />

--- a/app/routes/family-shopping.test.ts
+++ b/app/routes/family-shopping.test.ts
@@ -164,6 +164,7 @@ describe("family shopping route", () => {
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
       ingredientId: "ingredient-1",
       name: "Melk",
+      quantity: "",
       recentNameNormalized: "",
     });
     vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({
@@ -206,6 +207,7 @@ describe("family shopping route", () => {
       input: {
         ingredientId: "ingredient-1",
         name: "Melk",
+        quantity: "",
         recentNameNormalized: "",
       },
       userId: "user-1",
@@ -240,6 +242,7 @@ describe("family shopping route", () => {
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
       ingredientId: "",
       name: "",
+      quantity: "",
       recentNameNormalized: "",
     });
     vi.mocked(createQuickFamilyShoppingItem).mockResolvedValue({


### PR DESCRIPTION
## Summary
- Add quantity input support to `ManualShoppingQuickAdd` and send quantity through all quick-add submit paths.
- Extend quick-add parsing/resolver logic to accept quantity with precedence `explicit > recent item > default 1`.
- Add a store-mode card action that pre-fills and focuses the existing docked quick-add flow.

## Related issue
Closes #136

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual checks: verify quick-add quantity 2/4 from default flow and from store-mode card shortcut

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck