### PR TITLE
Polish store-mode quantity badge editing

### DIFF
--- a/.cursor/rules/frontend-standards.mdc
+++ b/.cursor/rules/frontend-standards.mdc
@@ -15,6 +15,7 @@ alwaysApply: true
 - Reuse existing primitives and patterns before introducing new wrappers, variants, or utilities.
 - In Tailwind, prefer readable utility composition and shared patterns over long repeated class strings.
 - Match existing project conventions and keep changes minimal.
+- Use text-base as font size for any text inputs to prevent auto-zoom in iOS devices
 
 ```tsx
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,7 +2,7 @@
 
 ## Current Objective
 
-Issue #136 on branch `issue/136-quick-add-quantity`: support quantity directly in quick add and provide a store-mode card entry that pre-fills the docked quick add flow.
+Issue #136 on branch `issue/136-store-mode-quantity-edit`: improve store-mode quantity editing by allowing direct badge tap editing with an always-visible hint and focused modal input.
 
 ## Completed
 
@@ -10,25 +10,28 @@ Issue #136 on branch `issue/136-quick-add-quantity`: support quantity directly i
 - Extended quick-add parsing/contracts to accept `quantity` for both meal-plan and family/store-mode quick-add intents.
 - Updated quick-add resolver precedence to use explicit quantity first, then recent-item quantity, then default `1`.
 - Added a store-mode card action (`Hurtiglegg til`) that pre-fills/focuses the docked quick add with name and quantity seed.
-- Updated resolver and route tests to cover quantity parsing/forwarding and precedence behavior.
+- Added store-mode quantity modal editing through a dedicated route intent/server helper and card callback wiring.
+- Switched interaction to tap the quantity badge directly (removed separate edit button in details), with a persistent pencil hint for mobile discoverability.
+- Updated modal behavior to autofocus/select the quantity input by default when opened.
+- Updated resolver and route tests to cover quantity parsing/forwarding, precedence behavior, and store-mode quantity update actions.
 
 ## Files To Read First
 
-- `app/components/manual-shopping-quick-add.tsx` - quick-add quantity UI, submit payload, and prefill handling
-- `app/routes/family-meal-plan-store-mode.tsx` - card-triggered prefill wiring into docked quick add
-- `app/components/store-mode-shopping-item-card.tsx` - new store-mode card quick-add action
-- `app/lib/shopping-write.server.ts` - quick-add resolver quantity precedence and input contract
+- `app/components/store-mode-shopping-item-card.tsx` - quantity badge tap-to-edit UI, persistent pencil hint, and modal autofocus
+- `app/routes/family-meal-plan-store-mode.tsx` - quantity update action intent and fetcher submit/revalidation flow
+- `app/lib/family-shopping-write.server.ts` - family item quantity update helper with concurrency protection
+- `app/components/manual-shopping-quick-add.tsx` - quick-add quantity UI and payload handling
 
 ## Validation
 
 - `npm run prisma:generate` - passed
 - `npm run lint` - passed
-- `npm run test:run` - passed (52 files, 303 tests)
+- `npm run test:run` - passed (52 files, 305 tests)
 - `npm run typecheck` - passed
 
 ## Open Items
 
-- Manual QA recommended for store-mode card quick-add flow on mobile: open card details, trigger `Hurtiglegg til`, verify prefilled values and successful add for quantities like `2` and `4`.
+- Manual QA recommended on mobile store mode: tap quantity badge, verify modal opens with focused input, save quantities like `2`/`4`, and confirm badge updates immediately after revalidation.
 
 ## Next Step
 

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react";
+
 import {
   formatGeneratedOccurrenceAttribution,
   formatGeneratedQuantityBadge,
@@ -6,6 +8,7 @@ import type { StoreModeShoppingView } from "../lib/shopping-store-mode-client";
 
 interface StoreModeShoppingItemCardBase {
   checked: boolean;
+  collaborationVersion: string;
   name: string;
   note: string | null;
   preferredStore: {
@@ -48,6 +51,11 @@ interface StoreModeShoppingItemCardProps {
     name: string;
     quantityLabel: string | null;
   }) => void;
+  onUpdateQuantity?: (item: {
+    expectedUpdatedAt: string;
+    quantity: string;
+    sourceKey: string;
+  }) => void;
   onToggle: () => void;
   selectedStoreId: string | undefined;
 }
@@ -59,11 +67,15 @@ export function StoreModeShoppingItemCard({
   item,
   layout: _layout,
   onQuickAddFromCard,
+  onUpdateQuantity,
   onToggle,
   selectedStoreId,
 }: StoreModeShoppingItemCardProps) {
   const quantityBadge = formatGeneratedQuantityBadge(item);
   const shouldAutoOpenDetails = shouldAutoOpenStoreModeDetails(item);
+  const [isQuantityModalOpen, setIsQuantityModalOpen] = useState(false);
+  const [quantityDraft, setQuantityDraft] = useState(item.quantityLabel ?? "");
+  const quantityInputRef = useRef<HTMLInputElement>(null);
 
   const cardStateClass = isRecentlyAdded
     ? "border-emerald-300 bg-emerald-100"
@@ -79,6 +91,16 @@ export function StoreModeShoppingItemCard({
   const nameClass = item.checked
     ? "text-sm font-semibold leading-5 text-stone-500 line-through decoration-stone-400"
     : "text-sm font-semibold leading-5 text-stone-950";
+  const showQuantityEdit = item.sourceType === "FAMILY";
+
+  useEffect(() => {
+    if (!isQuantityModalOpen) {
+      return;
+    }
+
+    quantityInputRef.current?.focus();
+    quantityInputRef.current?.select();
+  }, [isQuantityModalOpen]);
 
   return (
     <div
@@ -102,17 +124,33 @@ export function StoreModeShoppingItemCard({
           <span className="flex flex-wrap items-center gap-1.5">
             <span className={nameClass}>{item.name}</span>
             {quantityBadge ? (
-              <span
-                className={
-                  item.sourceType === "GENERATED" &&
-                  !item.quantityLabel &&
-                  item.occurrenceCount > 1
-                    ? `${badgeClass} bg-amber-100 text-amber-800`
-                    : `${badgeClass} bg-white text-stone-700 ring-1 ring-stone-200`
-                }
-              >
-                {quantityBadge}
-              </span>
+              showQuantityEdit ? (
+                <button
+                  className={`${badgeClass} pointer-events-auto bg-store-accent-light text-store-accent-text ring-1 ring-store-accent/40 transition hover:bg-store-accent-light/80`}
+                  onClick={() => {
+                    setQuantityDraft(item.quantityLabel ?? "");
+                    setIsQuantityModalOpen(true);
+                  }}
+                  type="button"
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {quantityBadge}
+                    <EditPencilIcon className="h-3 w-3 opacity-80" />
+                  </span>
+                </button>
+              ) : (
+                <span
+                  className={
+                    item.sourceType === "GENERATED" &&
+                    !item.quantityLabel &&
+                    item.occurrenceCount > 1
+                      ? `${badgeClass} bg-amber-100 text-amber-800`
+                      : `${badgeClass} bg-white text-stone-700 ring-1 ring-stone-200`
+                  }
+                >
+                  {quantityBadge}
+                </span>
+              )
             ) : null}
             {item.sourceType === "GENERATED" && item.recipeCount > 1 ? (
               <span className={`${badgeClass} bg-emerald-100 text-emerald-800`}>
@@ -177,6 +215,64 @@ export function StoreModeShoppingItemCard({
           </div>
         </details>
       </div>
+
+      {isQuantityModalOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/35 p-4"
+          onClick={() => setIsQuantityModalOpen(false)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setIsQuantityModalOpen(false);
+            }
+          }}
+          role="presentation"
+        >
+          <div
+            className="w-full max-w-sm rounded-2xl border border-stone-200 bg-white p-4 shadow-xl"
+            onClick={(event) => event.stopPropagation()}
+            role="dialog"
+          >
+            <h3 className="text-sm font-semibold text-stone-950">
+              Oppdater mengde
+            </h3>
+            <p className="mt-1 text-xs text-stone-600">{item.name}</p>
+            <label className="mt-3 block text-xs font-medium text-stone-700">
+              Mengde
+              <input
+                className="mt-1 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60"
+                onChange={(event) => setQuantityDraft(event.target.value)}
+                placeholder="F.eks. 4 flasker"
+                ref={quantityInputRef}
+                type="text"
+                value={quantityDraft}
+              />
+            </label>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                className="rounded-xl border border-stone-300 px-3 py-2 text-sm text-stone-700 transition hover:bg-stone-100"
+                onClick={() => setIsQuantityModalOpen(false)}
+                type="button"
+              >
+                Avbryt
+              </button>
+              <button
+                className="rounded-xl bg-stone-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-stone-800"
+                onClick={() => {
+                  onUpdateQuantity?.({
+                    expectedUpdatedAt: item.collaborationVersion,
+                    quantity: quantityDraft,
+                    sourceKey: item.sourceKey,
+                  });
+                  setIsQuantityModalOpen(false);
+                }}
+                type="button"
+              >
+                Lagre
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -243,6 +339,33 @@ function StoreModeInfoIcon({ className }: { className?: string }) {
         strokeWidth="1.75"
       />
       <circle cx="12" cy="8" fill="currentColor" r="0.9" />
+    </svg>
+  );
+}
+
+function EditPencilIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 20h4l10-10-4-4L4 16v4Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.75"
+      />
+      <path
+        d="m12 6 4 4"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.75"
+      />
     </svg>
   );
 }

--- a/app/lib/family-shopping-write.server.test.ts
+++ b/app/lib/family-shopping-write.server.test.ts
@@ -39,6 +39,7 @@ import {
   createFamilyShoppingItem,
   parseQuickAddFamilyShoppingItemInput,
   toggleFamilyShoppingItemChecked,
+  updateFamilyShoppingItemQuantity,
 } from "./family-shopping-write.server";
 
 describe("family-shopping-write.server", () => {
@@ -205,5 +206,30 @@ describe("family-shopping-write.server", () => {
       quantity: "4 flasker",
       recentNameNormalized: "",
     });
+  });
+
+  it("updates quantity on a family shopping item", async () => {
+    dbMock.familyShoppingItem.findFirst.mockResolvedValue({
+      id: "family-item-1",
+      updatedAt: new Date("2026-05-10T00:00:00.000Z"),
+    });
+    dbMock.familyShoppingItem.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await updateFamilyShoppingItemQuantity({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      quantity: " 4 flasker ",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(dbMock.familyShoppingItem.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          quantity: "4 flasker",
+        }),
+      }),
+    );
   });
 });

--- a/app/lib/family-shopping-write.server.ts
+++ b/app/lib/family-shopping-write.server.ts
@@ -447,6 +447,86 @@ export async function toggleFamilyShoppingItemChecked({
   };
 }
 
+export async function updateFamilyShoppingItemQuantity({
+  expectedUpdatedAt,
+  familyId,
+  familyItemId,
+  quantity,
+  userId,
+}: {
+  expectedUpdatedAt: string;
+  familyId: string;
+  familyItemId: string;
+  quantity: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const existingItem = await db.familyShoppingItem.findFirst({
+    select: {
+      id: true,
+      updatedAt: true,
+    },
+    where: {
+      familyId,
+      id: familyItemId,
+    },
+  });
+
+  if (!existingItem) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingItem.updatedAt)) {
+    return buildFamilyShoppingConflictResult({
+      action: "update-family-shopping-item-quantity",
+      entityId: existingItem.id,
+      familyId,
+      userId,
+    });
+  }
+
+  const updateResult = await db.familyShoppingItem.updateMany({
+    data: {
+      quantity: quantity.trim() || null,
+      ...buildActorUpdate(userId),
+    },
+    where: {
+      familyId,
+      id: existingItem.id,
+      updatedAt: existingItem.updatedAt,
+    },
+  });
+
+  if (updateResult.count === 0) {
+    return buildFamilyShoppingConflictResult({
+      action: "update-family-shopping-item-quantity",
+      entityId: existingItem.id,
+      familyId,
+      userId,
+    });
+  }
+
+  logCollaborationWrite({
+    action: "update-family-shopping-item-quantity",
+    domain: "shopping",
+    entityId: existingItem.id,
+    entityType: "family-shopping-item",
+    familyId,
+    outcome: "UPDATED",
+    userId,
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
 async function resolveQuickAddFamilyShoppingItemValues({
   familyId,
   input,

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -21,6 +21,7 @@ vi.mock("../lib/family-shopping-write.server", () => {
     createQuickFamilyShoppingItem: vi.fn(),
     parseQuickAddFamilyShoppingItemInput: vi.fn(),
     toggleFamilyShoppingItemChecked: vi.fn(),
+    updateFamilyShoppingItemQuantity: vi.fn(),
   };
 });
 
@@ -40,6 +41,7 @@ vi.mock("../lib/store-write.server", () => {
 import {
   createQuickFamilyShoppingItem,
   parseQuickAddFamilyShoppingItemInput,
+  updateFamilyShoppingItemQuantity,
 } from "../lib/family-shopping-write.server";
 import { requireUser } from "../lib/auth.server";
 import {
@@ -377,6 +379,39 @@ describe("family meal plan store mode route", () => {
     expect(result).toEqual({
       formError: "Kunne ikke legge til varen.",
       intent: "quick-add-family-shopping-item",
+    });
+  });
+
+  it("updates family item quantity without redirecting", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateFamilyShoppingItemQuantity).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-family-shopping-item-quantity");
+    formData.set("sourceKey", "family-item-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("quantity", "4 flasker");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(updateFamilyShoppingItemQuantity).toHaveBeenCalledWith({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      quantity: "4 flasker",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      intent: "update-family-shopping-item-quantity",
+      ok: true,
     });
   });
 

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -22,6 +22,7 @@ import {
   createQuickFamilyShoppingItem,
   parseQuickAddFamilyShoppingItemInput,
   toggleFamilyShoppingItemChecked,
+  updateFamilyShoppingItemQuantity,
 } from "../lib/family-shopping-write.server";
 import {
   buildStoreModeDeprioritizeBoughtStorageKey,
@@ -81,6 +82,7 @@ type StoreModeNotice =
 
 type StoreModeIntent =
   | "quick-add-family-shopping-item"
+  | "update-family-shopping-item-quantity"
   | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
   | "update-active-shopping-date"
@@ -315,6 +317,42 @@ export async function action({
     } satisfies StoreModeActionData;
   }
 
+  if (intent === "update-family-shopping-item-quantity") {
+    const familyItemId = String(formData.get("sourceKey") ?? "").trim();
+    const quantity = String(formData.get("quantity") ?? "");
+
+    if (!familyItemId) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const result = await updateFamilyShoppingItemQuantity({
+      expectedUpdatedAt: String(formData.get("expectedUpdatedAt") ?? ""),
+      familyId,
+      familyItemId,
+      quantity,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    return {
+      intent,
+      ok: true,
+    } satisfies StoreModeActionData;
+  }
+
   if (intent === "toggle-shopping-item-checked") {
     const sourceKey = String(formData.get("sourceKey") ?? "").trim();
     const sourceType = parseShoppingItemSource(formData.get("sourceType"));
@@ -368,6 +406,7 @@ export default function FamilyMealPlanStoreModeRoute({
   const revalidator = useRevalidator();
   const scheduleRevalidate = useDebouncedRevalidate(revalidator.revalidate);
   const toggleFetcher = useFetcher<StoreModeActionData>();
+  const quantityFetcher = useFetcher<StoreModeActionData>();
   const pendingIntent = navigation.formData?.get("intent");
   const [dueSectionGroups, setDueSectionGroups] = useState(
     loaderData.dueSectionGroups,
@@ -420,6 +459,38 @@ export default function FamilyMealPlanStoreModeRoute({
     },
     [],
   );
+
+  const handleUpdateQuantity = useCallback(
+    ({
+      expectedUpdatedAt,
+      quantity,
+      sourceKey,
+    }: {
+      expectedUpdatedAt: string;
+      quantity: string;
+      sourceKey: string;
+    }) => {
+      const formData = new FormData();
+      formData.set("intent", "update-family-shopping-item-quantity");
+      formData.set("sourceKey", sourceKey);
+      formData.set("expectedUpdatedAt", expectedUpdatedAt);
+      formData.set("quantity", quantity);
+      quantityFetcher.submit(formData, { method: "post" });
+    },
+    [quantityFetcher],
+  );
+
+  useEffect(() => {
+    if (
+      quantityFetcher.state !== "idle" ||
+      quantityFetcher.data?.intent !== "update-family-shopping-item-quantity" ||
+      !quantityFetcher.data.ok
+    ) {
+      return;
+    }
+
+    scheduleRevalidate();
+  }, [quantityFetcher.data, quantityFetcher.state, scheduleRevalidate]);
 
   useEffect(() => {
     if (!recentlyAddedSourceKey) {
@@ -708,6 +779,7 @@ export default function FamilyMealPlanStoreModeRoute({
                     items={section.items}
                     layout={shoppingView}
                     onQuickAddFromCard={handleQuickAddFromCard}
+                    onUpdateQuantity={handleUpdateQuantity}
                     onToggleItem={handleToggle}
                     recentlyAddedSourceKey={recentlyAddedSourceKey}
                     selectedStoreId={loaderData.selectedStore?.id}
@@ -740,6 +812,7 @@ export default function FamilyMealPlanStoreModeRoute({
                   items={boughtItems}
                   layout={shoppingView}
                   onQuickAddFromCard={handleQuickAddFromCard}
+                  onUpdateQuantity={handleUpdateQuantity}
                   onToggleItem={handleToggle}
                   recentlyAddedSourceKey={recentlyAddedSourceKey}
                   selectedStoreId={loaderData.selectedStore?.id}
@@ -905,6 +978,7 @@ function StoreModeItemGrid<
   items,
   layout,
   onQuickAddFromCard,
+  onUpdateQuantity,
   onToggleItem,
   recentlyAddedSourceKey,
   selectedStoreId,
@@ -912,6 +986,11 @@ function StoreModeItemGrid<
   items: TItem[];
   layout: StoreModeShoppingView;
   onQuickAddFromCard: (item: { name: string; quantityLabel: string | null }) => void;
+  onUpdateQuantity: (item: {
+    expectedUpdatedAt: string;
+    quantity: string;
+    sourceKey: string;
+  }) => void;
   onToggleItem: (item: TItem) => void;
   recentlyAddedSourceKey: string | null;
   selectedStoreId?: string;
@@ -931,6 +1010,7 @@ function StoreModeItemGrid<
           item={item}
           layout={layout}
           onQuickAddFromCard={onQuickAddFromCard}
+          onUpdateQuantity={onUpdateQuantity}
           onToggle={() => onToggleItem(item)}
           selectedStoreId={selectedStoreId}
         />


### PR DESCRIPTION
## Summary
- Add direct quantity editing from store-mode cards by tapping the quantity badge, instead of a separate edit control inside details.
- Add a persistent pencil hint in the editable badge so the affordance is visible on mobile where hover is unavailable.
- Auto-focus and select the modal quantity input on open so quantity corrections are faster.

## Related issue
Closes #136

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual checks: tap quantity badge on mobile, edit quantity, and confirm badge updates

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck