### PR TITLE
Change item section from store mode

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,33 @@
 
 ## Current Objective
 
-Issue #141 — PR ready on `issue/141-meal-plan-responsible-member`.
+Issue #143 — PR ready on `issue/143-store-mode-category`: change shopping section/category from store mode without leaving the page.
 
 ## Completed
 
-- Optional `responsibleUserId` on dinner `MealPlanEntry` (migration `20260603120000_meal_plan_entry_responsible_user`).
-- Meal plan editor: assign/clear responsible, visible in collapsed day row.
-- Family home `WeekDayMenuCard`: shows responsible display name chip on weekly overview.
-- Save validates family membership; copy preserves assignments; responsible-only days deleted on save.
+- In-place category editor on `StoreModeShoppingItemCard` for FAMILY and MANUAL items (info panel).
+- Auto-save on dropdown change; item relocates to the correct store-mode section optimistically.
+- Store-mode actions: `update-family-shopping-item-category`, `update-manual-shopping-item-category`.
+- Client helper `relocateProjectedItemInSectionGroups`; exported `parseManualShoppingItemValues`.
+- Details panel width fix (`open:w-1/2`); category select at 50% card width when open.
 
 ## Files To Read First
 
-- `prisma/schema.prisma` — `MealPlanEntry.responsibleUserId`
-- `app/lib/meal-plan.server.ts` — save/copy/validation
-- `app/routes/family-meal-plan.tsx` — editor UI
-- `app/lib/family-home.server.ts` — week overview data
+- `app/components/store-mode-shopping-item-card.tsx` — category UI and auto-save
+- `app/routes/family-meal-plan-store-mode.tsx` — loader categories, actions, fetcher regroup
+- `app/lib/shopping-list-client.ts` — `relocateProjectedItemInSectionGroups`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (52 files, 308 tests)
+- `npm run test:run` — passed (52 files, 311 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Deploy: `npm run prisma:migrate:deploy`
-- Manual QA on meal plan editor and family home week cards
+- Manual QA in store mode: quick-add item in wrong section → change dropdown → confirm move; verify on mobile grid and list layouts.
 
 ## Next Step
 
-Merge PR; issue closes via `Closes #141`.
+Merge PR; issue closes via `Closes #143`.

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   formatGeneratedOccurrenceAttribution,
   formatGeneratedQuantityBadge,
 } from "../lib/shopping-display";
 import type { StoreModeShoppingView } from "../lib/shopping-store-mode-client";
+import type { StoreCategory } from "../lib/store.server";
 
 interface StoreModeShoppingItemCardBase {
+  category: {
+    id: string;
+    name: string;
+  };
   checked: boolean;
   collaborationVersion: string;
   name: string;
@@ -15,6 +20,7 @@ interface StoreModeShoppingItemCardBase {
     id: string;
     name: string;
   } | null;
+  quantity?: string | null;
   quantityLabel: string | null;
   sourceKey: string;
 }
@@ -43,14 +49,41 @@ export type StoreModeShoppingItemCardItem =
   | StoreModeShoppingItemCardManual
   | StoreModeShoppingItemCardFamily;
 
+export type StoreModeCategoryUpdateRequest =
+  | {
+      buyOnDate: string;
+      categoryId: string;
+      expectedUpdatedAt: string;
+      name: string;
+      note: string;
+      preferredStoreId: string;
+      quantity: string;
+      sourceKey: string;
+      sourceType: "MANUAL";
+    }
+  | {
+      categoryId: string;
+      expectedUpdatedAt: string;
+      name: string;
+      note: string;
+      preferredStoreId: string;
+      quantity: string;
+      sourceKey: string;
+      sourceType: "FAMILY";
+    };
+
 interface StoreModeShoppingItemCardProps {
+  categories: StoreCategory[];
+  categoryError?: string | null;
   isRecentlyAdded?: boolean;
+  isSavingCategory?: boolean;
   item: StoreModeShoppingItemCardItem;
   layout: StoreModeShoppingView;
   onQuickAddFromCard?: (item: {
     name: string;
     quantityLabel: string | null;
   }) => void;
+  onUpdateCategory?: (request: StoreModeCategoryUpdateRequest) => void;
   onUpdateQuantity?: (item: {
     expectedUpdatedAt: string;
     quantity: string;
@@ -63,10 +96,14 @@ interface StoreModeShoppingItemCardProps {
 const badgeClass = "rounded-full px-2 py-0.5 text-[11px] font-medium leading-4";
 
 export function StoreModeShoppingItemCard({
+  categories,
+  categoryError = null,
   isRecentlyAdded = false,
+  isSavingCategory = false,
   item,
   layout: _layout,
   onQuickAddFromCard,
+  onUpdateCategory,
   onUpdateQuantity,
   onToggle,
   selectedStoreId,
@@ -75,7 +112,59 @@ export function StoreModeShoppingItemCard({
   const shouldAutoOpenDetails = shouldAutoOpenStoreModeDetails(item);
   const [isQuantityModalOpen, setIsQuantityModalOpen] = useState(false);
   const [quantityDraft, setQuantityDraft] = useState(item.quantityLabel ?? "");
+  const [categoryDraft, setCategoryDraft] = useState(item.category.id);
   const quantityInputRef = useRef<HTMLInputElement>(null);
+  const showCategoryEdit =
+    item.sourceType === "FAMILY" || item.sourceType === "MANUAL";
+
+  useEffect(() => {
+    setCategoryDraft(item.category.id);
+  }, [item.category.id]);
+
+  useEffect(() => {
+    if (categoryError) {
+      setCategoryDraft(item.category.id);
+    }
+  }, [categoryError, item.category.id]);
+
+  const handleCategoryChange = useCallback(
+    (nextCategoryId: string) => {
+      if (nextCategoryId === item.category.id || isSavingCategory) {
+        return;
+      }
+
+      setCategoryDraft(nextCategoryId);
+
+      if (item.sourceType === "FAMILY") {
+        onUpdateCategory?.({
+          categoryId: nextCategoryId,
+          expectedUpdatedAt: item.collaborationVersion,
+          name: item.name,
+          note: item.note ?? "",
+          preferredStoreId: item.preferredStore?.id ?? "",
+          quantity: item.quantity?.trim() || item.quantityLabel || "",
+          sourceKey: item.sourceKey,
+          sourceType: "FAMILY",
+        });
+        return;
+      }
+
+      if (item.sourceType === "MANUAL") {
+        onUpdateCategory?.({
+          buyOnDate: item.buyOnDate ?? "",
+          categoryId: nextCategoryId,
+          expectedUpdatedAt: item.collaborationVersion,
+          name: item.name,
+          note: item.note ?? "",
+          preferredStoreId: item.preferredStore?.id ?? "",
+          quantity: item.quantity?.trim() || item.quantityLabel || "",
+          sourceKey: item.sourceKey,
+          sourceType: "MANUAL",
+        });
+      }
+    },
+    [isSavingCategory, item, onUpdateCategory],
+  );
 
   const cardStateClass = isRecentlyAdded
     ? "border-emerald-300 bg-emerald-100"
@@ -172,18 +261,18 @@ export function StoreModeShoppingItemCard({
         </div>
 
         <details
-          className="group mt-auto flex w-0 min-w-0 flex-col-reverse items-start pointer-events-auto"
+          className="group mt-auto flex w-7 min-w-7 flex-col-reverse items-stretch self-start pointer-events-auto open:w-1/2 open:min-w-[50%] open:max-w-full"
           open={shouldAutoOpenDetails}
         >
           <summary
             aria-label={`Vis informasjon om ${item.name}`}
-            className="mt-1 flex h-7 w-7 cursor-pointer list-none items-center justify-center rounded-full border border-stone-200 bg-white text-stone-600 transition hover:bg-stone-100 hover:text-stone-950 group-open:border-store-accent group-open:bg-store-accent-light group-open:text-store-accent-text marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-store-accent [&::-webkit-details-marker]:hidden"
+            className="mt-1 flex h-7 w-7 shrink-0 cursor-pointer list-none items-center justify-center self-start rounded-full border border-stone-200 bg-white text-stone-600 transition hover:bg-stone-100 hover:text-stone-950 group-open:border-store-accent group-open:bg-store-accent-light group-open:text-store-accent-text marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-store-accent [&::-webkit-details-marker]:hidden"
           >
             <StoreModeInfoIcon className="h-3.5 w-3.5" />
             <span className="sr-only">Vis informasjon</span>
           </summary>
           <div
-            className="mb-1 w-full min-w-0 max-w-full space-y-1 border-b border-stone-200 pb-1.5 pointer-events-auto"
+            className="mb-1 w-full min-w-0 space-y-1.5 border-b border-stone-200 pb-1.5 pointer-events-auto"
             onClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => event.stopPropagation()}
           >
@@ -194,6 +283,34 @@ export function StoreModeShoppingItemCard({
               <p className="break-words text-xs leading-4 text-stone-700">
                 Notat: {item.note}
               </p>
+            ) : null}
+            {showCategoryEdit ? (
+              <div className="space-y-1.5">
+                <label className="block text-xs font-medium text-stone-700">
+                  Endre seksjon
+                  <select
+                    aria-busy={isSavingCategory}
+                    className="mt-1 box-border w-full max-w-full min-w-0 rounded-xl border border-stone-300 bg-white px-3 py-2 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60 disabled:cursor-wait disabled:opacity-70"
+                    disabled={isSavingCategory}
+                    onChange={(event) =>
+                      handleCategoryChange(event.currentTarget.value)
+                    }
+                    value={categoryDraft}
+                  >
+                    {categories.map((category) => (
+                      <option key={category.id} value={category.id}>
+                        {category.displayName}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {categoryError ? (
+                  <p className="text-xs text-rose-600">{categoryError}</p>
+                ) : null}
+                {isSavingCategory ? (
+                  <p className="text-xs text-stone-500">Lagrer...</p>
+                ) : null}
+              </div>
             ) : null}
             <button
               className="inline-flex w-fit rounded-full border border-store-accent/40 bg-store-accent-light px-2.5 py-1 text-xs font-medium text-store-accent-text transition hover:border-store-accent hover:bg-store-accent-light/80"

--- a/app/lib/shopping-list-client.test.ts
+++ b/app/lib/shopping-list-client.test.ts
@@ -5,6 +5,7 @@ import {
   insertProjectedItemIntoStoreGroups,
   mergeQuickAddedItemsIntoList,
   prependRecentManualItem,
+  relocateProjectedItemInSectionGroups,
 } from "./shopping-list-client";
 import type { SerializedProjectedShoppingItem } from "./shopping-serialize";
 
@@ -141,6 +142,37 @@ describe("shopping-list-client", () => {
     );
 
     expect(result.map((item) => item.nameNormalized)).toEqual(["melk", "brod"]);
+  });
+
+  it("relocates an item into a new section group", () => {
+    const existingItem = createFamilyItem({
+      category: { id: "category-other", name: "Annet" },
+      name: "Bananer",
+      section: { displayName: "Annet", sortOrder: 99 },
+      sourceKey: "item-1",
+    });
+    const updatedItem = createFamilyItem({
+      category: { id: "category-produce", name: "Frukt og grønt" },
+      name: "Bananer",
+      section: { displayName: "Frukt og grønt", sortOrder: 2 },
+      sourceKey: "item-1",
+    });
+
+    const result = relocateProjectedItemInSectionGroups(
+      [
+        {
+          category: existingItem.category,
+          displayName: existingItem.section.displayName,
+          items: [existingItem],
+        },
+      ],
+      "item-1",
+      updatedItem,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.displayName).toBe("Frukt og grønt");
+    expect(result[0]?.items[0]?.category.id).toBe("category-produce");
   });
 
   it("merges quick-added items by source key", () => {

--- a/app/lib/shopping-list-client.ts
+++ b/app/lib/shopping-list-client.ts
@@ -111,6 +111,29 @@ export function insertProjectedItemIntoStoreGroups(
   });
 }
 
+export function removeProjectedItemFromSectionGroups(
+  sections: SerializedProjectedShoppingSectionGroup[],
+  sourceKey: string,
+): SerializedProjectedShoppingSectionGroup[] {
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((existingItem) => existingItem.sourceKey !== sourceKey),
+    }))
+    .filter((section) => section.items.length > 0);
+}
+
+export function relocateProjectedItemInSectionGroups(
+  sections: SerializedProjectedShoppingSectionGroup[],
+  sourceKey: string,
+  updatedItem: SerializedProjectedShoppingItem,
+): SerializedProjectedShoppingSectionGroup[] {
+  return insertProjectedItemIntoSectionGroups(
+    removeProjectedItemFromSectionGroups(sections, sourceKey),
+    updatedItem,
+  );
+}
+
 export function insertProjectedItemIntoSectionGroups(
   sections: SerializedProjectedShoppingSectionGroup[],
   item: SerializedProjectedShoppingItem,

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -40,6 +40,19 @@ export interface QuickAddManualShoppingItemInput {
   recentNameNormalized?: string;
 }
 
+export function parseManualShoppingItemValues(
+  formData: FormData,
+): ManualShoppingItemValues {
+  return {
+    buyOnDate: String(formData.get("buyOnDate") ?? ""),
+    categoryId: String(formData.get("categoryId") ?? ""),
+    name: String(formData.get("name") ?? ""),
+    note: String(formData.get("note") ?? ""),
+    preferredStoreId: String(formData.get("preferredStoreId") ?? ""),
+    quantity: String(formData.get("quantity") ?? ""),
+  };
+}
+
 const OTHER_INGREDIENT_CATEGORY_KEY = "other";
 const QUICK_ADD_DEFAULT_QUANTITY = "1";
 

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -13,22 +13,34 @@ vi.mock("../lib/shopping.server", () => {
   return {
     getMealPlanStoreModeData: vi.fn(),
     listRecentManualShoppingItemsForFamily: vi.fn(),
+    projectCreatedFamilyShoppingItem: vi.fn(),
+    projectCreatedManualShoppingItem: vi.fn(),
   };
 });
 
 vi.mock("../lib/family-shopping-write.server", () => {
   return {
     createQuickFamilyShoppingItem: vi.fn(),
+    parseFamilyShoppingItemValues: vi.fn(),
     parseQuickAddFamilyShoppingItemInput: vi.fn(),
     toggleFamilyShoppingItemChecked: vi.fn(),
+    updateFamilyShoppingItem: vi.fn(),
     updateFamilyShoppingItemQuantity: vi.fn(),
   };
 });
 
 vi.mock("../lib/shopping-write.server", () => {
   return {
+    parseManualShoppingItemValues: vi.fn(),
     toggleShoppingItemChecked: vi.fn(),
     updateActiveShoppingDate: vi.fn(),
+    updateManualShoppingItem: vi.fn(),
+  };
+});
+
+vi.mock("../lib/store.server", () => {
+  return {
+    listIngredientCategories: vi.fn(),
   };
 });
 
@@ -40,15 +52,25 @@ vi.mock("../lib/store-write.server", () => {
 
 import {
   createQuickFamilyShoppingItem,
+  parseFamilyShoppingItemValues,
   parseQuickAddFamilyShoppingItemInput,
+  updateFamilyShoppingItem,
   updateFamilyShoppingItemQuantity,
 } from "../lib/family-shopping-write.server";
 import { requireUser } from "../lib/auth.server";
 import {
   getMealPlanStoreModeData,
   listRecentManualShoppingItemsForFamily,
+  projectCreatedFamilyShoppingItem,
+  projectCreatedManualShoppingItem,
 } from "../lib/shopping.server";
-import { toggleShoppingItemChecked, updateActiveShoppingDate } from "../lib/shopping-write.server";
+import {
+  parseManualShoppingItemValues,
+  toggleShoppingItemChecked,
+  updateActiveShoppingDate,
+  updateManualShoppingItem,
+} from "../lib/shopping-write.server";
+import { listIngredientCategories } from "../lib/store.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
 import { action, loader } from "./family-meal-plan-store-mode";
 
@@ -76,6 +98,12 @@ describe("family meal plan store mode route", () => {
 
   it("loads and serializes store mode data", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listIngredientCategories).mockResolvedValue([
+      {
+        displayName: "Meieri",
+        id: "category-dairy",
+      },
+    ]);
     vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([
       {
         categoryId: "",
@@ -197,6 +225,13 @@ describe("family meal plan store mode route", () => {
     expect(listRecentManualShoppingItemsForFamily).toHaveBeenCalledWith({
       familyId: "family-1",
     });
+    expect(listIngredientCategories).toHaveBeenCalled();
+    expect(result.categories).toEqual([
+      {
+        displayName: "Meieri",
+        id: "category-dairy",
+      },
+    ]);
     expect(result.recentManualItems).toEqual([
       {
         categoryId: "",
@@ -411,6 +446,170 @@ describe("family meal plan store mode route", () => {
     });
     expect(result).toEqual({
       intent: "update-family-shopping-item-quantity",
+      ok: true,
+    });
+  });
+
+  it("updates family item category without redirecting", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseFamilyShoppingItemValues).mockReturnValue({
+      categoryId: "category-produce",
+      name: "Bananer",
+      note: "",
+      preferredStoreId: "",
+      quantity: "1",
+    });
+    vi.mocked(updateFamilyShoppingItem).mockResolvedValue({
+      status: "UPDATED",
+    });
+    vi.mocked(projectCreatedFamilyShoppingItem).mockResolvedValue({
+      category: { id: "category-produce", name: "Frukt og gront" },
+      checked: false,
+      collaborationVersion: "2026-05-31T00:00:00.000Z",
+      name: "Bananer",
+      note: null,
+      preferredStore: null,
+      quantity: "1",
+      quantityLabel: "1",
+      section: { displayName: "Frukt og gront", sortOrder: 1 },
+      sourceKey: "family-item-1",
+      sourceType: "FAMILY",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-family-shopping-item-category");
+    formData.set("sourceKey", "family-item-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("categoryId", "category-produce");
+    formData.set("name", "Bananer");
+    formData.set("note", "");
+    formData.set("preferredStoreId", "");
+    formData.set("quantity", "1");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(updateFamilyShoppingItem).toHaveBeenCalledWith({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-produce",
+        name: "Bananer",
+        note: "",
+        preferredStoreId: "",
+        quantity: "1",
+      },
+    });
+    expect(projectCreatedFamilyShoppingItem).toHaveBeenCalledWith({
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+    });
+    expect(result).toEqual({
+      intent: "update-family-shopping-item-category",
+      item: {
+        category: { id: "category-produce", name: "Frukt og gront" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Bananer",
+        note: null,
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Frukt og gront", sortOrder: 1 },
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+      ok: true,
+    });
+  });
+
+  it("updates manual item category without redirecting", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(parseManualShoppingItemValues).mockReturnValue({
+      buyOnDate: "",
+      categoryId: "category-produce",
+      name: "Bananer",
+      note: "",
+      preferredStoreId: "",
+      quantity: "2 kg",
+    });
+    vi.mocked(updateManualShoppingItem).mockResolvedValue({
+      status: "UPDATED",
+    });
+    vi.mocked(projectCreatedManualShoppingItem).mockResolvedValue({
+      buyOnDate: null,
+      category: { id: "category-produce", name: "Frukt og gront" },
+      checked: false,
+      collaborationVersion: "2026-05-31T00:00:00.000Z",
+      name: "Bananer",
+      note: null,
+      overrideVersion: "",
+      preferredStore: null,
+      quantity: "2 kg",
+      quantityLabel: "2 kg",
+      section: { displayName: "Frukt og gront", sortOrder: 1 },
+      sourceKey: "manual-item-1",
+      sourceType: "MANUAL",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-manual-shopping-item-category");
+    formData.set("sourceKey", "manual-item-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("categoryId", "category-produce");
+    formData.set("name", "Bananer");
+    formData.set("note", "");
+    formData.set("preferredStoreId", "");
+    formData.set("quantity", "2 kg");
+    formData.set("buyOnDate", "");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(updateManualShoppingItem).toHaveBeenCalledWith({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      manualItemId: "manual-item-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+      values: {
+        buyOnDate: "",
+        categoryId: "category-produce",
+        name: "Bananer",
+        note: "",
+        preferredStoreId: "",
+        quantity: "2 kg",
+      },
+    });
+    expect(result).toEqual({
+      intent: "update-manual-shopping-item-category",
+      item: {
+        buyOnDate: null,
+        category: { id: "category-produce", name: "Frukt og gront" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        name: "Bananer",
+        note: null,
+        overrideVersion: "",
+        preferredStore: null,
+        quantity: "2 kg",
+        quantityLabel: "2 kg",
+        section: { displayName: "Frukt og gront", sortOrder: 1 },
+        sourceKey: "manual-item-1",
+        sourceType: "MANUAL",
+      },
       ok: true,
     });
   });

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -15,13 +15,18 @@ import {
 import { ManualShoppingQuickAdd } from "../components/manual-shopping-quick-add";
 import { ShoppingDateSelect } from "../components/shopping-list-item-expanded";
 import { StoreModeDeprioritizeBoughtToggle } from "../components/store-mode-deprioritize-bought-toggle";
-import { StoreModeShoppingItemCard } from "../components/store-mode-shopping-item-card";
+import {
+  StoreModeShoppingItemCard,
+  type StoreModeCategoryUpdateRequest,
+} from "../components/store-mode-shopping-item-card";
 import { StoreModeShoppingViewToggle } from "../components/store-mode-shopping-view-toggle";
 import { requireUser } from "../lib/auth.server";
 import {
   createQuickFamilyShoppingItem,
+  parseFamilyShoppingItemValues,
   parseQuickAddFamilyShoppingItemInput,
   toggleFamilyShoppingItemChecked,
+  updateFamilyShoppingItem,
   updateFamilyShoppingItemQuantity,
 } from "../lib/family-shopping-write.server";
 import {
@@ -38,6 +43,7 @@ import {
 import {
   insertProjectedItemIntoSectionGroups,
   prependRecentManualItem,
+  relocateProjectedItemInSectionGroups,
 } from "../lib/shopping-list-client";
 import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
 import { scrollToShoppingItem } from "../lib/shopping-quick-add-feedback.client";
@@ -45,12 +51,17 @@ import { serializeProjectedShoppingItem } from "../lib/shopping-serialize";
 import {
   getMealPlanStoreModeData,
   listRecentManualShoppingItemsForFamily,
+  projectCreatedFamilyShoppingItem,
+  projectCreatedManualShoppingItem,
   type RecentManualShoppingItem,
 } from "../lib/shopping.server";
 import {
+  parseManualShoppingItemValues,
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
+  updateManualShoppingItem,
 } from "../lib/shopping-write.server";
+import { listIngredientCategories } from "../lib/store.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
 import {
   getStoreModeBannerClass,
@@ -82,7 +93,9 @@ type StoreModeNotice =
 
 type StoreModeIntent =
   | "quick-add-family-shopping-item"
+  | "update-family-shopping-item-category"
   | "update-family-shopping-item-quantity"
+  | "update-manual-shopping-item-category"
   | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
   | "update-active-shopping-date"
@@ -93,6 +106,9 @@ interface StoreModeActionData {
     activeShoppingDate?: string;
   };
   activeShoppingDateValue?: string;
+  categoryFieldErrors?: {
+    categoryId?: string;
+  };
   formError?: string;
   intent?: StoreModeIntent;
   item?: QuickAddShoppingSuccess["item"];
@@ -135,7 +151,7 @@ export async function loader({
     params.mealPlanId,
     "Fant ikke ukeplanen.",
   );
-  const [result, recentManualItems] = await Promise.all([
+  const [result, recentManualItems, categories] = await Promise.all([
     getMealPlanStoreModeData({
       familyId,
       mealPlanId,
@@ -144,10 +160,12 @@ export async function loader({
     listRecentManualShoppingItemsForFamily({
       familyId,
     }),
+    listIngredientCategories(),
   ]);
 
   return {
     activeShoppingDate: formatDateOnly(result.activeShoppingDate),
+    categories,
     dueSectionGroups: result.dueSectionGroups.map((section) => ({
       ...section,
       items: section.items.map(serializeProjectedShoppingItem),
@@ -353,6 +371,123 @@ export async function action({
     } satisfies StoreModeActionData;
   }
 
+  if (intent === "update-family-shopping-item-category") {
+    const familyItemId = String(formData.get("sourceKey") ?? "").trim();
+
+    if (!familyItemId) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const result = await updateFamilyShoppingItem({
+      expectedUpdatedAt: String(formData.get("expectedUpdatedAt") ?? ""),
+      familyId,
+      familyItemId,
+      userId: user.id,
+      values: parseFamilyShoppingItemValues(formData),
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke varelinjen som skulle oppdateres.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        categoryFieldErrors: result.fieldErrors,
+        formError: result.fieldErrors.categoryId,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const item = await projectCreatedFamilyShoppingItem({
+      familyId,
+      familyItemId,
+    });
+
+    if (!item) {
+      return {
+        formError: "Fant ikke varelinjen etter oppdatering.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    return {
+      intent,
+      item: serializeProjectedShoppingItem(item),
+      ok: true,
+    } satisfies StoreModeActionData;
+  }
+
+  if (intent === "update-manual-shopping-item-category") {
+    const manualItemId = String(formData.get("sourceKey") ?? "").trim();
+
+    if (!manualItemId) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const result = await updateManualShoppingItem({
+      expectedUpdatedAt: String(formData.get("expectedUpdatedAt") ?? ""),
+      familyId,
+      manualItemId,
+      mealPlanId,
+      userId: user.id,
+      values: parseManualShoppingItemValues(formData),
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        categoryFieldErrors: result.fieldErrors,
+        formError: result.fieldErrors.categoryId,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const item = await projectCreatedManualShoppingItem({
+      familyId,
+      manualItemId,
+      mealPlanId,
+    });
+
+    if (!item) {
+      return {
+        formError: "Fant ikke varelinjen etter oppdatering.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    return {
+      intent,
+      item: serializeProjectedShoppingItem(item),
+      ok: true,
+    } satisfies StoreModeActionData;
+  }
+
   if (intent === "toggle-shopping-item-checked") {
     const sourceKey = String(formData.get("sourceKey") ?? "").trim();
     const sourceType = parseShoppingItemSource(formData.get("sourceType"));
@@ -407,6 +542,7 @@ export default function FamilyMealPlanStoreModeRoute({
   const scheduleRevalidate = useDebouncedRevalidate(revalidator.revalidate);
   const toggleFetcher = useFetcher<StoreModeActionData>();
   const quantityFetcher = useFetcher<StoreModeActionData>();
+  const categoryFetcher = useFetcher<StoreModeActionData>();
   const pendingIntent = navigation.formData?.get("intent");
   const [dueSectionGroups, setDueSectionGroups] = useState(
     loaderData.dueSectionGroups,
@@ -491,6 +627,79 @@ export default function FamilyMealPlanStoreModeRoute({
 
     scheduleRevalidate();
   }, [quantityFetcher.data, quantityFetcher.state, scheduleRevalidate]);
+
+  const handleUpdateCategory = useCallback(
+    (request: StoreModeCategoryUpdateRequest) => {
+      const formData = new FormData();
+      formData.set(
+        "intent",
+        request.sourceType === "FAMILY"
+          ? "update-family-shopping-item-category"
+          : "update-manual-shopping-item-category",
+      );
+      formData.set("sourceKey", request.sourceKey);
+      formData.set("expectedUpdatedAt", request.expectedUpdatedAt);
+      formData.set("categoryId", request.categoryId);
+      formData.set("name", request.name);
+      formData.set("note", request.note);
+      formData.set("preferredStoreId", request.preferredStoreId);
+      formData.set("quantity", request.quantity);
+
+      if (request.sourceType === "MANUAL") {
+        formData.set("buyOnDate", request.buyOnDate);
+      }
+
+      categoryFetcher.submit(formData, { method: "post" });
+    },
+    [categoryFetcher],
+  );
+
+  useEffect(() => {
+    if (categoryFetcher.state !== "idle") {
+      return;
+    }
+
+    const data = categoryFetcher.data;
+
+    if (
+      data?.intent !== "update-family-shopping-item-category" &&
+      data?.intent !== "update-manual-shopping-item-category"
+    ) {
+      return;
+    }
+
+    if (!data.ok) {
+      return;
+    }
+
+    const updatedItem = data.item;
+
+    if (!updatedItem) {
+      return;
+    }
+
+    setDueSectionGroups((currentSections) =>
+      relocateProjectedItemInSectionGroups(
+        currentSections,
+        updatedItem.sourceKey,
+        updatedItem,
+      ),
+    );
+    setRecentlyAddedSourceKey(updatedItem.sourceKey);
+    scheduleRevalidate();
+  }, [categoryFetcher.data, categoryFetcher.state, scheduleRevalidate]);
+
+  const categoryInteractionSourceKey = categoryFetcher.formData
+    ? String(categoryFetcher.formData.get("sourceKey") ?? "")
+    : "";
+  const isSavingCategorySourceKey =
+    categoryFetcher.state !== "idle" ? categoryInteractionSourceKey : null;
+  const categoryFetcherError =
+    categoryFetcher.data?.formError &&
+    (categoryFetcher.data.intent === "update-family-shopping-item-category" ||
+      categoryFetcher.data.intent === "update-manual-shopping-item-category")
+      ? categoryFetcher.data.formError
+      : null;
 
   useEffect(() => {
     if (!recentlyAddedSourceKey) {
@@ -612,10 +821,11 @@ export default function FamilyMealPlanStoreModeRoute({
       : loaderData.activeShoppingDate;
   const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
   const generalFormError =
-    actionData?.formError &&
+    categoryFetcherError ??
+    (actionData?.formError &&
     actionData.intent !== "quick-add-family-shopping-item"
       ? actionData.formError
-      : undefined;
+      : undefined);
 
   return (
     <main className={storeModePageClass}>
@@ -776,9 +986,14 @@ export default function FamilyMealPlanStoreModeRoute({
                   </div>
 
                   <StoreModeItemGrid
+                    categories={loaderData.categories}
+                    categoryFetcherError={categoryFetcherError}
+                    categoryInteractionSourceKey={categoryInteractionSourceKey}
+                    isSavingCategorySourceKey={isSavingCategorySourceKey}
                     items={section.items}
                     layout={shoppingView}
                     onQuickAddFromCard={handleQuickAddFromCard}
+                    onUpdateCategory={handleUpdateCategory}
                     onUpdateQuantity={handleUpdateQuantity}
                     onToggleItem={handleToggle}
                     recentlyAddedSourceKey={recentlyAddedSourceKey}
@@ -809,9 +1024,14 @@ export default function FamilyMealPlanStoreModeRoute({
                 </summary>
 
                 <StoreModeItemGrid
+                  categories={loaderData.categories}
+                  categoryFetcherError={categoryFetcherError}
+                  categoryInteractionSourceKey={categoryInteractionSourceKey}
+                  isSavingCategorySourceKey={isSavingCategorySourceKey}
                   items={boughtItems}
                   layout={shoppingView}
                   onQuickAddFromCard={handleQuickAddFromCard}
+                  onUpdateCategory={handleUpdateCategory}
                   onUpdateQuantity={handleUpdateQuantity}
                   onToggleItem={handleToggle}
                   recentlyAddedSourceKey={recentlyAddedSourceKey}
@@ -975,17 +1195,27 @@ function buildStoreModeRedirect({
 function StoreModeItemGrid<
   TItem extends ComponentProps<typeof StoreModeShoppingItemCard>["item"],
 >({
+  categories,
+  categoryFetcherError,
+  categoryInteractionSourceKey,
+  isSavingCategorySourceKey,
   items,
   layout,
   onQuickAddFromCard,
+  onUpdateCategory,
   onUpdateQuantity,
   onToggleItem,
   recentlyAddedSourceKey,
   selectedStoreId,
 }: {
+  categories: ComponentProps<typeof StoreModeShoppingItemCard>["categories"];
+  categoryFetcherError: string | null;
+  categoryInteractionSourceKey: string;
+  isSavingCategorySourceKey: string | null;
   items: TItem[];
   layout: StoreModeShoppingView;
   onQuickAddFromCard: (item: { name: string; quantityLabel: string | null }) => void;
+  onUpdateCategory: (request: StoreModeCategoryUpdateRequest) => void;
   onUpdateQuantity: (item: {
     expectedUpdatedAt: string;
     quantity: string;
@@ -1006,10 +1236,18 @@ function StoreModeItemGrid<
       {items.map((item) => (
         <StoreModeShoppingItemCard
           key={item.sourceKey}
+          categories={categories}
+          categoryError={
+            categoryInteractionSourceKey === item.sourceKey
+              ? categoryFetcherError
+              : null
+          }
           isRecentlyAdded={recentlyAddedSourceKey === item.sourceKey}
+          isSavingCategory={isSavingCategorySourceKey === item.sourceKey}
           item={item}
           layout={layout}
           onQuickAddFromCard={onQuickAddFromCard}
+          onUpdateCategory={onUpdateCategory}
           onUpdateQuantity={onUpdateQuantity}
           onToggle={() => onToggleItem(item)}
           selectedStoreId={selectedStoreId}


### PR DESCRIPTION
## Summary
- Add an in-card category dropdown for FAMILY and MANUAL items in store mode; saving happens on selection change and the item moves to the correct section without leaving the page.
- Wire store-mode actions that reuse existing family/manual update logic and optimistic section regrouping on the client.

## Related issue
Closes #143

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Quick-add a free-text item in store mode (often Annet) → open info panel → pick another section → confirm the card moves
- [ ] Repeat for a meal-plan MANUAL item if present in the list
- [ ] Check grid and list layouts on a narrow viewport; confirm the details panel is ~50% card width when open

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck