### PR TITLE
Keep one Fly machine always running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,7 +19,7 @@ primary_region = 'arn'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
 [[vm]]
   memory = '1gb'


### PR DESCRIPTION
## Summary
- Set `min_machines_running = 1` in `fly.toml` so Fly keeps one machine running in the primary region (`arn`)
- Autostop/autostart remains enabled — excess machines still scale down when idle, but the app avoids cold starts from scaling to zero

## Test plan
- [ ] Deploy and verify `fly.toml` config is applied (`fly deploy`)
- [ ] Confirm one machine stays running in `arn` after idle period
- [ ] Confirm additional machines still autostop when traffic is low