### PR TITLE
Integrate Kassalapp API with per-family token management

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,33 +2,36 @@
 
 ## Current Objective
 
-Issue #148 — PR ready on `issue/148-family-store-mode-url`: store mode uses a stable family-scoped URL and category sections collapse/expand as accordions.
+Issue #150 — PR ready on `issue/150-kassal-api-integration`: Kassalapp API integration with per-family encrypted tokens and admin UI for key management.
 
 ## Completed
 
-- Made `/families/:familyId/store-mode` the canonical route; legacy meal-plan URLs redirect there.
-- Added `resolveStoreModeAnchorMealPlan` and `getFamilyStoreModeData` for server-side anchor resolution.
-- Updated in-app links and mobile nav active state for the family URL.
-- Converted store-mode category sections to `<details>` accordions (open by default).
+- Added Kassalapp server modules: typed API client, per-family rate limiting, search/match/cache, and `estimateShoppingListCost`.
+- Stored API tokens per family in `FamilyKassalappIntegration` with AES-256-GCM encryption derived from `SESSION_SECRET`.
+- Added admin route `/families/:familyId/kassalapp` to save, update, and remove tokens (members see status only).
+- Removed global `KASSALAPP_API_TOKEN` env var approach; tokens are database-only.
+- Exposed `getStoreModeCostEstimate({ familyId, items })` for #151 UI wiring.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx` — canonical route, accordion sections, action redirects
-- `app/routes/family-meal-plan-store-mode-redirect.ts` — legacy URL redirect
-- `app/lib/meal-plan-for-date.server.ts` — `resolveStoreModeAnchorMealPlan`
-- `app/lib/shopping.server.ts` — `getFamilyStoreModeData`
+- `app/lib/kassalapp-cost.server.ts` — cost estimation orchestration
+- `app/lib/kassalapp-integration.server.ts` — per-family token lookup
+- `app/routes/family-kassalapp.tsx` — admin UI for API key management
+- `prisma/schema.prisma` — `FamilyKassalappIntegration` model
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (52 files, 317 tests)
+- `npm run test:run` — passed (60 files, 340 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual QA: bookmark `/families/:id/store-mode`, confirm stability after adding meal plans; open legacy meal-plan store-mode URL and confirm redirect; toggle category accordions while shopping.
+- Manual QA: as family admin, save a real Kassalapp token at `/families/:familyId/kassalapp`; verify another family without a token gets unavailable cost estimates.
+- #151: wire cost overview UI in store mode (collapsed details panel).
+- Remove `KASSALAPP_API_TOKEN` from local `.env` if still present (no longer used).
 
 ## Next Step
 
-Merge PR; issue closes via `Closes #148`.
+Merge PR; issue closes via `Closes #150`. Pick up #151 for store mode price UI.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ DATABASE_URL="postgresql://mealplanner:mealplanner@localhost:5466/mealplanner?sc
 SESSION_SECRET="replace-this-with-a-long-random-string-of-at-least-32-characters"
 ```
 
-`SESSION_SECRET` must be at least 32 characters and is used to sign the login session cookie.
+`SESSION_SECRET` must be at least 32 characters and is used to sign the login session cookie. It is also used to encrypt per-family Kassalapp API tokens stored in the database.
 
-If any variable is missing or invalid, the server fails fast during startup instead of waiting until the first database access.
+Kassalapp price estimation is opt-in per family: a family administrator adds their API key at `/families/:familyId/kassalapp`.
+
+If any required variable is missing or invalid, the server fails fast during startup instead of waiting until the first database access.
 
 ## Authentication
 

--- a/app/components/app-top-nav.test.tsx
+++ b/app/components/app-top-nav.test.tsx
@@ -28,6 +28,10 @@ describe("AppTopNav", () => {
       "href",
       "/families/family-1/stores",
     );
+    expect(screen.getByRole("link", { name: "Kassalapp" })).toHaveAttribute(
+      "href",
+      "/families/family-1/kassalapp",
+    );
     expect(screen.getByRole("link", { name: "Oppskrifter" })).toHaveAttribute(
       "href",
       "/families/family-1/recipes",

--- a/app/components/app-top-nav.tsx
+++ b/app/components/app-top-nav.tsx
@@ -30,6 +30,7 @@ function buildFamilyNavItems(
       to: `/families/${familyId}/store-mode`,
     },
     { end: true, label: "Butikker", to: `/families/${familyId}/stores` },
+    { end: true, label: "Kassalapp", to: `/families/${familyId}/kassalapp` },
     { end: false, label: "Oppskrifter", to: `/families/${familyId}/recipes` },
     {
       end: true,

--- a/app/lib/kassalapp-cache.server.ts
+++ b/app/lib/kassalapp-cache.server.ts
@@ -1,0 +1,68 @@
+const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000;
+
+interface CacheEntry<Value> {
+  expiresAt: number;
+  value: Value;
+}
+
+const searchCache = new Map<string, CacheEntry<unknown>>();
+const bulkCache = new Map<string, CacheEntry<unknown>>();
+
+function readCacheEntry<Value>(
+  cache: Map<string, CacheEntry<unknown>>,
+  key: string,
+): Value | undefined {
+  const entry = cache.get(key);
+
+  if (!entry) {
+    return undefined;
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return undefined;
+  }
+
+  return entry.value as Value;
+}
+
+function writeCacheEntry<Value>(
+  cache: Map<string, CacheEntry<unknown>>,
+  key: string,
+  value: Value,
+  ttlMs = DEFAULT_CACHE_TTL_MS,
+) {
+  cache.set(key, {
+    expiresAt: Date.now() + ttlMs,
+    value,
+  });
+}
+
+export function getCachedSearchResult<T>(searchTerm: string) {
+  return readCacheEntry<T>(searchCache, `search:${searchTerm}`);
+}
+
+export function setCachedSearchResult<T>(
+  searchTerm: string,
+  value: T,
+  ttlMs?: number,
+) {
+  writeCacheEntry(searchCache, `search:${searchTerm}`, value, ttlMs);
+}
+
+export function getCachedBulkPriceResult<T>(ean: string) {
+  return readCacheEntry<T>(bulkCache, `bulk:${ean}`);
+}
+
+export function setCachedBulkPriceResult<T>(
+  ean: string,
+  value: T,
+  ttlMs?: number,
+) {
+  writeCacheEntry(bulkCache, `bulk:${ean}`, value, ttlMs);
+}
+
+export function resetKassalappCacheForTests() {
+  searchCache.clear();
+  bulkCache.clear();
+}

--- a/app/lib/kassalapp-cost.server.test.ts
+++ b/app/lib/kassalapp-cost.server.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetKassalappCacheForTests } from "./kassalapp-cache.server";
+import { estimateShoppingListCost } from "./kassalapp-cost.server";
+import { resetKassalappRateLimiterForTests } from "./kassalapp-rate-limit.server";
+import type {
+  KassalappBulkPriceResponse,
+  KassalappProductSearchResponse,
+} from "./kassalapp.types";
+import type { ProjectedFamilyShoppingItem } from "./shopping.server";
+
+const getFamilyKassalappApiTokenMock = vi.fn();
+const isKassalappConfiguredForFamilyMock = vi.fn();
+
+vi.mock("./kassalapp-integration.server", () => ({
+  getFamilyKassalappApiToken: (...args: unknown[]) =>
+    getFamilyKassalappApiTokenMock(...args),
+  isKassalappConfiguredForFamily: (...args: unknown[]) =>
+    isKassalappConfiguredForFamilyMock(...args),
+}));
+
+function createFamilyItem(
+  overrides: Partial<ProjectedFamilyShoppingItem> = {},
+): ProjectedFamilyShoppingItem {
+  return {
+    category: { id: "category-1", name: "Meieri" },
+    checked: false,
+    collaborationVersion: "2026-01-01T00:00:00.000Z",
+    mealPlanId: null,
+    mealPlanTitle: null,
+    name: "Melk",
+    note: null,
+    preferredStore: null,
+    quantity: null,
+    quantityLabel: null,
+    section: {
+      displayName: "Meieri",
+      sortOrder: 0,
+    },
+    sourceKey: "family:item-1",
+    sourceType: "FAMILY",
+    ...overrides,
+  };
+}
+
+describe("kassalapp-cost.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetKassalappCacheForTests();
+    resetKassalappRateLimiterForTests();
+    isKassalappConfiguredForFamilyMock.mockResolvedValue(true);
+    getFamilyKassalappApiTokenMock.mockResolvedValue("test-token");
+  });
+
+  afterEach(() => {
+    resetKassalappCacheForTests();
+    resetKassalappRateLimiterForTests();
+  });
+
+  it("returns unavailable when the family has no integration", async () => {
+    isKassalappConfiguredForFamilyMock.mockResolvedValue(false);
+
+    await expect(
+      estimateShoppingListCost({
+        familyId: "family-1",
+        items: [createFamilyItem()],
+      }),
+    ).resolves.toEqual({
+      reason: "Kassalapp er ikke koblet til for denne familien.",
+      status: "unavailable",
+    });
+  });
+
+  it("aggregates per-store totals from search and bulk price lookups", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes("/products/prices-bulk")) {
+        const body = {
+          data: [
+            {
+              ean: "7039010019811",
+              name: "Tine Helmelk 1 liter",
+              price_history: [],
+              stores: [
+                {
+                  current_price: 24.9,
+                  current_unit_price: null,
+                  current_unit_price_unit: null,
+                  last_checked: null,
+                  name: "Kiwi",
+                  store: "KIWI",
+                },
+                {
+                  current_price: 22.5,
+                  current_unit_price: null,
+                  current_unit_price_unit: null,
+                  last_checked: null,
+                  name: "Rema 1000",
+                  store: "REMA_1000",
+                },
+              ],
+              weight: 1,
+              weight_unit: "l",
+            },
+          ],
+          meta: {
+            days_included: 1,
+            found_products: 1,
+            is_premium: false,
+            requested_eans: 1,
+          },
+        } satisfies KassalappBulkPriceResponse;
+
+        return new Response(JSON.stringify(body), { status: 200 });
+      }
+
+      const body = {
+        data: [
+          {
+            brand: "Tine",
+            current_price: 24.9,
+            current_unit_price: null,
+            ean: "7039010019811",
+            id: 1,
+            name: "Tine Helmelk 1 liter",
+            store: [{ code: "KIWI", logo: "", name: "Kiwi", url: "" }],
+            vendor: null,
+          },
+        ],
+      } satisfies KassalappProductSearchResponse;
+
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+
+    const result = await estimateShoppingListCost({
+      familyId: "family-1",
+      fetchImpl,
+      items: [
+        createFamilyItem({ name: "2 dl melk", sourceKey: "family:1" }),
+        createFamilyItem({ name: "Melk", sourceKey: "family:2" }),
+        createFamilyItem({
+          checked: true,
+          name: "Melk",
+          sourceKey: "family:3",
+        }),
+      ],
+      storeCodes: ["KIWI", "REMA_1000"],
+    });
+
+    expect(result).toMatchObject({
+      status: "ok",
+      meta: {
+        bulkCalls: 1,
+        searchCalls: 1,
+      },
+      stores: [
+        {
+          code: "KIWI",
+          matchedCount: 2,
+          total: 49.8,
+          unmatchedCount: 0,
+        },
+        {
+          code: "REMA_1000",
+          matchedCount: 2,
+          total: 45,
+          unmatchedCount: 0,
+        },
+      ],
+      unmatchedItems: [],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(getFamilyKassalappApiTokenMock).toHaveBeenCalledWith("family-1");
+  });
+
+  it("dedupes search calls and uses cache for repeated terms", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              brand: null,
+              current_price: 10,
+              current_unit_price: null,
+              ean: null,
+              id: 2,
+              name: "Bananas",
+              store: [],
+              vendor: null,
+            },
+          ],
+        } satisfies KassalappProductSearchResponse),
+        { status: 200 },
+      ),
+    );
+
+    await estimateShoppingListCost({
+      familyId: "family-1",
+      fetchImpl,
+      items: [
+        createFamilyItem({ name: "Banan", sourceKey: "family:1" }),
+        createFamilyItem({ name: "banan", sourceKey: "family:2" }),
+      ],
+      storeCodes: ["KIWI"],
+    });
+
+    await estimateShoppingListCost({
+      familyId: "family-1",
+      fetchImpl,
+      items: [createFamilyItem({ name: "Banan", sourceKey: "family:3" })],
+      storeCodes: ["KIWI"],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/lib/kassalapp-cost.server.ts
+++ b/app/lib/kassalapp-cost.server.ts
@@ -1,0 +1,320 @@
+import {
+  getFamilyKassalappApiToken,
+  isKassalappConfiguredForFamily,
+} from "./kassalapp-integration.server";
+import {
+  getCachedBulkPriceResult,
+  getCachedSearchResult,
+  setCachedBulkPriceResult,
+  setCachedSearchResult,
+} from "./kassalapp-cache.server";
+import { pickBestProductMatch } from "./kassalapp-match.server";
+import {
+  dedupeShoppingSearchTerms,
+  getUncheckedShoppingItems,
+  normalizeShoppingSearchTerm,
+} from "./kassalapp-search.server";
+import { getKassalappBulkPrices, searchKassalappProducts } from "./kassalapp.server";
+import {
+  DEFAULT_KASSALAPP_STORE_CODES,
+  isKassalappStoreCode,
+  KASSALAPP_STORE_DISPLAY_NAMES,
+} from "./kassalapp-stores.server";
+import type {
+  KassalappBulkPriceHistoryItem,
+  KassalappProduct,
+  KassalappStoreCode,
+  ShoppingListCostEstimate,
+} from "./kassalapp.types";
+import type { ProjectedShoppingItem } from "./shopping.server";
+
+const BULK_EAN_BATCH_SIZE = 100;
+
+interface MatchedSearchTerm {
+  ean: string | null;
+  product: KassalappProduct | null;
+  searchTerm: string;
+}
+
+interface TermPriceLookup {
+  ean: string | null;
+  pricesByStore: Partial<Record<KassalappStoreCode, number>>;
+  product: KassalappProduct | null;
+  searchTerm: string;
+}
+
+export async function estimateShoppingListCost({
+  familyId,
+  fetchImpl,
+  items,
+  storeCodes = DEFAULT_KASSALAPP_STORE_CODES,
+}: {
+  familyId: string;
+  fetchImpl?: typeof fetch;
+  items: ProjectedShoppingItem[];
+  storeCodes?: readonly KassalappStoreCode[];
+}): Promise<ShoppingListCostEstimate> {
+  if (!(await isKassalappConfiguredForFamily(familyId))) {
+    return {
+      reason: "Kassalapp er ikke koblet til for denne familien.",
+      status: "unavailable",
+    };
+  }
+
+  const apiToken = await getFamilyKassalappApiToken(familyId);
+
+  if (!apiToken) {
+    return {
+      reason: "Kassalapp er ikke koblet til for denne familien.",
+      status: "unavailable",
+    };
+  }
+
+  const uncheckedItems = getUncheckedShoppingItems(items);
+  const groupedTerms = dedupeShoppingSearchTerms(uncheckedItems);
+  const meta = {
+    bulkCalls: 0,
+    cachedHits: 0,
+    searchCalls: 0,
+  };
+
+  const matchedTerms = new Map<string, MatchedSearchTerm>();
+
+  for (const searchTerm of groupedTerms.keys()) {
+    const cachedProduct = getCachedSearchResult<KassalappProduct | null>(searchTerm);
+
+    if (cachedProduct !== undefined) {
+      meta.cachedHits += 1;
+      matchedTerms.set(searchTerm, {
+        ean: cachedProduct?.ean ?? null,
+        product: cachedProduct,
+        searchTerm,
+      });
+      continue;
+    }
+
+    const response = await searchKassalappProducts({
+      apiToken,
+      fetchImpl,
+      rateLimitKey: familyId,
+      search: searchTerm,
+    });
+    meta.searchCalls += 1;
+
+    const product = pickBestProductMatch(searchTerm, response.data);
+    setCachedSearchResult(searchTerm, product);
+
+    matchedTerms.set(searchTerm, {
+      ean: product?.ean ?? null,
+      product,
+      searchTerm,
+    });
+  }
+
+  const eansToLookup = [
+    ...new Set(
+      [...matchedTerms.values()]
+        .map((match) => match.ean)
+        .filter((ean): ean is string => Boolean(ean)),
+    ),
+  ];
+
+  const bulkPricesByEan = await loadBulkPricesByEan({
+    apiToken,
+    eans: eansToLookup,
+    familyId,
+    fetchImpl,
+    meta,
+    storeCodes,
+  });
+
+  const termLookups = new Map<string, TermPriceLookup>();
+
+  for (const [searchTerm, match] of matchedTerms.entries()) {
+    termLookups.set(searchTerm, {
+      ean: match.ean,
+      pricesByStore: match.ean
+        ? (bulkPricesByEan.get(match.ean) ?? {})
+        : extractPricesFromProduct(match.product, storeCodes),
+      product: match.product,
+      searchTerm,
+    });
+  }
+
+  const storeTotals = initializeStoreTotals(storeCodes);
+  const unmatchedItems: Array<{ name: string; sourceKey: string }> = [];
+  const itemMatches: Array<{
+    ean: string | null;
+    pricesByStore: Partial<Record<KassalappStoreCode, number>>;
+    searchTerm: string;
+    sourceKey: string;
+  }> = [];
+
+  for (const item of uncheckedItems) {
+    const searchTerm = normalizeShoppingSearchTerm(item.name, item.quantityLabel);
+    const lookup = searchTerm ? termLookups.get(searchTerm) : undefined;
+
+    if (!searchTerm || !lookup?.product) {
+      unmatchedItems.push({
+        name: item.name,
+        sourceKey: item.sourceKey,
+      });
+
+      for (const storeTotal of storeTotals) {
+        storeTotal.unmatchedCount += 1;
+      }
+
+      continue;
+    }
+
+    itemMatches.push({
+      ean: lookup.ean,
+      pricesByStore: lookup.pricesByStore,
+      searchTerm,
+      sourceKey: item.sourceKey,
+    });
+
+    for (const storeTotal of storeTotals) {
+      const price = lookup.pricesByStore[storeTotal.code];
+
+      if (price === undefined) {
+        storeTotal.unmatchedCount += 1;
+        continue;
+      }
+
+      storeTotal.matchedCount += 1;
+      storeTotal.total += price;
+    }
+  }
+
+  return {
+    itemMatches,
+    meta,
+    status: "ok",
+    stores: storeTotals.map((storeTotal) => ({
+      ...storeTotal,
+      total: roundCurrency(storeTotal.total),
+    })),
+    unmatchedItems,
+  };
+}
+
+async function loadBulkPricesByEan({
+  apiToken,
+  eans,
+  familyId,
+  fetchImpl,
+  meta,
+  storeCodes,
+}: {
+  apiToken: string;
+  eans: string[];
+  familyId: string;
+  fetchImpl?: typeof fetch;
+  meta: { bulkCalls: number; cachedHits: number };
+  storeCodes: readonly KassalappStoreCode[];
+}) {
+  const bulkPricesByEan = new Map<string, Partial<Record<KassalappStoreCode, number>>>();
+  const uncachedEans: string[] = [];
+
+  for (const ean of eans) {
+    const cached = getCachedBulkPriceResult<
+      Partial<Record<KassalappStoreCode, number>>
+    >(ean);
+
+    if (cached) {
+      meta.cachedHits += 1;
+      bulkPricesByEan.set(ean, cached);
+      continue;
+    }
+
+    uncachedEans.push(ean);
+  }
+
+  for (let index = 0; index < uncachedEans.length; index += BULK_EAN_BATCH_SIZE) {
+    const batch = uncachedEans.slice(index, index + BULK_EAN_BATCH_SIZE);
+    const response = await getKassalappBulkPrices({
+      apiToken,
+      eans: batch,
+      fetchImpl,
+      rateLimitKey: familyId,
+    });
+    meta.bulkCalls += 1;
+
+    const itemsByEan = new Map(
+      response.data.map((item) => [item.ean, item] as const),
+    );
+
+    for (const ean of batch) {
+      const item = itemsByEan.get(ean);
+      const prices = item
+        ? extractPricesFromBulkItem(item, storeCodes)
+        : {};
+      setCachedBulkPriceResult(ean, prices);
+      bulkPricesByEan.set(ean, prices);
+    }
+  }
+
+  return bulkPricesByEan;
+}
+
+function extractPricesFromBulkItem(
+  item: KassalappBulkPriceHistoryItem,
+  storeCodes: readonly KassalappStoreCode[],
+) {
+  const allowedStoreCodes = new Set(storeCodes);
+  const prices: Partial<Record<KassalappStoreCode, number>> = {};
+
+  for (const storePrice of item.stores) {
+    if (
+      !isKassalappStoreCode(storePrice.store) ||
+      !allowedStoreCodes.has(storePrice.store) ||
+      storePrice.current_price === null
+    ) {
+      continue;
+    }
+
+    prices[storePrice.store] = storePrice.current_price;
+  }
+
+  return prices;
+}
+
+function extractPricesFromProduct(
+  product: KassalappProduct | null,
+  storeCodes: readonly KassalappStoreCode[],
+) {
+  if (!product || product.current_price === null) {
+    return {};
+  }
+
+  const allowedStoreCodes = new Set(storeCodes);
+  const prices: Partial<Record<KassalappStoreCode, number>> = {};
+
+  for (const store of product.store) {
+    if (
+      !isKassalappStoreCode(store.code) ||
+      !allowedStoreCodes.has(store.code)
+    ) {
+      continue;
+    }
+
+    prices[store.code] = product.current_price;
+  }
+
+  return prices;
+}
+
+function initializeStoreTotals(storeCodes: readonly KassalappStoreCode[]) {
+  return storeCodes.map((code) => ({
+    code,
+    matchedCount: 0,
+    name: KASSALAPP_STORE_DISPLAY_NAMES[code],
+    total: 0,
+    unmatchedCount: 0,
+  }));
+}
+
+function roundCurrency(value: number) {
+  return Math.round(value * 100) / 100;
+}

--- a/app/lib/kassalapp-integration-write.server.test.ts
+++ b/app/lib/kassalapp-integration-write.server.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyAdminMock } = vi.hoisted(() => ({
+  dbMock: {
+    familyKassalappIntegration: {
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+  requireFamilyAdminMock: vi.fn(),
+}));
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyAdmin: requireFamilyAdminMock,
+}));
+
+import {
+  removeFamilyKassalappApiToken,
+  saveFamilyKassalappApiToken,
+} from "./kassalapp-integration-write.server";
+
+describe("kassalapp-integration-write.server", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates empty api tokens", async () => {
+    const result = await saveFamilyKassalappApiToken({
+      apiToken: "   ",
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      fieldErrors: {
+        apiToken: "Lim inn en Kassalapp API-nøkkel.",
+      },
+      status: "VALIDATION_ERROR",
+    });
+    expect(requireFamilyAdminMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+  });
+
+  it("stores encrypted api tokens for admins", async () => {
+    dbMock.familyKassalappIntegration.upsert.mockResolvedValue({});
+
+    const result = await saveFamilyKassalappApiToken({
+      apiToken: "family-token-12345678",
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(dbMock.familyKassalappIntegration.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          familyId: "family-1",
+          tokenLastFour: "5678",
+          updatedByUserId: "user-1",
+        }),
+        update: expect.objectContaining({
+          tokenLastFour: "5678",
+          updatedByUserId: "user-1",
+        }),
+        where: {
+          familyId: "family-1",
+        },
+      }),
+    );
+    expect(
+      dbMock.familyKassalappIntegration.upsert.mock.calls[0]?.[0].create
+        .encryptedApiToken,
+    ).not.toBe("family-token-12345678");
+  });
+
+  it("removes stored api tokens", async () => {
+    dbMock.familyKassalappIntegration.deleteMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      removeFamilyKassalappApiToken({
+        familyId: "family-1",
+        userId: "user-1",
+      }),
+    ).resolves.toEqual({ status: "REMOVED" });
+  });
+});

--- a/app/lib/kassalapp-integration-write.server.ts
+++ b/app/lib/kassalapp-integration-write.server.ts
@@ -1,0 +1,91 @@
+import { db } from "./db.server";
+import { requireFamilyAdmin } from "./family.server";
+import { encryptSecret } from "./secret-encryption.server";
+
+export async function saveFamilyKassalappApiToken({
+  apiToken,
+  familyId,
+  userId,
+}: {
+  apiToken: string;
+  familyId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const normalizedToken = apiToken.trim();
+
+  if (!normalizedToken) {
+    return {
+      fieldErrors: {
+        apiToken: "Lim inn en Kassalapp API-nøkkel.",
+      },
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  if (normalizedToken.length < 8) {
+    return {
+      fieldErrors: {
+        apiToken: "API-nøkkelen ser ut til å være for kort.",
+      },
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  const encryptedApiToken = encryptSecret(normalizedToken);
+  const tokenLastFour = normalizedToken.slice(-4);
+
+  await db.familyKassalappIntegration.upsert({
+    create: {
+      encryptedApiToken,
+      familyId,
+      tokenLastFour,
+      updatedByUserId: userId,
+    },
+    update: {
+      encryptedApiToken,
+      tokenLastFour,
+      updatedByUserId: userId,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+export async function removeFamilyKassalappApiToken({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const result = await db.familyKassalappIntegration.deleteMany({
+    where: {
+      familyId,
+    },
+  });
+
+  if (result.count === 0) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  return {
+    status: "REMOVED" as const,
+  };
+}

--- a/app/lib/kassalapp-integration.server.ts
+++ b/app/lib/kassalapp-integration.server.ts
@@ -1,0 +1,74 @@
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { decryptSecret } from "./secret-encryption.server";
+
+export async function getFamilyKassalappIntegrationData({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const integration = await db.familyKassalappIntegration.findUnique({
+    select: {
+      tokenLastFour: true,
+      updatedAt: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    integration:
+      integration === null
+        ? {
+            isConfigured: false as const,
+          }
+        : {
+            isConfigured: true as const,
+            tokenLastFour: integration.tokenLastFour,
+            updatedAt: integration.updatedAt.toISOString(),
+          },
+    userRole: membership.role,
+  };
+}
+
+export async function isKassalappConfiguredForFamily(familyId: string) {
+  const integration = await db.familyKassalappIntegration.findUnique({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  return integration !== null;
+}
+
+export async function getFamilyKassalappApiToken(familyId: string) {
+  const integration = await db.familyKassalappIntegration.findUnique({
+    select: {
+      encryptedApiToken: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  if (!integration) {
+    return null;
+  }
+
+  return decryptSecret(integration.encryptedApiToken);
+}

--- a/app/lib/kassalapp-match.server.test.ts
+++ b/app/lib/kassalapp-match.server.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { pickBestProductMatch } from "./kassalapp-match.server";
+import type { KassalappProduct } from "./kassalapp.types";
+
+function createProduct(
+  overrides: Partial<KassalappProduct> = {},
+): KassalappProduct {
+  return {
+    brand: null,
+    current_price: 20,
+    current_unit_price: null,
+    ean: "7039010019811",
+    id: 1,
+    name: "Tine Helmelk 1 liter",
+    store: [],
+    vendor: null,
+    ...overrides,
+  };
+}
+
+describe("kassalapp-match.server", () => {
+  it("prefers exact name matches with EAN and price", () => {
+    const match = pickBestProductMatch("tine helmelk 1 liter", [
+      createProduct({ ean: null, name: "Tine Lettmelk 1 liter" }),
+      createProduct({ name: "Tine Helmelk 1 liter" }),
+    ]);
+
+    expect(match?.name).toBe("Tine Helmelk 1 liter");
+  });
+
+  it("returns null when no result contains the search term", () => {
+    expect(
+      pickBestProductMatch("appelsin", [
+        createProduct({ name: "Grandiosa Pizza" }),
+      ]),
+    ).toBeNull();
+  });
+});

--- a/app/lib/kassalapp-match.server.ts
+++ b/app/lib/kassalapp-match.server.ts
@@ -1,0 +1,62 @@
+import type { KassalappProduct } from "./kassalapp.types";
+
+function normalizeProductName(name: string) {
+  return name.trim().toLowerCase();
+}
+
+function scoreProductMatch(searchTerm: string, product: KassalappProduct) {
+  const normalizedProductName = normalizeProductName(product.name);
+  let score = 0;
+
+  if (normalizedProductName === searchTerm) {
+    score += 100;
+  } else if (normalizedProductName.startsWith(searchTerm)) {
+    score += 60;
+  } else if (normalizedProductName.includes(searchTerm)) {
+    score += 30;
+  } else {
+    return null;
+  }
+
+  if (product.ean) {
+    score += 10;
+  }
+
+  if (product.current_price !== null) {
+    score += 5;
+  }
+
+  return score;
+}
+
+export function pickBestProductMatch(
+  searchTerm: string,
+  results: KassalappProduct[],
+) {
+  let bestProduct: KassalappProduct | null = null;
+  let bestScore = -1;
+
+  for (const product of results) {
+    const score = scoreProductMatch(searchTerm, product);
+
+    if (score === null || score < bestScore) {
+      continue;
+    }
+
+    if (score > bestScore) {
+      bestProduct = product;
+      bestScore = score;
+      continue;
+    }
+
+    if (
+      score === bestScore &&
+      bestProduct &&
+      product.name.localeCompare(bestProduct.name, "nb") < 0
+    ) {
+      bestProduct = product;
+    }
+  }
+
+  return bestProduct;
+}

--- a/app/lib/kassalapp-rate-limit.server.test.ts
+++ b/app/lib/kassalapp-rate-limit.server.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getKassalappRateLimiterStats,
+  kassalappRateLimitConfig,
+  resetKassalappRateLimiterForTests,
+  scheduleKassalappRequest,
+} from "./kassalapp-rate-limit.server";
+import { KassalappApiError } from "./kassalapp.types";
+
+const TEST_RATE_LIMIT_KEY = "test-family";
+
+describe("kassalapp-rate-limit.server", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    resetKassalappRateLimiterForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetKassalappRateLimiterForTests();
+  });
+
+  it("allows up to 60 calls inside the window", async () => {
+    let callCount = 0;
+
+    await Promise.all(
+      Array.from({ length: kassalappRateLimitConfig.maxCalls }, () =>
+        scheduleKassalappRequest({
+          rateLimitKey: TEST_RATE_LIMIT_KEY,
+          request: async () => {
+            callCount += 1;
+          },
+        }),
+      ),
+    );
+
+    expect(callCount).toBe(kassalappRateLimitConfig.maxCalls);
+    expect(getKassalappRateLimiterStats(TEST_RATE_LIMIT_KEY).activeCallsInWindow).toBe(
+      kassalappRateLimitConfig.maxCalls,
+    );
+  });
+
+  it("queues calls beyond the per-minute limit", async () => {
+    let callCount = 0;
+    const pendingCalls = Array.from({ length: 61 }, () =>
+      scheduleKassalappRequest({
+        rateLimitKey: TEST_RATE_LIMIT_KEY,
+        request: async () => {
+          callCount += 1;
+        },
+      }),
+    );
+
+    await Promise.resolve();
+    expect(callCount).toBe(60);
+    expect(getKassalappRateLimiterStats(TEST_RATE_LIMIT_KEY).queuedCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(kassalappRateLimitConfig.windowMs + 1);
+    await Promise.all(pendingCalls);
+
+    expect(callCount).toBe(61);
+  });
+
+  it("isolates rate limits per family key", async () => {
+    let firstFamilyCalls = 0;
+    let secondFamilyCalls = 0;
+
+    await Promise.all(
+      Array.from({ length: kassalappRateLimitConfig.maxCalls }, () =>
+        scheduleKassalappRequest({
+          rateLimitKey: "family-1",
+          request: async () => {
+            firstFamilyCalls += 1;
+          },
+        }),
+      ),
+    );
+
+    await scheduleKassalappRequest({
+      rateLimitKey: "family-2",
+      request: async () => {
+        secondFamilyCalls += 1;
+      },
+    });
+
+    expect(firstFamilyCalls).toBe(kassalappRateLimitConfig.maxCalls);
+    expect(secondFamilyCalls).toBe(1);
+    expect(getKassalappRateLimiterStats("family-1").queuedCalls).toBe(0);
+  });
+
+  it("retries rate-limited responses with backoff", async () => {
+    let attempts = 0;
+
+    const resultPromise = scheduleKassalappRequest({
+      rateLimitKey: TEST_RATE_LIMIT_KEY,
+      request: async () => {
+        attempts += 1;
+
+        if (attempts === 1) {
+          throw new KassalappApiError("Too many requests", 429);
+        }
+
+        return "ok";
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(resultPromise).resolves.toBe("ok");
+    expect(attempts).toBe(2);
+  });
+});

--- a/app/lib/kassalapp-rate-limit.server.ts
+++ b/app/lib/kassalapp-rate-limit.server.ts
@@ -1,0 +1,156 @@
+const KASSALAPP_RATE_LIMIT_MAX_CALLS = 60;
+const KASSALAPP_RATE_LIMIT_WINDOW_MS = 60_000;
+const KASSALAPP_RATE_LIMIT_MAX_RETRIES = 3;
+const KASSALAPP_RATE_LIMIT_INITIAL_BACKOFF_MS = 1_000;
+
+interface RateLimiterWaiter {
+  reject: (error: unknown) => void;
+  resolve: () => void;
+}
+
+interface RateLimiterBucket {
+  callTimestamps: number[];
+  drainTimer: ReturnType<typeof setTimeout> | null;
+  waitQueue: RateLimiterWaiter[];
+}
+
+const buckets = new Map<string, RateLimiterBucket>();
+
+function getRateLimiterBucket(rateLimitKey: string) {
+  const existingBucket = buckets.get(rateLimitKey);
+
+  if (existingBucket) {
+    return existingBucket;
+  }
+
+  const bucket: RateLimiterBucket = {
+    callTimestamps: [],
+    drainTimer: null,
+    waitQueue: [],
+  };
+  buckets.set(rateLimitKey, bucket);
+
+  return bucket;
+}
+
+function pruneExpiredCalls(bucket: RateLimiterBucket, now: number) {
+  const windowStart = now - KASSALAPP_RATE_LIMIT_WINDOW_MS;
+
+  while (
+    bucket.callTimestamps.length > 0 &&
+    bucket.callTimestamps[0]! < windowStart
+  ) {
+    bucket.callTimestamps.shift();
+  }
+}
+
+function scheduleDrain(rateLimitKey: string, now = Date.now()) {
+  const bucket = getRateLimiterBucket(rateLimitKey);
+
+  if (bucket.drainTimer !== null) {
+    return;
+  }
+
+  pruneExpiredCalls(bucket, now);
+
+  if (bucket.callTimestamps.length < KASSALAPP_RATE_LIMIT_MAX_CALLS) {
+    while (
+      bucket.waitQueue.length > 0 &&
+      bucket.callTimestamps.length < KASSALAPP_RATE_LIMIT_MAX_CALLS
+    ) {
+      bucket.callTimestamps.push(Date.now());
+      bucket.waitQueue.shift()?.resolve();
+    }
+
+    return;
+  }
+
+  const oldestCall = bucket.callTimestamps[0] ?? now;
+  const delayMs = Math.max(
+    0,
+    oldestCall + KASSALAPP_RATE_LIMIT_WINDOW_MS - now,
+  );
+
+  bucket.drainTimer = setTimeout(() => {
+    bucket.drainTimer = null;
+    scheduleDrain(rateLimitKey);
+  }, delayMs);
+}
+
+async function waitForRateLimitSlot(rateLimitKey: string) {
+  const bucket = getRateLimiterBucket(rateLimitKey);
+  pruneExpiredCalls(bucket, Date.now());
+
+  if (bucket.callTimestamps.length < KASSALAPP_RATE_LIMIT_MAX_CALLS) {
+    bucket.callTimestamps.push(Date.now());
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    bucket.waitQueue.push({ reject, resolve });
+    scheduleDrain(rateLimitKey);
+  });
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function resetKassalappRateLimiterForTests() {
+  for (const bucket of buckets.values()) {
+    if (bucket.drainTimer !== null) {
+      clearTimeout(bucket.drainTimer);
+    }
+  }
+
+  buckets.clear();
+}
+
+export function getKassalappRateLimiterStats(rateLimitKey = "default") {
+  const bucket = getRateLimiterBucket(rateLimitKey);
+  pruneExpiredCalls(bucket, Date.now());
+
+  return {
+    activeCallsInWindow: bucket.callTimestamps.length,
+    queuedCalls: bucket.waitQueue.length,
+  };
+}
+
+export async function scheduleKassalappRequest<T>({
+  rateLimitKey,
+  request,
+}: {
+  rateLimitKey: string;
+  request: () => Promise<T>;
+}): Promise<T> {
+  let backoffMs = KASSALAPP_RATE_LIMIT_INITIAL_BACKOFF_MS;
+
+  for (let attempt = 0; attempt <= KASSALAPP_RATE_LIMIT_MAX_RETRIES; attempt += 1) {
+    await waitForRateLimitSlot(rateLimitKey);
+
+    try {
+      return await request();
+    } catch (error) {
+      const isRateLimited =
+        error instanceof Error &&
+        "status" in error &&
+        (error as { status: number }).status === 429;
+
+      if (!isRateLimited || attempt === KASSALAPP_RATE_LIMIT_MAX_RETRIES) {
+        throw error;
+      }
+
+      await sleep(backoffMs);
+      backoffMs *= 2;
+    }
+  }
+
+  throw new Error("Kassalapp rate limit retries exhausted.");
+}
+
+export const kassalappRateLimitConfig = {
+  maxCalls: KASSALAPP_RATE_LIMIT_MAX_CALLS,
+  windowMs: KASSALAPP_RATE_LIMIT_WINDOW_MS,
+};

--- a/app/lib/kassalapp-search.server.test.ts
+++ b/app/lib/kassalapp-search.server.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dedupeShoppingSearchTerms,
+  getUncheckedShoppingItems,
+  normalizeShoppingSearchTerm,
+} from "./kassalapp-search.server";
+import type { ProjectedFamilyShoppingItem } from "./shopping.server";
+
+function createFamilyItem(
+  overrides: Partial<ProjectedFamilyShoppingItem> = {},
+): ProjectedFamilyShoppingItem {
+  return {
+    category: { id: "category-1", name: "Meieri" },
+    checked: false,
+    collaborationVersion: "2026-01-01T00:00:00.000Z",
+    mealPlanId: null,
+    mealPlanTitle: null,
+    name: "Melk",
+    note: null,
+    preferredStore: null,
+    quantity: null,
+    quantityLabel: null,
+    section: {
+      displayName: "Meieri",
+      sortOrder: 0,
+    },
+    sourceKey: "family:item-1",
+    sourceType: "FAMILY",
+    ...overrides,
+  };
+}
+
+describe("kassalapp-search.server", () => {
+  it("strips leading quantity prefixes from search terms", () => {
+    expect(normalizeShoppingSearchTerm("2 dl melk")).toBe("melk");
+    expect(normalizeShoppingSearchTerm("500 g kjøttdeig")).toBe("kjøttdeig");
+    expect(normalizeShoppingSearchTerm("1 stk løk")).toBe("løk");
+  });
+
+  it("falls back to quantityLabel when the name is too short", () => {
+    expect(normalizeShoppingSearchTerm("lø", "2 stk gul løk")).toBe("gul løk");
+  });
+
+  it("returns null for terms shorter than three characters", () => {
+    expect(normalizeShoppingSearchTerm("2 dl")).toBeNull();
+    expect(normalizeShoppingSearchTerm("te")).toBeNull();
+  });
+
+  it("dedupes unchecked items by normalized search term", () => {
+    const groupedTerms = dedupeShoppingSearchTerms(
+      getUncheckedShoppingItems([
+        createFamilyItem({ name: "2 dl melk", sourceKey: "family:1" }),
+        createFamilyItem({ name: "Melk", sourceKey: "family:2" }),
+        createFamilyItem({
+          checked: true,
+          name: "Melk",
+          sourceKey: "family:3",
+        }),
+      ]),
+    );
+
+    expect(groupedTerms.get("melk")?.map((item) => item.sourceKey)).toEqual([
+      "family:1",
+      "family:2",
+    ]);
+  });
+
+  it("filters checked items out of cost estimation input", () => {
+    expect(
+      getUncheckedShoppingItems([
+        createFamilyItem({ checked: false }),
+        createFamilyItem({ checked: true, sourceKey: "family:2" }),
+      ]),
+    ).toHaveLength(1);
+  });
+});

--- a/app/lib/kassalapp-search.server.ts
+++ b/app/lib/kassalapp-search.server.ts
@@ -1,0 +1,62 @@
+import type { ProjectedShoppingItem } from "./shopping.server";
+
+const QUANTITY_PREFIX_PATTERN =
+  /^(?:\d+(?:[.,]\d+)?\s*(?:stk|ss|ts|dl|cl|ml|l|g|kg|hg|mg|pk|pakke|boks|pose|kopp|neve|fedd)\.?\s+)+/i;
+
+const STANDALONE_QUANTITY_PATTERN =
+  /^\d+(?:[.,]\d+)?\s*(?:stk|ss|ts|dl|cl|ml|l|g|kg|hg|mg|pk|pakke|boks|pose|kopp|neve|fedd)\.?$/i;
+
+function isStandaloneQuantity(value: string) {
+  return STANDALONE_QUANTITY_PATTERN.test(value.trim());
+}
+
+export function normalizeShoppingSearchTerm(
+  name: string,
+  quantityLabel?: string | null,
+) {
+  const normalizedName = stripQuantityPrefix(name.trim());
+  const candidate =
+    normalizedName.length >= 3 && !isStandaloneQuantity(normalizedName)
+      ? normalizedName
+      : stripQuantityPrefix((quantityLabel ?? "").trim());
+
+  const cleaned = candidate.trim().toLowerCase();
+
+  if (cleaned.length < 3 || isStandaloneQuantity(cleaned)) {
+    return null;
+  }
+
+  return cleaned;
+}
+
+function stripQuantityPrefix(value: string) {
+  let current = value.trim();
+
+  while (QUANTITY_PREFIX_PATTERN.test(current)) {
+    current = current.replace(QUANTITY_PREFIX_PATTERN, "").trim();
+  }
+
+  return current;
+}
+
+export function dedupeShoppingSearchTerms(items: ProjectedShoppingItem[]) {
+  const groupedTerms = new Map<string, ProjectedShoppingItem[]>();
+
+  for (const item of items) {
+    const searchTerm = normalizeShoppingSearchTerm(item.name, item.quantityLabel);
+
+    if (!searchTerm) {
+      continue;
+    }
+
+    const existingItems = groupedTerms.get(searchTerm) ?? [];
+    existingItems.push(item);
+    groupedTerms.set(searchTerm, existingItems);
+  }
+
+  return groupedTerms;
+}
+
+export function getUncheckedShoppingItems(items: ProjectedShoppingItem[]) {
+  return items.filter((item) => !item.checked);
+}

--- a/app/lib/kassalapp-stores.server.test.ts
+++ b/app/lib/kassalapp-stores.server.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isKassalappStoreCode,
+  resolveKassalappCodeFromStoreKey,
+} from "./kassalapp-stores.server";
+
+describe("kassalapp-stores.server", () => {
+  it("resolves known store keys to Kassalapp codes", () => {
+    expect(resolveKassalappCodeFromStoreKey("kiwi")).toBe("KIWI");
+    expect(resolveKassalappCodeFromStoreKey("rema-1000")).toBe("REMA_1000");
+  });
+
+  it("validates supported store codes", () => {
+    expect(isKassalappStoreCode("KIWI")).toBe(true);
+    expect(isKassalappStoreCode("UNKNOWN")).toBe(false);
+  });
+});

--- a/app/lib/kassalapp-stores.server.ts
+++ b/app/lib/kassalapp-stores.server.ts
@@ -1,0 +1,40 @@
+import type { KassalappStoreCode } from "./kassalapp.types";
+
+export const DEFAULT_KASSALAPP_STORE_CODES = [
+  "KIWI",
+  "REMA_1000",
+  "MENY_NO",
+  "SPAR_NO",
+  "BUNNPRIS",
+] as const satisfies readonly KassalappStoreCode[];
+
+export const KASSALAPP_STORE_DISPLAY_NAMES: Record<KassalappStoreCode, string> = {
+  BUNNPRIS: "Bunnpris",
+  KIWI: "Kiwi",
+  MENY_NO: "Meny",
+  REMA_1000: "Rema 1000",
+  SPAR_NO: "Spar",
+};
+
+const STORE_KEY_TO_KASSALAPP_CODE: Record<string, KassalappStoreCode> = {
+  bunnpris: "BUNNPRIS",
+  kiwi: "KIWI",
+  meny: "MENY_NO",
+  "rema-1000": "REMA_1000",
+  rema_1000: "REMA_1000",
+  spar: "SPAR_NO",
+};
+
+export function resolveKassalappCodeFromStoreKey(
+  key: string | null | undefined,
+): KassalappStoreCode | null {
+  if (!key) {
+    return null;
+  }
+
+  return STORE_KEY_TO_KASSALAPP_CODE[key.trim().toLowerCase()] ?? null;
+}
+
+export function isKassalappStoreCode(value: string): value is KassalappStoreCode {
+  return value in KASSALAPP_STORE_DISPLAY_NAMES;
+}

--- a/app/lib/kassalapp.server.ts
+++ b/app/lib/kassalapp.server.ts
@@ -1,0 +1,163 @@
+import { scheduleKassalappRequest } from "./kassalapp-rate-limit.server";
+import {
+  KASSALAPP_API_BASE_URL,
+  KassalappApiError,
+  type KassalappBulkPriceResponse,
+  type KassalappHealthResponse,
+  type KassalappProductSearchResponse,
+} from "./kassalapp.types";
+
+interface KassalappRequestOptions {
+  apiToken: string;
+  body?: unknown;
+  fetchImpl?: typeof fetch;
+  method?: "GET" | "POST";
+  path: string;
+  rateLimitKey: string;
+  searchParams?: Record<string, string | number | boolean | undefined>;
+}
+
+function buildKassalappUrl(
+  path: string,
+  searchParams?: KassalappRequestOptions["searchParams"],
+) {
+  const url = new URL(`${KASSALAPP_API_BASE_URL}${path}`);
+
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      if (value === undefined) {
+        continue;
+      }
+
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url;
+}
+
+async function kassalappRequest<T>({
+  apiToken,
+  body,
+  fetchImpl = fetch,
+  method = "GET",
+  path,
+  rateLimitKey,
+  searchParams,
+}: KassalappRequestOptions): Promise<T> {
+  if (!apiToken.trim()) {
+    throw new KassalappApiError("Kassalapp API token is not configured.", 503);
+  }
+
+  const response = await scheduleKassalappRequest({
+    rateLimitKey,
+    request: () =>
+      fetchImpl(buildKassalappUrl(path, searchParams), {
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${apiToken}`,
+          ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+        },
+        method,
+      }),
+  });
+
+  if (response.ok) {
+    return (await response.json()) as T;
+  }
+
+  let details: unknown;
+
+  try {
+    details = await response.json();
+  } catch {
+    details = undefined;
+  }
+
+  const message =
+    typeof details === "object" &&
+    details !== null &&
+    "message" in details &&
+    typeof details.message === "string"
+      ? details.message
+      : `Kassalapp API request failed with status ${response.status}.`;
+
+  throw new KassalappApiError(message, response.status, details);
+}
+
+export async function checkKassalappHealth({
+  apiToken,
+  fetchImpl,
+  rateLimitKey,
+}: {
+  apiToken: string;
+  fetchImpl?: typeof fetch;
+  rateLimitKey: string;
+}) {
+  const response = await kassalappRequest<KassalappHealthResponse>({
+    apiToken,
+    fetchImpl,
+    path: "/health",
+    rateLimitKey,
+  });
+
+  return response.status === "Healthy";
+}
+
+export async function searchKassalappProducts({
+  apiToken,
+  fetchImpl,
+  rateLimitKey,
+  search,
+  size = 10,
+  unique = true,
+}: {
+  apiToken: string;
+  fetchImpl?: typeof fetch;
+  rateLimitKey: string;
+  search: string;
+  size?: number;
+  unique?: boolean;
+}) {
+  return kassalappRequest<KassalappProductSearchResponse>({
+    apiToken,
+    fetchImpl,
+    path: "/products",
+    rateLimitKey,
+    searchParams: {
+      search,
+      size,
+      unique,
+    },
+  });
+}
+
+export async function getKassalappBulkPrices({
+  aggregation = "min",
+  apiToken,
+  days = 1,
+  eans,
+  fetchImpl,
+  rateLimitKey,
+}: {
+  aggregation?: "avg" | "max" | "min";
+  apiToken: string;
+  days?: number;
+  eans: string[];
+  fetchImpl?: typeof fetch;
+  rateLimitKey: string;
+}) {
+  return kassalappRequest<KassalappBulkPriceResponse>({
+    apiToken,
+    body: {
+      aggregation,
+      days,
+      eans,
+    },
+    fetchImpl,
+    method: "POST",
+    path: "/products/prices-bulk",
+    rateLimitKey,
+  });
+}

--- a/app/lib/kassalapp.types.ts
+++ b/app/lib/kassalapp.types.ts
@@ -1,0 +1,108 @@
+export const KASSALAPP_API_BASE_URL = "https://kassal.app/api/v1";
+
+export type KassalappStoreCode =
+  | "BUNNPRIS"
+  | "KIWI"
+  | "MENY_NO"
+  | "REMA_1000"
+  | "SPAR_NO";
+
+export interface KassalappStoreRef {
+  code: string;
+  logo: string;
+  name: string;
+  url: string;
+}
+
+export interface KassalappProduct {
+  brand: string | null;
+  current_price: number | null;
+  current_unit_price: number | null;
+  ean: string | null;
+  id: number;
+  name: string;
+  store: KassalappStoreRef[];
+  vendor: string | null;
+}
+
+export interface KassalappProductSearchResponse {
+  data: KassalappProduct[];
+}
+
+export interface KassalappBulkPriceStore {
+  current_price: number | null;
+  current_unit_price: number | null;
+  current_unit_price_unit: string | null;
+  last_checked: string | null;
+  name: string;
+  store: string;
+}
+
+export interface KassalappBulkPriceHistoryItem {
+  ean: string;
+  name: string;
+  price_history: Array<{
+    date: string;
+    price: number;
+    store: string;
+  }>;
+  stores: KassalappBulkPriceStore[];
+  weight: number | null;
+  weight_unit: string | null;
+}
+
+export interface KassalappBulkPriceResponse {
+  data: KassalappBulkPriceHistoryItem[];
+  meta: {
+    days_included: number;
+    found_products: number;
+    is_premium: boolean;
+    requested_eans: number;
+  };
+}
+
+export interface KassalappHealthResponse {
+  status: string;
+}
+
+export class KassalappApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "KassalappApiError";
+  }
+}
+
+export type ShoppingListCostEstimate =
+  | {
+      reason: string;
+      status: "unavailable";
+    }
+  | {
+      itemMatches: Array<{
+        ean: string | null;
+        pricesByStore: Partial<Record<KassalappStoreCode, number>>;
+        searchTerm: string;
+        sourceKey: string;
+      }>;
+      meta: {
+        bulkCalls: number;
+        cachedHits: number;
+        searchCalls: number;
+      };
+      status: "ok";
+      stores: Array<{
+        code: KassalappStoreCode;
+        matchedCount: number;
+        name: string;
+        total: number;
+        unmatchedCount: number;
+      }>;
+      unmatchedItems: Array<{
+        name: string;
+        sourceKey: string;
+      }>;
+    };

--- a/app/lib/secret-encryption.server.test.ts
+++ b/app/lib/secret-encryption.server.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { decryptSecret, encryptSecret } from "./secret-encryption.server";
+
+describe("secret-encryption.server", () => {
+  it("encrypts and decrypts secrets", () => {
+    const encrypted = encryptSecret("my-kassalapp-token");
+
+    expect(encrypted).not.toContain("my-kassalapp-token");
+    expect(decryptSecret(encrypted)).toBe("my-kassalapp-token");
+  });
+});

--- a/app/lib/secret-encryption.server.ts
+++ b/app/lib/secret-encryption.server.ts
@@ -1,0 +1,45 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  scryptSync,
+} from "node:crypto";
+
+import { env } from "./env.server";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const ENCRYPTION_SALT = "mealplanner-kassalapp-token-v1";
+
+const encryptionKey = scryptSync(env.SESSION_SECRET, ENCRYPTION_SALT, 32);
+
+export function encryptSecret(plaintext: string) {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, encryptionKey, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return Buffer.concat([iv, authTag, encrypted]).toString("base64url");
+}
+
+export function decryptSecret(ciphertext: string) {
+  const payload = Buffer.from(ciphertext, "base64url");
+
+  if (payload.length <= IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error("Invalid encrypted secret payload.");
+  }
+
+  const iv = payload.subarray(0, IV_LENGTH);
+  const authTag = payload.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const encrypted = payload.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, encryptionKey, iv);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
+    "utf8",
+  );
+}

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -2196,3 +2196,15 @@ function getProjectedItemSortTimestamp(item: ProjectedShoppingItem) {
 function getProjectedItemRelevantTimestamp(item: ProjectedShoppingItem) {
   return getProjectedItemRelevantDate(item)?.getTime() ?? Number.MIN_SAFE_INTEGER;
 }
+
+export async function getStoreModeCostEstimate({
+  familyId,
+  items,
+}: {
+  familyId: string;
+  items: ProjectedShoppingItem[];
+}) {
+  const { estimateShoppingListCost } = await import("./kassalapp-cost.server");
+
+  return estimateShoppingListCost({ familyId, items });
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -39,6 +39,7 @@ export default [
       "routes/family-shopping-ingredient-search.ts",
     ),
     route("families/:familyId/stores", "routes/family-stores.tsx"),
+    route("families/:familyId/kassalapp", "routes/family-kassalapp.tsx"),
     route("families/:familyId/stock-ingredients", "routes/family-stock-ingredients.tsx"),
     route("families/:familyId/recipes", "routes/family-recipes.tsx"),
     route("families/:familyId/recipes/:recipeId", "routes/family-recipe.tsx"),

--- a/app/routes/family-kassalapp.test.ts
+++ b/app/routes/family-kassalapp.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/kassalapp-integration.server", () => ({
+  getFamilyKassalappIntegrationData: vi.fn(),
+}));
+
+vi.mock("../lib/kassalapp-integration-write.server", () => ({
+  removeFamilyKassalappApiToken: vi.fn(),
+  saveFamilyKassalappApiToken: vi.fn(),
+}));
+
+import { requireUser } from "../lib/auth.server";
+import { getFamilyKassalappIntegrationData } from "../lib/kassalapp-integration.server";
+import {
+  removeFamilyKassalappApiToken,
+  saveFamilyKassalappApiToken,
+} from "../lib/kassalapp-integration-write.server";
+import { action, loader } from "./family-kassalapp";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/kassalapp",
+  formData?: FormData,
+) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family kassalapp route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads integration status for family members", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getFamilyKassalappIntegrationData).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      integration: {
+        isConfigured: true,
+        tokenLastFour: "abcd",
+        updatedAt: "2026-06-08T08:00:00.000Z",
+      },
+      userRole: "ADMIN",
+    });
+
+    const result = await loader({
+      params: { familyId: "family-1" },
+      request: buildRequest(),
+    });
+
+    expect(getFamilyKassalappIntegrationData).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result.integration.isConfigured).toBe(true);
+    expect(result.userRole).toBe("ADMIN");
+  });
+
+  it("saves api tokens for admins", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(saveFamilyKassalappApiToken).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "save-token");
+    formData.set("apiToken", "secret-token");
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(saveFamilyKassalappApiToken).toHaveBeenCalledWith({
+      apiToken: "secret-token",
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(response).toEqual(
+      Response.redirect(
+        "http://localhost/families/family-1/kassalapp?notice=token-saved",
+        302,
+      ),
+    );
+  });
+
+  it("removes stored api tokens for admins", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(removeFamilyKassalappApiToken).mockResolvedValue({
+      status: "REMOVED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "remove-token");
+
+    const response = await action({
+      params: { familyId: "family-1" },
+      request: buildRequest(undefined, formData),
+    });
+
+    expect(removeFamilyKassalappApiToken).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(response).toEqual(
+      Response.redirect(
+        "http://localhost/families/family-1/kassalapp?notice=token-removed",
+        302,
+      ),
+    );
+  });
+});

