### PR TITLE
Assign optional responsible family member per meal plan day

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,37 +2,34 @@
 
 ## Current Objective
 
-Issue #136 on branch `issue/136-store-mode-quantity-edit`: improve store-mode quantity editing by allowing direct badge tap editing with an always-visible hint and focused modal input.
+Issue #141 — PR ready on `issue/141-meal-plan-responsible-member`.
 
 ## Completed
 
-- Added compact quantity input to `ManualShoppingQuickAdd` and wired quantity through all quick-add submit paths (enter, button, ingredient match, create option, recents).
-- Extended quick-add parsing/contracts to accept `quantity` for both meal-plan and family/store-mode quick-add intents.
-- Updated quick-add resolver precedence to use explicit quantity first, then recent-item quantity, then default `1`.
-- Added a store-mode card action (`Hurtiglegg til`) that pre-fills/focuses the docked quick add with name and quantity seed.
-- Added store-mode quantity modal editing through a dedicated route intent/server helper and card callback wiring.
-- Switched interaction to tap the quantity badge directly (removed separate edit button in details), with a persistent pencil hint for mobile discoverability.
-- Updated modal behavior to autofocus/select the quantity input by default when opened.
-- Updated resolver and route tests to cover quantity parsing/forwarding, precedence behavior, and store-mode quantity update actions.
+- Optional `responsibleUserId` on dinner `MealPlanEntry` (migration `20260603120000_meal_plan_entry_responsible_user`).
+- Meal plan editor: assign/clear responsible, visible in collapsed day row.
+- Family home `WeekDayMenuCard`: shows responsible display name chip on weekly overview.
+- Save validates family membership; copy preserves assignments; responsible-only days deleted on save.
 
 ## Files To Read First
 
-- `app/components/store-mode-shopping-item-card.tsx` - quantity badge tap-to-edit UI, persistent pencil hint, and modal autofocus
-- `app/routes/family-meal-plan-store-mode.tsx` - quantity update action intent and fetcher submit/revalidation flow
-- `app/lib/family-shopping-write.server.ts` - family item quantity update helper with concurrency protection
-- `app/components/manual-shopping-quick-add.tsx` - quick-add quantity UI and payload handling
+- `prisma/schema.prisma` — `MealPlanEntry.responsibleUserId`
+- `app/lib/meal-plan.server.ts` — save/copy/validation
+- `app/routes/family-meal-plan.tsx` — editor UI
+- `app/lib/family-home.server.ts` — week overview data
 
 ## Validation
 
-- `npm run prisma:generate` - passed
-- `npm run lint` - passed
-- `npm run test:run` - passed (52 files, 305 tests)
-- `npm run typecheck` - passed
+- `npm run prisma:generate` — passed
+- `npm run lint` — passed
+- `npm run test:run` — passed (52 files, 308 tests)
+- `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual QA recommended on mobile store mode: tap quantity badge, verify modal opens with focused input, save quantities like `2`/`4`, and confirm badge updates immediately after revalidation.
+- Deploy: `npm run prisma:migrate:deploy`
+- Manual QA on meal plan editor and family home week cards
 
 ## Next Step
 
-Commit branch changes, push, and open PR with `Closes #136`.
+Merge PR; issue closes via `Closes #141`.

--- a/app/lib/family-home.server.test.ts
+++ b/app/lib/family-home.server.test.ts
@@ -47,12 +47,14 @@ describe("getFamilyWeekDinnerMenu", () => {
             note: null,
             recipe: { title: "Taco" },
             recipeId: "recipe-1",
+            responsibleUser: { displayName: "Kari" },
           },
           {
             date: new Date("2026-06-05T00:00:00.000Z"),
             note: "Restemat",
             recipe: null,
             recipeId: null,
+            responsibleUser: null,
           },
         ],
         id: "meal-plan-1",
@@ -73,10 +75,12 @@ describe("getFamilyWeekDinnerMenu", () => {
       mealPlanId: "meal-plan-1",
       mealPlanTitle: "Uke 23",
       menuLabel: "Taco",
+      responsibleDisplayName: "Kari",
     });
     expect(result[4]).toMatchObject({
       date: "2026-06-05",
       menuLabel: "Restemat",
+      responsibleDisplayName: null,
     });
     expect(result[0]).toMatchObject({
       date: "2026-06-01",

--- a/app/lib/family-home.server.ts
+++ b/app/lib/family-home.server.ts
@@ -20,6 +20,7 @@ export type FamilyWeekDayMenu = {
   mealPlanId: string | null;
   mealPlanTitle: string | null;
   menuLabel: string;
+  responsibleDisplayName: string | null;
   weekdayLabel: string;
 };
 
@@ -56,6 +57,11 @@ export async function getFamilyWeekDinnerMenu({
             },
           },
           recipeId: true,
+          responsibleUser: {
+            select: {
+              displayName: true,
+            },
+          },
         },
         where: {
           mealType: MealType.DINNER,
@@ -92,6 +98,8 @@ export async function getFamilyWeekDinnerMenu({
       mealPlanId: coveringPlan?.id ?? null,
       mealPlanTitle: coveringPlan?.title ?? null,
       menuLabel: coveringPlan ? getDinnerMenuLabel(dinnerEntry) : "Ingen ukeplan",
+      responsibleDisplayName:
+        dinnerEntry?.responsibleUser?.displayName ?? null,
       weekdayLabel: formatWeekdayLabel(date),
     } satisfies FamilyWeekDayMenu;
   });

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { dbMock, requireFamilyAdminMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+const {
+  dbMock,
+  listFamilyMembersMock,
+  requireFamilyAdminMock,
+  requireFamilyMembershipMock,
+} = vi.hoisted(() => {
   return {
     dbMock: {
       $transaction: vi.fn(),
@@ -26,6 +31,7 @@ const { dbMock, requireFamilyAdminMock, requireFamilyMembershipMock } = vi.hoist
         findMany: vi.fn(),
       },
     },
+    listFamilyMembersMock: vi.fn(),
     requireFamilyAdminMock: vi.fn(),
     requireFamilyMembershipMock: vi.fn(),
   };
@@ -39,6 +45,7 @@ vi.mock("./db.server", () => {
 
 vi.mock("./family.server", () => {
   return {
+    listFamilyMembers: listFamilyMembersMock,
     requireFamilyAdmin: requireFamilyAdminMock,
     requireFamilyMembership: requireFamilyMembershipMock,
   };
@@ -260,11 +267,13 @@ describe("meal-plan.server", () => {
           date: new Date("2026-05-15T00:00:00.000Z"),
           note: "Rester til lunsj",
           recipeId: "kylling-taco",
+          responsibleUserId: "user-2",
         },
         {
           date: new Date("2026-05-17T00:00:00.000Z"),
           note: null,
           recipeId: "tomatsuppe",
+          responsibleUserId: null,
         },
       ],
       id: "meal-plan-source",
@@ -301,6 +310,7 @@ describe("meal-plan.server", () => {
             date: true,
             note: true,
             recipeId: true,
+            responsibleUserId: true,
           },
           where: {
             mealType: "DINNER",
@@ -345,6 +355,7 @@ describe("meal-plan.server", () => {
           mealType: "DINNER",
           note: "Rester til lunsj",
           recipeId: "kylling-taco",
+          responsibleUserId: "user-2",
         },
         {
           date: new Date("2026-05-22T00:00:00.000Z"),
@@ -352,6 +363,7 @@ describe("meal-plan.server", () => {
           mealType: "DINNER",
           note: null,
           recipeId: "tomatsuppe",
+          responsibleUserId: null,
         },
       ],
     });
@@ -770,6 +782,7 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "",
           recipeId: "kylling-taco",
+          responsibleUserId: "",
         },
       ],
       familyId: "family-1",
@@ -786,6 +799,7 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "",
           recipeId: "kylling-taco",
+          responsibleUserId: "",
         },
       ],
     });
@@ -806,11 +820,13 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "",
           recipeId: "kylling-taco",
+          responsibleUserId: "",
         },
         {
           date: "2026-05-16",
           note: "",
           recipeId: "",
+          responsibleUserId: "",
         },
       ],
       entryVersions: {},
@@ -845,6 +861,7 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "Bruk rester til lunsj",
           recipeId: "",
+          responsibleUserId: "",
         },
       ],
       entryVersions: {},
@@ -863,11 +880,13 @@ describe("meal-plan.server", () => {
         mealType: "DINNER",
         note: "Bruk rester til lunsj",
         recipeId: null,
+        responsibleUserId: null,
         updatedByUserId: "user-1",
       },
       update: {
         note: "Bruk rester til lunsj",
         recipeId: null,
+        responsibleUserId: null,
         updatedByUserId: "user-1",
       },
       where: {
@@ -899,6 +918,7 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "Oppdatert notat",
           recipeId: "",
+          responsibleUserId: "",
         },
       ],
       entryVersions: {
@@ -918,6 +938,7 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "Oppdatert notat",
           recipeId: "",
+          responsibleUserId: "",
         },
       ],
     });
@@ -938,6 +959,7 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "",
           recipeId: "ukjent-rett",
+          responsibleUserId: "",
         },
       ],
       entryVersions: {},
@@ -954,8 +976,147 @@ describe("meal-plan.server", () => {
           date: "2026-05-15",
           note: "",
           recipeId: "ukjent-rett",
+          responsibleUserId: "",
         },
       ],
+    });
+    expect(dbMock.mealPlanEntry.upsert).not.toHaveBeenCalled();
+  });
+
+  it("persists responsible family members on dinner entries", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-15T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+    });
+    dbMock.recipe.findMany.mockResolvedValue([{ id: "kylling-taco" }]);
+    listFamilyMembersMock.mockResolvedValue([
+      {
+        user: {
+          displayName: "Ola",
+          email: "ola@example.com",
+          id: "user-2",
+        },
+      },
+    ]);
+
+    const result = await saveMealPlanEntries({
+      entries: [
+        {
+          date: "2026-05-15",
+          note: "",
+          recipeId: "kylling-taco",
+          responsibleUserId: "user-2",
+        },
+      ],
+      entryVersions: {},
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(listFamilyMembersMock).toHaveBeenCalledWith("family-1");
+    expect(dbMock.mealPlanEntry.upsert).toHaveBeenCalledWith({
+      create: expect.objectContaining({
+        responsibleUserId: "user-2",
+      }),
+      update: expect.objectContaining({
+        responsibleUserId: "user-2",
+      }),
+      where: expect.any(Object),
+    });
+  });
+
+  it("rejects responsible users who are not family members", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-15T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+    });
+    dbMock.recipe.findMany.mockResolvedValue([{ id: "kylling-taco" }]);
+    listFamilyMembersMock.mockResolvedValue([
+      {
+        user: {
+          displayName: "Ola",
+          email: "ola@example.com",
+          id: "user-2",
+        },
+      },
+    ]);
+
+    const result = await saveMealPlanEntries({
+      entries: [
+        {
+          date: "2026-05-15",
+          note: "",
+          recipeId: "kylling-taco",
+          responsibleUserId: "user-99",
+        },
+      ],
+      entryVersions: {},
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      formError: "Minst en valgt ansvarlig er ikke medlem av familien.",
+      status: "VALIDATION_ERROR",
+      values: [
+        {
+          date: "2026-05-15",
+          note: "",
+          recipeId: "kylling-taco",
+          responsibleUserId: "user-99",
+        },
+      ],
+    });
+    expect(dbMock.mealPlanEntry.upsert).not.toHaveBeenCalled();
+  });
+
+  it("deletes days that only have a responsible member without a meal", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-15T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+    });
+    listFamilyMembersMock.mockResolvedValue([
+      {
+        user: {
+          displayName: "Ola",
+          email: "ola@example.com",
+          id: "user-2",
+        },
+      },
+    ]);
+
+    const result = await saveMealPlanEntries({
+      entries: [
+        {
+          date: "2026-05-15",
+          note: "",
+          recipeId: "",
+          responsibleUserId: "user-2",
+        },
+      ],
+      entryVersions: {},
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.mealPlanEntry.deleteMany).toHaveBeenCalledWith({
+      where: {
+        date: new Date("2026-05-15T00:00:00.000Z"),
+        mealPlanId: "meal-plan-1",
+        mealType: "DINNER",
+      },
     });
     expect(dbMock.mealPlanEntry.upsert).not.toHaveBeenCalled();
   });

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -10,7 +10,10 @@ import {
   matchesExpectedUpdatedAt,
 } from "./collaboration.server";
 import { db } from "./db.server";
-import { requireFamilyMembership } from "./family.server";
+import {
+  listFamilyMembers,
+  requireFamilyMembership,
+} from "./family.server";
 import { formatDateOnly } from "./meal-plan-dates";
 import {
   logCollaborationFailure,
@@ -60,6 +63,13 @@ const mealPlanEntrySelect = Prisma.validator<Prisma.MealPlanEntrySelect>()({
     select: recipeOptionSelect,
   },
   recipeId: true,
+  responsibleUser: {
+    select: {
+      displayName: true,
+      id: true,
+    },
+  },
+  responsibleUserId: true,
   updatedAt: true,
 });
 
@@ -122,6 +132,7 @@ export interface MealPlanEntryValues {
   date: string;
   note: string;
   recipeId: string;
+  responsibleUserId: string;
 }
 
 interface SaveMealPlanEntriesInput {
@@ -448,6 +459,7 @@ export async function copyMealPlan(input: CopyMealPlanInput) {
             date: true,
             note: true,
             recipeId: true,
+            responsibleUserId: true,
           },
           where: {
             mealType: PLANNING_MEAL_TYPE,
@@ -503,6 +515,7 @@ export async function copyMealPlan(input: CopyMealPlanInput) {
           mealType: PLANNING_MEAL_TYPE,
           note: entry.note,
           recipeId: entry.recipeId,
+          responsibleUserId: entry.responsibleUserId,
         },
       ];
     });
@@ -871,6 +884,7 @@ export async function autoFillMealPlanEntries({
         date,
         note: "",
         recipeId: assignedRecipeId,
+        responsibleUserId: existingEntry?.responsibleUserId ?? "",
       };
     }
 
@@ -878,6 +892,7 @@ export async function autoFillMealPlanEntries({
       date,
       note: existingEntry?.note ?? "",
       recipeId: existingEntry?.recipeId ?? "",
+      responsibleUserId: existingEntry?.responsibleUserId ?? "",
     };
   });
   const entryVersions = Object.fromEntries(
@@ -1001,6 +1016,34 @@ export async function saveMealPlanEntries({
     }
   }
 
+  const responsibleUserIds = [
+    ...new Set(values.map((entry) => entry.responsibleUserId).filter(Boolean)),
+  ];
+
+  if (responsibleUserIds.length > 0) {
+    const members = await listFamilyMembers(familyId);
+    const memberUserIds = new Set(members.map((member) => member.user.id));
+
+    if (responsibleUserIds.some((userId) => !memberUserIds.has(userId))) {
+      logCollaborationWrite({
+        action: "save-meal-plan-entries",
+        domain: "meal-plan",
+        entityType: "meal-plan-entry",
+        familyId,
+        mealPlanId: mealPlan.id,
+        outcome: "VALIDATION_ERROR",
+        userId,
+      });
+
+      return {
+        formError:
+          "Minst en valgt ansvarlig er ikke medlem av familien.",
+        status: "VALIDATION_ERROR" as const,
+        values,
+      };
+    }
+  }
+
   const submittedDates = values
     .map((entry) => parseDateOnly(entry.date)!)
     .filter(Boolean);
@@ -1083,11 +1126,13 @@ export async function saveMealPlanEntries({
             mealType: PLANNING_MEAL_TYPE,
             note: entry.note || null,
             recipeId: entry.recipeId || null,
+            responsibleUserId: entry.responsibleUserId || null,
             ...buildActorUpdate(userId),
           },
           update: {
             note: entry.note || null,
             recipeId: entry.recipeId || null,
+            responsibleUserId: entry.responsibleUserId || null,
             ...buildActorUpdate(userId),
           },
           where: {
@@ -1419,6 +1464,7 @@ function normalizeMealPlanEntryValues(
     date: entry.date.trim(),
     note: entry.note.trim(),
     recipeId: entry.recipeId.trim(),
+    responsibleUserId: entry.responsibleUserId.trim(),
   };
 }
 

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -27,7 +27,12 @@ vi.mock("../lib/meal-plan-share.server", () => ({
   markReviewCommentAddressed: vi.fn(),
 }));
 
+vi.mock("../lib/family.server", () => ({
+  listFamilyMembers: vi.fn(),
+}));
+
 import { requireUser } from "../lib/auth.server";
+import { listFamilyMembers } from "../lib/family.server";
 import {
   approveMealPlan,
   getMealPlanPlanningData,
@@ -84,6 +89,8 @@ describe("family meal plan route", () => {
             note: "Bruk rester til lunsj",
             recipe: null,
             recipeId: "",
+            responsibleUser: null,
+            responsibleUserId: null,
             updatedAt: new Date("2026-05-01T12:00:00.000Z"),
           },
         ],
@@ -113,6 +120,26 @@ describe("family meal plan route", () => {
       openShares: [],
     });
     vi.mocked(listSharesForMealPlan).mockResolvedValue([]);
+    vi.mocked(listFamilyMembers).mockResolvedValue([
+      {
+        id: "membership-1",
+        role: "ADMIN",
+        user: {
+          displayName: "Ola",
+          email: "ola@example.com",
+          id: "user-1",
+        },
+      },
+      {
+        id: "membership-2",
+        role: "MEMBER",
+        user: {
+          displayName: "Kari",
+          email: "kari@example.com",
+          id: "user-2",
+        },
+      },
+    ]);
 
     const result = await loader({
       params: {
@@ -127,6 +154,7 @@ describe("family meal plan route", () => {
       mealPlanId: "meal-plan-1",
       userId: "user-1",
     });
+    expect(listFamilyMembers).toHaveBeenCalledWith("family-1");
     expect(result).toEqual({
       activeOpenShare: null,
       calendarExportDates: [],
@@ -150,6 +178,10 @@ describe("family meal plan route", () => {
       },
       entriesSnapshot:
         "2026-05-15T00:00:00.000Z:DINNER:2026-05-01T12:00:00.000Z",
+      familyMembers: [
+        { displayName: "Ola", id: "user-1" },
+        { displayName: "Kari", id: "user-2" },
+      ],
       feedbackShares: [],
       notice: "meal-plan-created",
       noticeMeta: null,
@@ -170,21 +202,25 @@ describe("family meal plan route", () => {
         "2026-05-15": {
           note: "Bruk rester til lunsj",
           recipeId: "",
+          responsibleUserId: "",
           updatedAt: "2026-05-01T12:00:00.000Z",
         },
         "2026-05-16": {
           note: "",
           recipeId: "",
+          responsibleUserId: "",
           updatedAt: "",
         },
         "2026-05-17": {
           note: "",
           recipeId: "",
+          responsibleUserId: "",
           updatedAt: "",
         },
         "2026-05-18": {
           note: "",
           recipeId: "",
+          responsibleUserId: "",
           updatedAt: "",
         },
       },
@@ -201,11 +237,13 @@ describe("family meal plan route", () => {
           date: "2026-05-15",
           note: "Bruk rester til lunsj",
           recipeId: "",
+          responsibleUserId: "user-2",
         },
         {
           date: "2026-05-16",
           note: "",
           recipeId: "kylling-taco",
+          responsibleUserId: "",
         },
       ],
     });
@@ -216,8 +254,10 @@ describe("family meal plan route", () => {
     formData.append("entryDate", "2026-05-16");
     formData.set("note:2026-05-15", "Bruk rester til lunsj");
     formData.set("recipeId:2026-05-15", "");
+    formData.set("responsibleUserId:2026-05-15", "user-2");
     formData.set("note:2026-05-16", "");
     formData.set("recipeId:2026-05-16", "kylling-taco");
+    formData.set("responsibleUserId:2026-05-16", "");
 
     const result = await action({
       params: {
@@ -233,11 +273,13 @@ describe("family meal plan route", () => {
           date: "2026-05-15",
           note: "Bruk rester til lunsj",
           recipeId: "",
+          responsibleUserId: "user-2",
         },
         {
           date: "2026-05-16",
           note: "",
           recipeId: "kylling-taco",
+          responsibleUserId: "",
         },
       ],
       entryVersions: {
@@ -254,11 +296,13 @@ describe("family meal plan route", () => {
         "2026-05-15": {
           note: "Bruk rester til lunsj",
           recipeId: "",
+          responsibleUserId: "user-2",
           updatedAt: "",
         },
         "2026-05-16": {
           note: "",
           recipeId: "kylling-taco",
+          responsibleUserId: "",
           updatedAt: "",
         },
       },
@@ -326,11 +370,13 @@ describe("family meal plan route", () => {
           date: "2026-05-15",
           note: "",
           recipeId: "",
+          responsibleUserId: "",
         },
         {
           date: "2026-05-16",
           note: "",
           recipeId: "",
+          responsibleUserId: "",
         },
       ],
       entryVersions: {
@@ -360,6 +406,7 @@ describe("family meal plan route", () => {
           date: "2026-05-15",
           note: "",
           recipeId: "",
+          responsibleUserId: "",
         },
       ],
     });
@@ -385,6 +432,7 @@ describe("family meal plan route", () => {
         "2026-05-15": {
           note: "",
           recipeId: "",
+          responsibleUserId: "",
           updatedAt: "2026-05-01T12:00:00.000Z",
         },
       },

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router";
 
 import { requireUser } from "../lib/auth.server";
+import { listFamilyMembers } from "../lib/family.server";
 import {
   buildMealPlanEntriesSnapshot,
   COLLABORATION_CONFLICT_MESSAGE,
@@ -58,9 +59,15 @@ interface MealPlanNoticeMeta {
 
 const CALENDAR_DOWNLOAD_TARGET = "meal-plan-calendar-download";
 
+interface MealPlanFamilyMemberOption {
+  displayName: string;
+  id: string;
+}
+
 interface MealPlanEntryFormState {
   note: string;
   recipeId: string;
+  responsibleUserId: string;
   updatedAt: string;
 }
 
@@ -116,11 +123,18 @@ export async function loader({
     params.mealPlanId,
     "Fant ikke ukeplanen.",
   );
-  const result = await getMealPlanPlanningData({
-    familyId,
-    mealPlanId,
-    userId: user.id,
-  });
+  const [result, members] = await Promise.all([
+    getMealPlanPlanningData({
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    }),
+    listFamilyMembers(familyId),
+  ]);
+  const familyMembers: MealPlanFamilyMemberOption[] = members.map((member) => ({
+    displayName: member.user.displayName,
+    id: member.user.id,
+  }));
 
   const entriesByDate = Object.fromEntries(
     result.visibleDates.map((date) => {
@@ -135,6 +149,7 @@ export async function loader({
         {
           note: entry?.note ?? "",
           recipeId: entry?.recipeId ?? "",
+          responsibleUserId: entry?.responsibleUserId ?? "",
           updatedAt: entry?.updatedAt.toISOString() ?? "",
         },
       ];
@@ -186,6 +201,7 @@ export async function loader({
       updatedAt: result.mealPlan.updatedAt.toISOString(),
     },
     entriesSnapshot,
+    familyMembers,
     notice: getMealPlanNotice(request),
     noticeMeta: getMealPlanNoticeMeta(request),
     recipes: result.recipes,
@@ -691,6 +707,7 @@ export default function FamilyMealPlanRoute({
                   const entry = entryValues[date] ?? {
                     note: "",
                     recipeId: "",
+                    responsibleUserId: "",
                     updatedAt: "",
                   };
 
@@ -702,6 +719,7 @@ export default function FamilyMealPlanRoute({
                       date={date}
                       entry={entry}
                       familyId={loaderData.family.id}
+                      familyMembers={loaderData.familyMembers}
                       isToday={isPlanDateToday(date)}
                       mealPlanId={loaderData.mealPlan.id}
                       recipes={loaderData.recipes}
@@ -1607,6 +1625,7 @@ function MealPlanDayRow({
   date,
   entry,
   familyId,
+  familyMembers,
   isToday,
   mealPlanId,
   recipes,
@@ -1616,20 +1635,32 @@ function MealPlanDayRow({
   date: string;
   entry: MealPlanEntryFormState;
   familyId: string;
+  familyMembers: MealPlanFamilyMemberOption[];
   isToday: boolean;
   mealPlanId: string;
   recipes: MealPlanRecipeOption[];
 }) {
   const [selectedRecipeId, setSelectedRecipeId] = useState(entry.recipeId);
+  const [selectedResponsibleUserId, setSelectedResponsibleUserId] = useState(
+    entry.responsibleUserId,
+  );
 
   useEffect(() => {
     setSelectedRecipeId(entry.recipeId);
   }, [entry.recipeId]);
 
+  useEffect(() => {
+    setSelectedResponsibleUserId(entry.responsibleUserId);
+  }, [entry.responsibleUserId]);
+
   const selectedRecipe =
     recipes.find((recipe) => recipe.id === entry.recipeId) ?? null;
   const mealLabel = getMealDaySummaryLabel(entry, selectedRecipe);
   const hasNoteOnly = !entry.recipeId && Boolean(entry.note.trim());
+  const responsibleMember =
+    familyMembers.find(
+      (member) => member.id === selectedResponsibleUserId,
+    ) ?? null;
 
   return (
     <details
@@ -1658,6 +1689,11 @@ function MealPlanDayRow({
           {hasNoteOnly ? (
             <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800">
               Notat
+            </span>
+          ) : null}
+          {responsibleMember ? (
+            <span className="max-w-[8rem] truncate rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-medium text-sky-800">
+              {responsibleMember.displayName}
             </span>
           ) : null}
           <span className="text-xs text-slate-400 group-open:hidden">Åpne</span>
@@ -1708,6 +1744,25 @@ function MealPlanDayRow({
               Se oppskrift
             </Link>
           ) : null}
+        </label>
+
+        <label className="block min-w-0 text-sm font-medium text-slate-700">
+          Ansvarlig
+          <select
+            className="mt-2 box-border w-full max-w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            name={`responsibleUserId:${date}`}
+            onChange={(event) =>
+              setSelectedResponsibleUserId(event.target.value)
+            }
+            value={selectedResponsibleUserId}
+          >
+            <option value="">Ingen valgt</option>
+            {familyMembers.map((member) => (
+              <option key={member.id} value={member.id}>
+                {member.displayName}
+              </option>
+            ))}
+          </select>
         </label>
 
         <label className="block min-w-0 text-sm font-medium text-slate-700">
@@ -1796,6 +1851,9 @@ function parseMealPlanEntries(formData: FormData): MealPlanEntryValues[] {
       date,
       note: String(formData.get(`note:${date}`) ?? ""),
       recipeId: String(formData.get(`recipeId:${date}`) ?? ""),
+      responsibleUserId: String(
+        formData.get(`responsibleUserId:${date}`) ?? "",
+      ),
     };
   });
 }
@@ -1805,6 +1863,7 @@ function buildResetMealPlanEntries(formData: FormData): MealPlanEntryValues[] {
     date: String(dateValue),
     note: "",
     recipeId: "",
+    responsibleUserId: "",
   }));
 }
 
@@ -1828,6 +1887,7 @@ function indexMealPlanEntryValues(
       {
         note: entry.note,
         recipeId: entry.recipeId,
+        responsibleUserId: entry.responsibleUserId,
         updatedAt: entryVersions[entry.date] ?? "",
       },
     ]),

--- a/app/routes/family.test.ts
+++ b/app/routes/family.test.ts
@@ -98,6 +98,7 @@ const mockWeekDays = [
     mealPlanId: "meal-plan-1",
     mealPlanTitle: "Uke 23",
     menuLabel: "Ikke planlagt",
+    responsibleDisplayName: null,
     weekdayLabel: "mandag",
   },
   {
@@ -107,6 +108,7 @@ const mockWeekDays = [
     mealPlanId: "meal-plan-1",
     mealPlanTitle: "Uke 23",
     menuLabel: "Taco",
+    responsibleDisplayName: "Kari",
     weekdayLabel: "torsdag",
   },
 ];

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -178,6 +178,11 @@ function WeekDayMenuCard({
       <p className="mt-3 text-base font-semibold leading-snug text-slate-950">
         {day.menuLabel}
       </p>
+      {day.responsibleDisplayName ? (
+        <span className="mt-2 inline-flex max-w-full truncate rounded-full bg-sky-100 px-2 py-1 text-xs font-medium text-sky-800">
+          {day.responsibleDisplayName}
+        </span>
+      ) : null}
       {day.mealPlanTitle ? (
         <p className="mt-2 text-xs text-slate-500">{day.mealPlanTitle}</p>
       ) : null}

--- a/prisma/migrations/20260603120000_meal_plan_entry_responsible_user/migration.sql
+++ b/prisma/migrations/20260603120000_meal_plan_entry_responsible_user/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "MealPlanEntry" ADD COLUMN "responsibleUserId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "MealPlanEntry_responsibleUserId_idx" ON "MealPlanEntry"("responsibleUserId");
+
+-- AddForeignKey
+ALTER TABLE "MealPlanEntry" ADD CONSTRAINT "MealPlanEntry_responsibleUserId_fkey" FOREIGN KEY ("responsibleUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model User {
   mealPlanShareRecipients      MealPlanShareRecipient[]
   mealPlanReviewComments       MealPlanReviewComment[] @relation("MealPlanReviewCommentAuthor")
   addressedMealPlanReviewComments MealPlanReviewComment[] @relation("MealPlanReviewCommentAddressedBy")
+  responsibleMealPlanEntries      MealPlanEntry[]        @relation("MealPlanEntryResponsible")
 
   @@index([displayName])
 }
@@ -256,19 +257,22 @@ model MealPlanEntry {
   date       DateTime @db.Date
   mealType   MealType @default(DINNER)
   recipeId   String?
-  note              String?
-  locked            Boolean  @default(false)
-  updatedByUserId   String?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
-  mealPlan          MealPlan @relation(fields: [mealPlanId], references: [id], onDelete: Cascade)
-  recipe            Recipe?  @relation(fields: [recipeId], references: [id], onDelete: SetNull)
-  updatedByUser     User?    @relation("MealPlanEntryUpdatedBy", fields: [updatedByUserId], references: [id], onDelete: SetNull)
+  note                String?
+  locked              Boolean  @default(false)
+  responsibleUserId   String?
+  updatedByUserId     String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+  mealPlan            MealPlan @relation(fields: [mealPlanId], references: [id], onDelete: Cascade)
+  recipe              Recipe?  @relation(fields: [recipeId], references: [id], onDelete: SetNull)
+  responsibleUser     User?    @relation("MealPlanEntryResponsible", fields: [responsibleUserId], references: [id], onDelete: SetNull)
+  updatedByUser       User?    @relation("MealPlanEntryUpdatedBy", fields: [updatedByUserId], references: [id], onDelete: SetNull)
 
   @@unique([mealPlanId, date, mealType])
   @@index([updatedByUserId])
   @@index([mealPlanId, date])
   @@index([recipeId])
+  @@index([responsibleUserId])
 }
 
 model MealPlanShare {


### PR DESCRIPTION
## Summary
- Add optional `responsibleUserId` on dinner meal plan entries so families can record who is cooking each day.
- Meal plan editor: “Ansvarlig” select per day, visible in collapsed row summary after save.
- Family home week overview (`WeekDayMenuCard`): shows responsible member name when assigned.
- Validates assignee is a family member; copy meal plan preserves assignments; responsible-only days are not persisted.

## Related issue
Closes #141

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Manual: assign responsible in meal plan editor, collapse row, verify chip on family home week card
- [ ] Manual: copy meal plan and confirm assignments carry over
- [ ] Deploy migration: `npm run prisma:migrate:deploy`

## Validation
- `npm run prisma:generate`
- `npm run lint`
- `npm run test:run` (52 files, 308 tests)
- `npm run typecheck`