### PR TITLE
Fix store-mode layout shift from sync status banner.

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,36 +2,31 @@
 
 ## Current Objective
 
-Issue #155 — Family freezer register on branch `issue/155-freezer-register`. Ready for PR.
+Issue #158 — Prevent store-mode layout shift when sync banner appears, on branch `issue/158-store-mode-sync-layout-shift`.
 
 ## Completed
 
-- Added `FamilyFreezerItem` model and `MealPlanEntry.freezerItemId` with migration `20260625120000_add_family_freezer_items`.
-- Implemented `freezer.server.ts`, `freezer-write.server.ts`, `freezer-stock.server.ts` with stock delta on meal-plan save.
-- Extended `saveMealPlanEntries` / `getMealPlanPlanningData` for freezer validation, decrement on save, and reset restore.
-- Added admin route `/families/:familyId/freezer` with add/update/remove and Fryser nav link.
-- Updated meal-plan UI: closed-by-default freezer panel, unified `mealSelection` picker with Fryser marking.
-- Updated downstream labels: `getDinnerMenuLabel`, family home, calendar export, meal-plan review.
+- Moved sync progress/error UI from an in-flow banner to a fixed top compact overlay so shopping list rows no longer jump on sync.
+- Added `storeModeSyncOverlayShellClass` and `getStoreModeSyncOverlayClass` in store-mode theme.
+- Left `useStoreModeToggleSync` queue/delay/optimistic behavior unchanged.
 
 ## Files To Read First
 
-- `prisma/schema.prisma` — `FamilyFreezerItem`, `MealPlanEntry.freezerItemId`
-- `app/lib/meal-plan.server.ts` — save pipeline stock delta
-- `app/routes/family-meal-plan.tsx` — freezer panel + picker
-- `app/routes/family-freezer.tsx` — admin CRUD
+- `app/routes/family-meal-plan-store-mode.tsx` — overlay render near quick-add dock
+- `app/lib/store-mode-theme.ts` — overlay shell/tone classes
+- `app/lib/use-store-mode-toggle-sync.ts` — still owns `syncBannerMessage` (unchanged)
 
 ## Validation
 
-- `npm run prisma:generate` — passed
-- `npm run lint` — passed (after fixing unused imports)
-- `npm run test:run` — passed (55 files, 334 tests)
-- `npm run typecheck` — passed
+- `npx vitest run app/lib/store-mode-theme.test.ts app/lib/use-store-mode-toggle-sync.test.ts` — passed
+- `npx tsc --noEmit -p tsconfig.json` — passed
+- Manual phone-width check-off / mis-tap verification — not run yet
 
 ## Open Items
 
-- Migration not applied to local DB (drift detected); migration SQL file is committed for deploy/CI.
-- Plan copy does not copy `freezerItemId` (intentional v1 safety).
+- Confirm overlay clears sticky top nav (`top-16`) on real devices with safe-area insets
+- Open PR with `Closes #158` when ready
 
 ## Next Step
 
-Open PR with `Closes #155`.
+Push is done or in progress; open a PR targeting `main` with `Closes #158`.

--- a/app/lib/store-mode-theme.test.ts
+++ b/app/lib/store-mode-theme.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   getStoreModeBannerClass,
+  getStoreModeSyncOverlayClass,
   storeModeMetaDateSelectClass,
   storeModeMetaStoreSelectClass,
   storeModeSelectClass,
+  storeModeSyncOverlayShellClass,
 } from "./store-mode-theme";
 
 describe("store-mode-theme", () => {
@@ -17,6 +19,18 @@ describe("store-mode-theme", () => {
     expect(sync).toContain("amber");
     expect(error).toContain("rose");
     expect(success).not.toBe(sync);
+  });
+
+  it("returns compact fixed overlay classes for sync and error", () => {
+    const sync = getStoreModeSyncOverlayClass("sync");
+    const error = getStoreModeSyncOverlayClass("error");
+
+    expect(storeModeSyncOverlayShellClass).toContain("fixed");
+    expect(storeModeSyncOverlayShellClass).toContain("pointer-events-none");
+    expect(sync).toContain("amber");
+    expect(error).toContain("rose");
+    expect(sync).not.toBe(error);
+    expect(sync).not.toContain("py-5");
   });
 
   it("uses compact auto-width meta selects distinct from full-width selects", () => {

--- a/app/lib/store-mode-theme.ts
+++ b/app/lib/store-mode-theme.ts
@@ -42,6 +42,12 @@ export const storeModeQuickAddDockClass =
 
 export type StoreModeBannerTone = "success" | "sync" | "error";
 
+export type StoreModeSyncOverlayTone = "sync" | "error";
+
+/** Fixed shell under sticky app top nav — out of document flow to avoid list shift. */
+export const storeModeSyncOverlayShellClass =
+  "pointer-events-none fixed inset-x-0 top-16 z-[60] px-4";
+
 export function getStoreModeBannerClass(tone: StoreModeBannerTone) {
   switch (tone) {
     case "success":
@@ -50,5 +56,17 @@ export function getStoreModeBannerClass(tone: StoreModeBannerTone) {
       return "rounded-[28px] border border-amber-200/80 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm";
     case "error":
       return "rounded-[28px] border border-rose-200/80 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm";
+  }
+}
+
+export function getStoreModeSyncOverlayClass(tone: StoreModeSyncOverlayTone) {
+  const base =
+    "mx-auto max-w-4xl rounded-2xl border px-4 py-3 text-sm shadow-lg backdrop-blur-sm";
+
+  switch (tone) {
+    case "sync":
+      return `${base} border-amber-200/80 bg-amber-50/95 text-amber-950`;
+    case "error":
+      return `${base} border-rose-200/80 bg-rose-50/95 text-rose-900`;
   }
 }

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -67,6 +67,7 @@ import { listIngredientCategories } from "../lib/store.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
 import {
   getStoreModeBannerClass,
+  getStoreModeSyncOverlayClass,
   storeModeAccentBarClass,
   storeModeCountChipClass,
   storeModeLaterChipClass,
@@ -80,6 +81,7 @@ import {
   storeModeQuickAddDockClass,
   storeModeSectionCardClass,
   storeModeSurfaceCardClass,
+  storeModeSyncOverlayShellClass,
 } from "../lib/store-mode-theme";
 import {
   STORE_MODE_SYNC_PROGRESS_MESSAGE,
@@ -919,23 +921,6 @@ export default function FamilyMealPlanStoreModeRoute({
           </section>
         ) : null}
 
-        {syncBannerMessage ? (
-          <section
-            className={getStoreModeBannerClass(
-              syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
-                ? "sync"
-                : "error",
-            )}
-          >
-            <h2 className="text-base font-semibold">
-              {syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
-                ? "Synkroniserer"
-                : "Kunne ikke synkronisere"}
-            </h2>
-            <p className="mt-2 text-sm leading-6">{syncBannerMessage}</p>
-          </section>
-        ) : null}
-
         {generalFormError ? (
           <section className={getStoreModeBannerClass("error")}>
             <h2 className="text-base font-semibold">
@@ -1076,6 +1061,29 @@ export default function FamilyMealPlanStoreModeRoute({
           </div>
         </section>
       </div>
+
+      {syncBannerMessage ? (
+        <div
+          aria-live="polite"
+          className={storeModeSyncOverlayShellClass}
+          role="status"
+        >
+          <div
+            className={getStoreModeSyncOverlayClass(
+              syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
+                ? "sync"
+                : "error",
+            )}
+          >
+            <p className="font-semibold">
+              {syncBannerMessage === STORE_MODE_SYNC_PROGRESS_MESSAGE
+                ? "Synkroniserer"
+                : "Kunne ikke synkronisere"}
+            </p>
+            <p className="mt-0.5 leading-5">{syncBannerMessage}</p>
+          </div>
+        </div>
+      ) : null}
 
       <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 overflow-x-clip px-4 pb-4 pt-3">
         <div className="pointer-events-auto mx-auto max-w-4xl min-w-0">


### PR DESCRIPTION
Render sync progress and errors as a fixed top overlay so checking off items no longer pushes the shopping list.