--- a/app/routes/family-kassalapp.tsx
+++ b/app/routes/family-kassalapp.tsx
@@ -1,0 +1,389 @@
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { getFamilyKassalappIntegrationData } from "../lib/kassalapp-integration.server";
+import {
+  removeFamilyKassalappApiToken,
+  saveFamilyKassalappApiToken,
+} from "../lib/kassalapp-integration-write.server";
+
+type KassalappNotice = "token-removed" | "token-saved";
+
+type KassalappIntent = "remove-token" | "save-token";
+
+interface KassalappActionData {
+  fieldErrors?: {
+    apiToken?: string;
+  };
+  formError?: string;
+  intent?: KassalappIntent;
+}
+
+interface FamilyKassalappRouteProps {
+  actionData?: KassalappActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Kassalapp | Mealplanner" },
+    {
+      name: "description",
+      content:
+        "Koble familiens Kassalapp API-nøkkel for prisoverslag i handlelisten.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const result = await getFamilyKassalappIntegrationData({
+    familyId,
+    userId: user.id,
+  });
+
+  return {
+    family: result.family,
+    integration: result.integration,
+    notice: getKassalappNotice(request),
+    userRole: result.userRole,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "save-token") {
+    const result = await saveFamilyKassalappApiToken({
+      apiToken: String(formData.get("apiToken") ?? ""),
+      familyId,
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        fieldErrors: result.fieldErrors,
+        intent,
+      } satisfies KassalappActionData;
+    }
+
+    return buildKassalappRedirect({
+      familyId,
+      notice: "token-saved",
+      request,
+    });
+  }
+
+  if (intent === "remove-token") {
+    const result = await removeFamilyKassalappApiToken({
+      familyId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ingen lagret Kassalapp-nøkkel for familien.",
+        intent,
+      } satisfies KassalappActionData;
+    }
+
+    return buildKassalappRedirect({
+      familyId,
+      notice: "token-removed",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies KassalappActionData;
+}
+
+export default function FamilyKassalappRoute({
+  actionData,
+  loaderData,
+}: FamilyKassalappRouteProps) {
+  const navigation = useNavigation();
+  const noticeContent = loaderData.notice
+    ? getKassalappNoticeContent(loaderData.notice)
+    : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const canManageIntegration = loaderData.userRole === "ADMIN";
+  const isConfigured = loaderData.integration.isConfigured;
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-3xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Kassalapp
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Koble familiens egen Kassalapp API-nøkkel for å estimere
+                handlelistepriser. Nøkkelen lagres kryptert og brukes bare for
+                denne familien.
+              </p>
+            </div>
+
+            <Link
+              className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+              to={`/families/${loaderData.family.id}`}
+            >
+              Tilbake til familie
+            </Link>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere Kassalapp
+            </h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <h2 className="text-lg font-semibold text-slate-950">Status</h2>
+          {isConfigured ? (
+            <div className="mt-4 space-y-2 text-sm leading-6 text-slate-600">
+              <p>
+                Kassalapp er koblet til for familien. Lagret nøkkel slutter på{" "}
+                <span className="font-mono text-slate-950">
+                  ...{loaderData.integration.tokenLastFour}
+                </span>
+                .
+              </p>
+              <p>
+                Sist oppdatert{" "}
+                {formatIntegrationTimestamp(loaderData.integration.updatedAt)}.
+              </p>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm leading-6 text-slate-600">
+              Ingen API-nøkkel er lagret for familien ennå. Prisoverslag i
+              handlelisten blir utilgjengelig til en administrator legger inn en
+              nøkkel.
+            </p>
+          )}
+        </section>
+
+        {canManageIntegration ? (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">
+              {isConfigured ? "Oppdater API-nøkkel" : "Legg inn API-nøkkel"}
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Hent nøkkelen fra{" "}
+              <a
+                className="font-medium text-slate-950 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500"
+                href="https://kassal.app"
+                rel="noreferrer"
+                target="_blank"
+              >
+                kassal.app
+              </a>
+              . Den lagres kryptert i databasen og vises aldri i klartekst
+              etter lagring.
+            </p>
+
+            <Form className="mt-6 space-y-4" method="post">
+              <input name="intent" type="hidden" value="save-token" />
+              <label className="block text-sm font-medium text-slate-700">
+                API-nøkkel
+                <input
+                  autoComplete="off"
+                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 font-mono text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                  name="apiToken"
+                  placeholder="Lim inn Kassalapp API-nøkkel"
+                  spellCheck={false}
+                  type="password"
+                />
+              </label>
+              {actionData?.intent === "save-token" &&
+              actionData.fieldErrors?.apiToken ? (
+                <p className="text-sm text-rose-600">
+                  {actionData.fieldErrors.apiToken}
+                </p>
+              ) : null}
+              <button
+                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                disabled={
+                  navigation.state === "submitting" &&
+                  pendingIntent === "save-token"
+                }
+                type="submit"
+              >
+                {navigation.state === "submitting" &&
+                pendingIntent === "save-token"
+                  ? "Lagrer..."
+                  : isConfigured
+                    ? "Oppdater nøkkel"
+                    : "Lagre nøkkel"}
+              </button>
+            </Form>
+
+            {isConfigured ? (
+              <Form className="mt-4" method="post">
+                <input name="intent" type="hidden" value="remove-token" />
+                <button
+                  className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-700 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={
+                    navigation.state === "submitting" &&
+                    pendingIntent === "remove-token"
+                  }
+                  type="submit"
+                >
+                  {navigation.state === "submitting" &&
+                  pendingIntent === "remove-token"
+                    ? "Fjerner..."
+                    : "Fjern nøkkel"}
+                </button>
+              </Form>
+            ) : null}
+          </section>
+        ) : (
+          <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+            <h2 className="text-lg font-semibold text-slate-950">
+              Kun for administratorer
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Bare familieadministratorer kan legge inn eller fjerne
+              Kassalapp-nøkkelen.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi klarte ikke å laste Kassalapp-innstillingene akkurat nå.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke familien" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-16 text-slate-900">
+      <div className="mx-auto max-w-2xl rounded-[32px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{message}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white"
+          to="/app"
+        >
+          Til appen
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function getKassalappNotice(request: Request): KassalappNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (notice === "token-saved" || notice === "token-removed") {
+    return notice;
+  }
+
+  return null;
+}
+
+function getKassalappNoticeContent(notice: KassalappNotice) {
+  switch (notice) {
+    case "token-saved":
+      return {
+        description:
+          "Familiens Kassalapp API-nøkkel er lagret og kan brukes til prisoverslag.",
+        title: "API-nøkkel lagret",
+      };
+    case "token-removed":
+      return {
+        description:
+          "Prisoverslag blir utilgjengelig til en administrator legger inn en ny nøkkel.",
+        title: "API-nøkkel fjernet",
+      };
+  }
+}
+
+function buildKassalappRedirect({
+  familyId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  notice: KassalappNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/kassalapp`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}
+
+function formatIntegrationTimestamp(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}

--- a/prisma/migrations/20260608065650_add_family_kassalapp_integration/migration.sql
+++ b/prisma/migrations/20260608065650_add_family_kassalapp_integration/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "FamilyKassalappIntegration" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "encryptedApiToken" TEXT NOT NULL,
+    "tokenLastFour" TEXT NOT NULL,
+    "updatedByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FamilyKassalappIntegration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FamilyKassalappIntegration_familyId_key" ON "FamilyKassalappIntegration"("familyId");
+
+-- CreateIndex
+CREATE INDEX "FamilyKassalappIntegration_updatedByUserId_idx" ON "FamilyKassalappIntegration"("updatedByUserId");
+
+-- AddForeignKey
+ALTER TABLE "FamilyKassalappIntegration" ADD CONSTRAINT "FamilyKassalappIntegration_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FamilyKassalappIntegration" ADD CONSTRAINT "FamilyKassalappIntegration_updatedByUserId_fkey" FOREIGN KEY ("updatedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model User {
   updatedShoppingItemOverrides ShoppingItemOverride[] @relation("ShoppingItemOverrideUpdatedBy")
   storePreferences             UserStorePreference[]
   familyShoppingPreferences    UserFamilyShoppingPreference[]
+  updatedKassalappIntegrations FamilyKassalappIntegration[] @relation("FamilyKassalappIntegrationUpdatedBy")
   sharedMealPlans              MealPlanShare[]        @relation("MealPlanShareSharedBy")
   mealPlanShareRecipients      MealPlanShareRecipient[]
   mealPlanReviewComments       MealPlanReviewComment[] @relation("MealPlanReviewCommentAuthor")
@@ -101,9 +102,24 @@ model Family {
   familyShoppingPreferences  UserFamilyShoppingPreference[]
   stockIngredients           FamilyStockIngredient[]
   shoppingItems       FamilyShoppingItem[]
+  kassalappIntegration FamilyKassalappIntegration?
 
   @@index([createdByUserId])
   @@index([name])
+}
+
+model FamilyKassalappIntegration {
+  id                String   @id @default(cuid())
+  familyId          String   @unique
+  encryptedApiToken String
+  tokenLastFour     String
+  updatedByUserId   String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+  family            Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  updatedByUser     User?    @relation("FamilyKassalappIntegrationUpdatedBy", fields: [updatedByUserId], references: [id], onDelete: SetNull)
+
+  @@index([updatedByUserId])
 }
 
 model FamilyMembership {


### PR DESCRIPTION
## Summary
- Adds server-side Kassalapp integration for shopping list cost estimation: typed API client, per-family rate limiting, product search/matching, and bulk price aggregation.
- Stores each family's API token encrypted in `FamilyKassalappIntegration`; admins manage keys at `/families/:familyId/kassalapp` (no shared env token).
- Exposes `getStoreModeCostEstimate({ familyId, items })` for the #151 UI follow-up.

## Related issue
Closes #150

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual: save Kassalapp API key as family admin; confirm token last-four displays and cost estimate returns data
- [ ] Manual: verify a family without a configured token gets unavailable cost estimates

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck