### PR TITLE
Allow meal plans longer than 7 days

### DIFF
--- a/.cursor/rules/frontend-standards.mdc
+++ b/.cursor/rules/frontend-standards.mdc
@@ -6,6 +6,7 @@ alwaysApply: true
 # Project Standards
 
 - Use React Router 7 as the application framework and follow its conventions for routes, loaders, actions, and server/client boundaries.
+- Never import `*.server` modules for values used in a route's default component or other client exports; put shared constants/helpers in non-`.server` files. `npm run build` catches this; lint/typecheck do not.
 - Use Prisma as the ORM for database access and prefer Prisma-based solutions over introducing other data access layers unless the user asks for it.
 - For GitHub work, treat this `mealplanner` project as the default repository context unless the user explicitly points to another repository.
 - Default to React, TypeScript, and Tailwind solutions that are clean, concise, and easy to maintain.

--- a/.cursor/rules/react-router-server-client-boundary.mdc
+++ b/.cursor/rules/react-router-server-client-boundary.mdc
@@ -1,0 +1,35 @@
+---
+description: Never import .server modules into React Router client route UI
+globs: app/routes/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# React Router server/client boundary
+
+React Router strips `.server` imports from `loader` / `action` / `middleware` / `headers` only. **Any other route export** (especially the default component) must not depend on `*.server` modules. Violations fail `npm run build` with `Server-only module referenced by client`.
+
+## Rules
+
+- In route modules, import from `*.server` **only** for values used inside `loader` / `action` (and other server-only exports).
+- Shared constants, formatters, and copy helpers used in JSX or client helpers belong in non-`.server` modules (e.g. `meal-plan-dates.ts`, `meal-plan-display.ts`).
+- Before shipping route UI that needs a constant from a server file: **extract it** to a shared module, then import that shared module from both server and client.
+- Run `npm run build` after adding client-visible imports to routes; lint/typecheck alone will not catch this.
+
+```tsx
+// BAD — default component uses a value imported from *.server
+import { MEAL_PLAN_MAX_SPAN_DAYS, createMealPlan } from "../lib/meal-plan.server";
+
+export async function action() { /* createMealPlan ok here */ }
+export default function Route() {
+  return <p>Maks {MEAL_PLAN_MAX_SPAN_DAYS} dager</p>; // breaks production build
+}
+
+// GOOD — shared module for client-visible values
+import { MEAL_PLAN_MAX_SPAN_DAYS } from "../lib/meal-plan-dates";
+import { createMealPlan } from "../lib/meal-plan.server";
+
+export async function action() { /* server-only import stays in action */ }
+export default function Route() {
+  return <p>Maks {MEAL_PLAN_MAX_SPAN_DAYS} dager</p>;
+}
+```

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,31 +2,33 @@
 
 ## Current Objective
 
-Issue #158 — Prevent store-mode layout shift when sync banner appears, on branch `issue/158-store-mode-sync-layout-shift`.
+Issue #160 — Allow meal plans longer than 7 days (up to 14), on branch `issue/160-allow-meal-plans-longer-than-7-days`.
 
 ## Completed
 
-- Moved sync progress/error UI from an in-flow banner to a fixed top compact overlay so shopping list rows no longer jump on sync.
-- Added `storeModeSyncOverlayShellClass` and `getStoreModeSyncOverlayClass` in store-mode theme.
-- Left `useStoreModeToggleSync` queue/delay/optimistic behavior unchanged.
+- Raised `MEAL_PLAN_MAX_SPAN_DAYS` to 14 and centralized max-span validation/UI copy via `getMealPlanMaxSpanMessage()`.
+- `updateMealPlan` now prunes out-of-range entries and clamps manual buy-on / postpone dates in a transaction.
+- Auto-fill exclusion switched from “last 2 plans” to a 14-day calendar lookback before the plan start.
+- Planning UI shows week-chunk separators when a plan has more than 7 days; create/edit/home copy updated.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx` — overlay render near quick-add dock
-- `app/lib/store-mode-theme.ts` — overlay shell/tone classes
-- `app/lib/use-store-mode-toggle-sync.ts` — still owns `syncBannerMessage` (unchanged)
+- `app/lib/meal-plan.server.ts` — span cap, prune-on-shrink, auto-fill lookback
+- `app/routes/family-meal-plan.tsx` — week separators + edit-range copy
+- `app/routes/family-meal-plans.tsx` — create/copy max-span and copy-truncation notes
+- `app/routes/family.tsx` — kalenderuke home copy
 
 ## Validation
 
-- `npx vitest run app/lib/store-mode-theme.test.ts app/lib/use-store-mode-toggle-sync.test.ts` — passed
+- `npx vitest run app/lib/meal-plan.server.test.ts app/routes/family-meal-plans.test.ts` — passed (48 tests)
 - `npx tsc --noEmit -p tsconfig.json` — passed
-- Manual phone-width check-off / mis-tap verification — not run yet
+- Manual create/shrink/home smoke — not run yet
 
 ## Open Items
 
-- Confirm overlay clears sticky top nav (`top-16`) on real devices with safe-area insets
-- Open PR with `Closes #158` when ready
+- Open PR targeting `main` with `Closes #160` when ready
+- Optional: manual smoke of 14-day create, shrink prune, and family home kalenderuke
 
 ## Next Step
 
-Push is done or in progress; open a PR targeting `main` with `Closes #158`.
+Push branch and open a PR for #160.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,7 +2,7 @@
 
 ## Current Objective
 
-Issue #160 — Allow meal plans longer than 7 days (up to 14), on branch `issue/160-allow-meal-plans-longer-than-7-days`.
+Issue #160 — Allow meal plans longer than 7 days (up to 14), on branch `issue/160-allow-meal-plans-longer-than-7-days`. PR #161.
 
 ## Completed
 
@@ -10,28 +10,30 @@ Issue #160 — Allow meal plans longer than 7 days (up to 14), on branch `issue/
 - `updateMealPlan` now prunes out-of-range entries and clamps manual buy-on / postpone dates in a transaction.
 - Auto-fill exclusion switched from “last 2 plans” to a 14-day calendar lookback before the plan start.
 - Planning UI shows week-chunk separators when a plan has more than 7 days; create/edit/home copy updated.
-- Full local validation passed; PR opened with `Closes #160`.
+- Fixed CI build failure: moved `MEAL_PLAN_MAX_SPAN_DAYS` / `getMealPlanMaxSpanMessage` to client-safe `meal-plan-dates.ts` so route components no longer import `.server` for UI copy.
 
 ## Files To Read First
 
+- `app/lib/meal-plan-dates.ts` — shared max-span constant/message
 - `app/lib/meal-plan.server.ts` — span cap, prune-on-shrink, auto-fill lookback
 - `app/routes/family-meal-plan.tsx` — week separators + edit-range copy
 - `app/routes/family-meal-plans.tsx` — create/copy max-span and copy-truncation notes
-- `app/routes/family.tsx` — kalenderuke home copy
 
 ## Validation
 
-- `npm run prisma:generate` — passed
-- `npm run lint` — passed
-- `npm run test:run` — passed (55 files, 337 tests)
-- `npm run typecheck` — passed
+- `npm run prisma:generate` — passed (earlier ship run)
+- `npm run lint` — passed (earlier ship run)
+- `npm run test:run` — passed earlier; targeted re-run after fix passed (51 tests)
+- `npm run typecheck` — passed after fix
+- `npm run build` — passed after fix
 - Manual create/shrink/home smoke — not run yet
 
 ## Open Items
 
+- Confirm CI Validate on PR #161 goes green after push
 - Optional: manual smoke of 14-day create, shrink prune, and family home kalenderuke
 - Merge PR when review is complete (issue closes via `Closes #160`)
 
 ## Next Step
 
-Review and merge the open PR for #160.
+Wait for CI on PR #161, then merge.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -10,6 +10,7 @@ Issue #160 — Allow meal plans longer than 7 days (up to 14), on branch `issue/
 - `updateMealPlan` now prunes out-of-range entries and clamps manual buy-on / postpone dates in a transaction.
 - Auto-fill exclusion switched from “last 2 plans” to a 14-day calendar lookback before the plan start.
 - Planning UI shows week-chunk separators when a plan has more than 7 days; create/edit/home copy updated.
+- Full local validation passed; PR opened with `Closes #160`.
 
 ## Files To Read First
 
@@ -20,15 +21,17 @@ Issue #160 — Allow meal plans longer than 7 days (up to 14), on branch `issue/
 
 ## Validation
 
-- `npx vitest run app/lib/meal-plan.server.test.ts app/routes/family-meal-plans.test.ts` — passed (48 tests)
-- `npx tsc --noEmit -p tsconfig.json` — passed
+- `npm run prisma:generate` — passed
+- `npm run lint` — passed
+- `npm run test:run` — passed (55 files, 337 tests)
+- `npm run typecheck` — passed
 - Manual create/shrink/home smoke — not run yet
 
 ## Open Items
 
-- Open PR targeting `main` with `Closes #160` when ready
 - Optional: manual smoke of 14-day create, shrink prune, and family home kalenderuke
+- Merge PR when review is complete (issue closes via `Closes #160`)
 
 ## Next Step
 
-Push branch and open a PR for #160.
+Review and merge the open PR for #160.

--- a/app/lib/meal-plan-dates.ts
+++ b/app/lib/meal-plan-dates.ts
@@ -1,3 +1,9 @@
+export const MEAL_PLAN_MAX_SPAN_DAYS = 14;
+
+export function getMealPlanMaxSpanMessage() {
+  return `Datointervallet kan være maks ${MEAL_PLAN_MAX_SPAN_DAYS} dager.`;
+}
+
 export function formatDateOnly(date: Date) {
   return [
     date.getUTCFullYear().toString().padStart(4, "0"),

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -27,6 +27,12 @@ const {
         findMany: vi.fn(),
         upsert: vi.fn(),
       },
+      manualShoppingItem: {
+        updateMany: vi.fn(),
+      },
+      shoppingItemOverride: {
+        updateMany: vi.fn(),
+      },
       familyFreezerItem: {
         findMany: vi.fn(),
         updateMany: vi.fn(),
@@ -76,9 +82,11 @@ import {
   deleteMealPlan,
   formatDateOnly,
   getMealPlanForFamily,
+  getMealPlanMaxSpanMessage,
   getMealPlanPlanningData,
   getRecentlyUsedRecipeIds,
   listMealPlansForFamily,
+  MEAL_PLAN_MAX_SPAN_DAYS,
   reopenMealPlan,
   saveMealPlanEntries,
   updateMealPlan,
@@ -111,6 +119,9 @@ describe("meal-plan.server", () => {
     dbMock.familyFreezerItem.updateMany.mockResolvedValue({ count: 1 });
     dbMock.mealPlan.updateMany.mockResolvedValue({ count: 1 });
     dbMock.mealPlanShare.updateMany.mockResolvedValue({ count: 0 });
+    dbMock.manualShoppingItem.updateMany.mockResolvedValue({ count: 0 });
+    dbMock.shoppingItemOverride.updateMany.mockResolvedValue({ count: 0 });
+    dbMock.mealPlanEntry.deleteMany.mockResolvedValue({ count: 0 });
     dbMock.mealPlan.findUniqueOrThrow.mockResolvedValue({
       id: "meal-plan-1",
       title: "Langhelg",
@@ -146,14 +157,25 @@ describe("meal-plan.server", () => {
     });
   });
 
-  it("rejects ranges longer than seven days", () => {
-    expect(validateMealPlanRange("2026-05-12", "2026-05-20")).toEqual({
+  it("rejects ranges longer than fourteen days", () => {
+    expect(validateMealPlanRange("2026-05-12", "2026-05-26")).toEqual({
       fieldErrors: {
-        endDate: "Datointervallet kan være maks 7 dager.",
+        endDate: getMealPlanMaxSpanMessage(),
       },
       ok: false,
       values: {
-        endDate: "2026-05-20",
+        endDate: "2026-05-26",
+        startDate: "2026-05-12",
+        title: "",
+      },
+    });
+  });
+
+  it("accepts fourteen-day ranges", () => {
+    expect(validateMealPlanRange("2026-05-12", "2026-05-25")).toEqual({
+      ok: true,
+      values: {
+        endDate: "2026-05-25",
         startDate: "2026-05-12",
         title: "",
       },
@@ -250,7 +272,7 @@ describe("meal-plan.server", () => {
 
   it("returns validation errors instead of creating invalid meal plans", async () => {
     const result = await createMealPlan({
-      endDate: "2026-05-20",
+      endDate: "2026-05-26",
       familyId: "family-1",
       startDate: "2026-05-12",
       title: " ",
@@ -259,12 +281,12 @@ describe("meal-plan.server", () => {
 
     expect(result).toEqual({
       fieldErrors: {
-        endDate: "Datointervallet kan være maks 7 dager.",
+        endDate: getMealPlanMaxSpanMessage(),
         title: "Skriv inn et navn for ukeplanen.",
       },
       status: "VALIDATION_ERROR",
       values: {
-        endDate: "2026-05-20",
+        endDate: "2026-05-26",
         startDate: "2026-05-12",
         title: "",
       },
@@ -580,6 +602,85 @@ describe("meal-plan.server", () => {
       status: "NOT_FOUND",
     });
     expect(dbMock.mealPlan.update).not.toHaveBeenCalled();
+  });
+
+  it("prunes out-of-range entries and clamps shopping dates when shrinking a meal plan", async () => {
+    const existingUpdatedAt = new Date("2026-05-01T12:00:00.000Z");
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-24T00:00:00.000Z"),
+      id: "meal-plan-1",
+      updatedAt: existingUpdatedAt,
+    });
+    dbMock.mealPlan.findUniqueOrThrow.mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: existingUpdatedAt,
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+      updatedAt: new Date("2026-05-01T13:00:00.000Z"),
+    });
+
+    const result = await updateMealPlan({
+      endDate: "2026-05-18",
+      expectedMealPlanUpdatedAt: existingUpdatedAt.toISOString(),
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      startDate: "2026-05-15",
+      title: "Langhelg",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("UPDATED");
+    expect(dbMock.mealPlan.updateMany).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        title: "Langhelg",
+      }),
+      where: {
+        id: "meal-plan-1",
+        updatedAt: existingUpdatedAt,
+      },
+    });
+    expect(dbMock.mealPlanEntry.deleteMany).toHaveBeenCalledWith({
+      where: {
+        mealPlanId: "meal-plan-1",
+        OR: [
+          { date: { lt: new Date("2026-05-15T00:00:00.000Z") } },
+          { date: { gt: new Date("2026-05-18T00:00:00.000Z") } },
+        ],
+      },
+    });
+    expect(dbMock.manualShoppingItem.updateMany).toHaveBeenCalledWith({
+      data: {
+        buyOnDate: new Date("2026-05-15T00:00:00.000Z"),
+      },
+      where: {
+        mealPlanId: "meal-plan-1",
+        OR: [
+          { buyOnDate: { lt: new Date("2026-05-15T00:00:00.000Z") } },
+          { buyOnDate: { gt: new Date("2026-05-18T00:00:00.000Z") } },
+        ],
+      },
+    });
+    expect(dbMock.shoppingItemOverride.updateMany).toHaveBeenCalledWith({
+      data: {
+        postponedUntilDate: new Date("2026-05-15T00:00:00.000Z"),
+      },
+      where: {
+        mealPlanId: "meal-plan-1",
+        OR: [
+          { postponedUntilDate: { lt: new Date("2026-05-15T00:00:00.000Z") } },
+          { postponedUntilDate: { gt: new Date("2026-05-18T00:00:00.000Z") } },
+        ],
+      },
+    });
   });
 
   it("approves a draft meal plan as a family member", async () => {
@@ -1300,47 +1401,43 @@ describe("meal-plan.server", () => {
     });
   });
 
-  it("collects recipe ids from the two most recent other meal plans", async () => {
-    dbMock.mealPlan.findMany.mockResolvedValue([
-      {
-        entries: [{ recipeId: "recipe-a" }, { recipeId: "recipe-b" }],
-      },
-      {
-        entries: [{ recipeId: "recipe-c" }],
-      },
+  it("collects recipe ids from dinners in the lookback window before the plan starts", async () => {
+    dbMock.mealPlanEntry.findMany.mockResolvedValue([
+      { recipeId: "recipe-a" },
+      { recipeId: "recipe-b" },
+      { recipeId: "recipe-c" },
     ]);
 
+    const beforeDate = new Date("2026-05-22T00:00:00.000Z");
     const result = await getRecentlyUsedRecipeIds({
+      beforeDate,
       currentMealPlanId: "meal-plan-3",
       familyId: "family-1",
     });
 
     expect(result).toEqual(new Set(["recipe-a", "recipe-b", "recipe-c"]));
-    expect(dbMock.mealPlan.findMany).toHaveBeenCalledWith({
-      orderBy: {
-        endDate: "desc",
-      },
+    expect(dbMock.mealPlanEntry.findMany).toHaveBeenCalledWith({
       select: {
-        entries: {
-          select: {
-            recipeId: true,
-          },
-          where: {
-            mealType: "DINNER",
-            recipeId: {
-              not: null,
-            },
+        recipeId: true,
+      },
+      where: {
+        date: {
+          gte: new Date("2026-05-08T00:00:00.000Z"),
+          lt: beforeDate,
+        },
+        mealPlan: {
+          familyId: "family-1",
+          id: {
+            not: "meal-plan-3",
           },
         },
-      },
-      take: 2,
-      where: {
-        familyId: "family-1",
-        id: {
-          not: "meal-plan-3",
+        mealType: "DINNER",
+        recipeId: {
+          not: null,
         },
       },
     });
+    expect(MEAL_PLAN_MAX_SPAN_DAYS).toBe(14);
   });
 
   it("rejects auto-fill for approved meal plans", async () => {
@@ -1440,10 +1537,8 @@ describe("meal-plan.server", () => {
       title: "Uke 22",
       updatedAt: new Date("2026-05-01T12:00:00.000Z"),
     });
-    dbMock.mealPlan.findMany.mockResolvedValue([
-      {
-        entries: [{ recipeId: "kylling-taco" }],
-      },
+    dbMock.mealPlanEntry.findMany.mockResolvedValue([
+      { recipeId: "kylling-taco" },
     ]);
     dbMock.recipe.findMany.mockResolvedValue([{ id: "kylling-taco" }]);
 
@@ -1455,7 +1550,7 @@ describe("meal-plan.server", () => {
 
     expect(result).toEqual({
       formError:
-        "Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de to forrige ukeplanene.",
+        `Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de siste ${MEAL_PLAN_MAX_SPAN_DAYS} dagene.`,
       status: "NO_ELIGIBLE_RECIPES",
     });
     expect(dbMock.mealPlanEntry.upsert).not.toHaveBeenCalled();
@@ -1497,11 +1592,14 @@ describe("meal-plan.server", () => {
         id: planningMealPlan.id,
         startDate: planningMealPlan.startDate,
       });
-    dbMock.mealPlan.findMany.mockResolvedValue([
-      {
-        entries: [{ recipeId: "recipe-a" }],
-      },
-    ]);
+    dbMock.mealPlanEntry.findMany
+      .mockResolvedValueOnce([{ recipeId: "recipe-a" }])
+      .mockResolvedValue([
+        {
+          date: new Date("2026-05-22T00:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ]);
     dbMock.recipe.findMany
       .mockResolvedValueOnce([
         { id: "recipe-a" },
@@ -1509,12 +1607,6 @@ describe("meal-plan.server", () => {
         { id: "recipe-c" },
       ])
       .mockResolvedValueOnce([{ id: "recipe-b" }, { id: "recipe-c" }, { id: "recipe-d" }]);
-    dbMock.mealPlanEntry.findMany.mockResolvedValue([
-      {
-        date: new Date("2026-05-22T00:00:00.000Z"),
-        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
-      },
-    ]);
 
     const result = await autoFillMealPlanEntries({
       familyId: "family-1",
@@ -1561,7 +1653,7 @@ describe("meal-plan.server", () => {
         id: planningMealPlan.id,
         startDate: planningMealPlan.startDate,
       });
-    dbMock.mealPlan.findMany.mockResolvedValue([]);
+    dbMock.mealPlanEntry.findMany.mockResolvedValue([]);
     dbMock.recipe.findMany
       .mockResolvedValueOnce([{ id: "recipe-b" }])
       .mockResolvedValueOnce([{ id: "recipe-b" }]);

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -19,20 +19,20 @@ import {
   validateFreezerStockDelta,
 } from "./freezer-stock.server";
 import { listActiveFreezerItemsForPlanning } from "./freezer.server";
-import { formatDateOnly } from "./meal-plan-dates";
+import { formatDateOnly, MEAL_PLAN_MAX_SPAN_DAYS, getMealPlanMaxSpanMessage } from "./meal-plan-dates";
 import {
   logCollaborationFailure,
   logCollaborationWrite,
 } from "./write-observability.server";
 
-export { formatDateOnly, isPlanDateToday } from "./meal-plan-dates";
+export {
+  formatDateOnly,
+  getMealPlanMaxSpanMessage,
+  isPlanDateToday,
+  MEAL_PLAN_MAX_SPAN_DAYS,
+} from "./meal-plan-dates";
 
-export const MEAL_PLAN_MAX_SPAN_DAYS = 14;
 const MEAL_PLAN_MAX_DAY_OFFSET = MEAL_PLAN_MAX_SPAN_DAYS - 1;
-
-export function getMealPlanMaxSpanMessage() {
-  return `Datointervallet kan være maks ${MEAL_PLAN_MAX_SPAN_DAYS} dager.`;
-}
 
 const mealPlanSummarySelect = {
   activeShoppingDate: true,

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -27,8 +27,12 @@ import {
 
 export { formatDateOnly, isPlanDateToday } from "./meal-plan-dates";
 
-const MEAL_PLAN_MAX_SPAN_DAYS = 7;
+export const MEAL_PLAN_MAX_SPAN_DAYS = 14;
 const MEAL_PLAN_MAX_DAY_OFFSET = MEAL_PLAN_MAX_SPAN_DAYS - 1;
+
+export function getMealPlanMaxSpanMessage() {
+  return `Datointervallet kan være maks ${MEAL_PLAN_MAX_SPAN_DAYS} dager.`;
+}
 
 const mealPlanSummarySelect = {
   activeShoppingDate: true,
@@ -192,7 +196,7 @@ type MealPlanApprovalAction = "APPROVE" | "REOPEN";
 const AUTO_FILL_NOT_DRAFT_MESSAGE =
   "Godkjente ukeplaner kan ikke fylles automatisk.";
 const AUTO_FILL_NO_ELIGIBLE_RECIPES_MESSAGE =
-  "Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de to forrige ukeplanene.";
+  `Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de siste ${MEAL_PLAN_MAX_SPAN_DAYS} dagene.`;
 const AUTO_FILL_REPEAT_WARNING_MESSAGE =
   "Noen middager ble valgt flere ganger fordi det var for fa oppskrifter igjen.";
 
@@ -291,7 +295,7 @@ export function validateMealPlanRange(
   if (spanInDays > MEAL_PLAN_MAX_DAY_OFFSET) {
     return {
       fieldErrors: {
-        endDate: "Datointervallet kan være maks 7 dager.",
+        endDate: getMealPlanMaxSpanMessage(),
       },
       ok: false,
       values,
@@ -653,25 +657,74 @@ export async function updateMealPlan(input: UpdateMealPlanInput) {
   const nextEndDate = parseDateOnly(validation.values.endDate)!;
 
   try {
-    const updateResult = await db.mealPlan.updateMany({
-      data: {
-        activeShoppingDate: clampShoppingDateToRange(
-          existingMealPlan.activeShoppingDate,
-          nextStartDate,
-          nextEndDate,
-        ),
-        endDate: nextEndDate,
-        startDate: nextStartDate,
-        title: validation.values.title,
-        ...buildActorUpdate(input.userId),
-      },
-      where: {
-        id: existingMealPlan.id,
-        updatedAt: existingMealPlan.updatedAt,
-      },
+    const mealPlan = await db.$transaction(async (tx) => {
+      const updateResult = await tx.mealPlan.updateMany({
+        data: {
+          activeShoppingDate: clampShoppingDateToRange(
+            existingMealPlan.activeShoppingDate,
+            nextStartDate,
+            nextEndDate,
+          ),
+          endDate: nextEndDate,
+          startDate: nextStartDate,
+          title: validation.values.title,
+          ...buildActorUpdate(input.userId),
+        },
+        where: {
+          id: existingMealPlan.id,
+          updatedAt: existingMealPlan.updatedAt,
+        },
+      });
+
+      if (updateResult.count === 0) {
+        return null;
+      }
+
+      await tx.mealPlanEntry.deleteMany({
+        where: {
+          mealPlanId: existingMealPlan.id,
+          OR: [
+            { date: { lt: nextStartDate } },
+            { date: { gt: nextEndDate } },
+          ],
+        },
+      });
+
+      await tx.manualShoppingItem.updateMany({
+        data: {
+          buyOnDate: nextStartDate,
+        },
+        where: {
+          mealPlanId: existingMealPlan.id,
+          OR: [
+            { buyOnDate: { lt: nextStartDate } },
+            { buyOnDate: { gt: nextEndDate } },
+          ],
+        },
+      });
+
+      await tx.shoppingItemOverride.updateMany({
+        data: {
+          postponedUntilDate: nextStartDate,
+        },
+        where: {
+          mealPlanId: existingMealPlan.id,
+          OR: [
+            { postponedUntilDate: { lt: nextStartDate } },
+            { postponedUntilDate: { gt: nextEndDate } },
+          ],
+        },
+      });
+
+      return tx.mealPlan.findUniqueOrThrow({
+        select: mealPlanDetailSelect,
+        where: {
+          id: existingMealPlan.id,
+        },
+      });
     });
 
-    if (updateResult.count === 0) {
+    if (!mealPlan) {
       logCollaborationWrite({
         action: "update-meal-plan",
         domain: "meal-plan",
@@ -688,13 +741,6 @@ export async function updateMealPlan(input: UpdateMealPlanInput) {
         status: "CONFLICT" as const,
       };
     }
-
-    const mealPlan = await db.mealPlan.findUniqueOrThrow({
-      select: mealPlanDetailSelect,
-      where: {
-        id: existingMealPlan.id,
-      },
-    });
 
     logCollaborationWrite({
       action: "update-meal-plan",
@@ -768,44 +814,41 @@ export async function deleteMealPlan({
 }
 
 export async function getRecentlyUsedRecipeIds({
+  beforeDate,
   currentMealPlanId,
   familyId,
 }: {
+  beforeDate: Date;
   currentMealPlanId: string;
   familyId: string;
 }) {
-  const priorPlans = await db.mealPlan.findMany({
-    orderBy: {
-      endDate: "desc",
-    },
+  const lookbackStart = addUtcDays(beforeDate, -MEAL_PLAN_MAX_SPAN_DAYS);
+  const recentEntries = await db.mealPlanEntry.findMany({
     select: {
-      entries: {
-        select: {
-          recipeId: true,
-        },
-        where: {
-          mealType: PLANNING_MEAL_TYPE,
-          recipeId: {
-            not: null,
-          },
+      recipeId: true,
+    },
+    where: {
+      date: {
+        gte: lookbackStart,
+        lt: beforeDate,
+      },
+      mealPlan: {
+        familyId,
+        id: {
+          not: currentMealPlanId,
         },
       },
-    },
-    take: 2,
-    where: {
-      familyId,
-      id: {
-        not: currentMealPlanId,
+      mealType: PLANNING_MEAL_TYPE,
+      recipeId: {
+        not: null,
       },
     },
   });
 
   return new Set(
-    priorPlans.flatMap((plan) =>
-      plan.entries
-        .map((entry) => entry.recipeId)
-        .filter((recipeId): recipeId is string => Boolean(recipeId)),
-    ),
+    recentEntries
+      .map((entry) => entry.recipeId)
+      .filter((recipeId): recipeId is string => Boolean(recipeId)),
   );
 }
 
@@ -875,6 +918,7 @@ export async function autoFillMealPlanEntries({
     },
   });
   const excludedRecipeIds = await getRecentlyUsedRecipeIds({
+    beforeDate: mealPlan.startDate,
     currentMealPlanId: mealPlan.id,
     familyId,
   });

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -30,6 +30,7 @@ import {
   autoFillMealPlanEntries,
   formatDateOnly,
   getMealPlanPlanningData,
+  MEAL_PLAN_MAX_SPAN_DAYS,
   reopenMealPlan,
   saveMealPlanEntries,
   type MealPlanEntryValues,
@@ -773,7 +774,7 @@ export default function FamilyMealPlanRoute({
               method="post"
             >
               <div className="grid min-w-0 gap-2">
-                {loaderData.visibleDates.map((date) => {
+                {loaderData.visibleDates.map((date, index) => {
                   const entry = entryValues[date] ?? {
                     freezerItemId: "",
                     note: "",
@@ -781,21 +782,30 @@ export default function FamilyMealPlanRoute({
                     responsibleUserId: "",
                     updatedAt: "",
                   };
+                  const showWeekSeparator =
+                    loaderData.visibleDates.length > 7 &&
+                    (index === 0 || isUtcMonday(date));
 
                   return (
-                    <MealPlanDayRow
-                      key={date}
-                      calendarDownloadTarget={CALENDAR_DOWNLOAD_TARGET}
-                      canExportDay={calendarExportDateSet.has(date)}
-                      date={date}
-                      entry={entry}
-                      familyId={loaderData.family.id}
-                      familyMembers={loaderData.familyMembers}
-                      freezerItems={loaderData.freezerItems}
-                      isToday={isPlanDateToday(date)}
-                      mealPlanId={loaderData.mealPlan.id}
-                      recipes={loaderData.recipes}
-                    />
+                    <div key={date} className="grid min-w-0 gap-2">
+                      {showWeekSeparator ? (
+                        <p className="pt-1 text-xs font-medium uppercase tracking-wide text-slate-400">
+                          {formatWeekChunkLabel(date)}
+                        </p>
+                      ) : null}
+                      <MealPlanDayRow
+                        calendarDownloadTarget={CALENDAR_DOWNLOAD_TARGET}
+                        canExportDay={calendarExportDateSet.has(date)}
+                        date={date}
+                        entry={entry}
+                        familyId={loaderData.family.id}
+                        familyMembers={loaderData.familyMembers}
+                        freezerItems={loaderData.freezerItems}
+                        isToday={isPlanDateToday(date)}
+                        mealPlanId={loaderData.mealPlan.id}
+                        recipes={loaderData.recipes}
+                      />
+                    </div>
                   );
                 })}
               </div>
@@ -938,7 +948,9 @@ export default function FamilyMealPlanRoute({
               </h2>
               <p className="text-sm leading-6 text-slate-600">
                 Du kan fortsatt endre navn og datointervall her. Datointervallet
-                kan være maks 7 dager.
+                kan være maks {MEAL_PLAN_MAX_SPAN_DAYS} dager. Middager og
+                handledatoer utenfor det nye intervallet fjernes eller justeres
+                automatisk.
               </p>
             </div>
 
@@ -2061,4 +2073,19 @@ function formatWeekdayLabel(date: string) {
   }).format(new Date(`${date}T00:00:00.000Z`));
 
   return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function isUtcMonday(date: string) {
+  return new Date(`${date}T00:00:00.000Z`).getUTCDay() === 1;
+}
+
+function formatWeekChunkLabel(date: string) {
+  const parsedDate = new Date(`${date}T00:00:00.000Z`);
+  const dayOffset = (parsedDate.getUTCDay() + 6) % 7;
+  const weekStart = new Date(parsedDate.getTime());
+  weekStart.setUTCDate(weekStart.getUTCDate() - dayOffset);
+  const weekEnd = new Date(weekStart.getTime());
+  weekEnd.setUTCDate(weekEnd.getUTCDate() + 6);
+
+  return `${formatDateLabel(formatDateOnly(weekStart))} – ${formatDateLabel(formatDateOnly(weekEnd))}`;
 }

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -19,7 +19,7 @@ import {
   listSharesForMealPlan,
   markReviewCommentAddressed,
 } from "../lib/meal-plan-share.server";
-import { isPlanDateToday } from "../lib/meal-plan-dates";
+import { isPlanDateToday, formatDateOnly, MEAL_PLAN_MAX_SPAN_DAYS } from "../lib/meal-plan-dates";
 import {
   encodeMealSelection,
   getDinnerMenuLabel,
@@ -28,9 +28,7 @@ import {
 import {
   approveMealPlan,
   autoFillMealPlanEntries,
-  formatDateOnly,
   getMealPlanPlanningData,
-  MEAL_PLAN_MAX_SPAN_DAYS,
   reopenMealPlan,
   saveMealPlanEntries,
   type MealPlanEntryValues,

--- a/app/routes/family-meal-plans.test.ts
+++ b/app/routes/family-meal-plans.test.ts
@@ -107,11 +107,11 @@ describe("family meal plans route", () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(createMealPlan).mockResolvedValue({
       fieldErrors: {
-        endDate: "Datointervallet kan være maks 7 dager.",
+        endDate: "Datointervallet kan være maks 14 dager.",
       },
       status: "VALIDATION_ERROR",
       values: {
-        endDate: "2026-05-20",
+        endDate: "2026-05-26",
         startDate: "2026-05-12",
         title: "Uke 20",
       },
@@ -121,7 +121,7 @@ describe("family meal plans route", () => {
     formData.set("intent", "create-meal-plan");
     formData.set("title", "Uke 20");
     formData.set("startDate", "2026-05-12");
-    formData.set("endDate", "2026-05-20");
+    formData.set("endDate", "2026-05-26");
 
     const result = await action({
       params: {
@@ -131,7 +131,7 @@ describe("family meal plans route", () => {
     });
 
     expect(createMealPlan).toHaveBeenCalledWith({
-      endDate: "2026-05-20",
+      endDate: "2026-05-26",
       familyId: "family-1",
       startDate: "2026-05-12",
       title: "Uke 20",
@@ -139,11 +139,11 @@ describe("family meal plans route", () => {
     });
     expect(result).toEqual({
       fieldErrors: {
-        endDate: "Datointervallet kan være maks 7 dager.",
+        endDate: "Datointervallet kan være maks 14 dager.",
       },
       intent: "create-meal-plan",
       values: {
-        endDate: "2026-05-20",
+        endDate: "2026-05-26",
         sourceMealPlanId: "",
         startDate: "2026-05-12",
         title: "Uke 20",

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -7,9 +7,9 @@ import {
   createMealPlan,
   deleteMealPlan,
   formatDateOnly,
-  MEAL_PLAN_MAX_SPAN_DAYS,
   listMealPlansForFamily,
 } from "../lib/meal-plan.server";
+import { MEAL_PLAN_MAX_SPAN_DAYS } from "../lib/meal-plan-dates";
 
 type MealPlanNotice =
   | "meal-plan-copied"

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -7,6 +7,7 @@ import {
   createMealPlan,
   deleteMealPlan,
   formatDateOnly,
+  MEAL_PLAN_MAX_SPAN_DAYS,
   listMealPlansForFamily,
 } from "../lib/meal-plan.server";
 
@@ -271,9 +272,9 @@ export default function FamilyMealPlansRoute({
                 Opprett ukeplan
               </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Velg et navn og et datointervall på maks 7 dager. Du kan starte
-                fra en tom ukeplan eller gjenbruke middager og notater fra en
-                tidligere plan.
+                Velg et navn og et datointervall på maks {MEAL_PLAN_MAX_SPAN_DAYS}{" "}
+                dager. Du kan starte fra en tom ukeplan eller gjenbruke middager
+                og notater fra en tidligere plan.
               </p>
             </div>
 
@@ -325,7 +326,8 @@ export default function FamilyMealPlansRoute({
 
               <p className="text-sm leading-6 text-slate-500">
                 Velg en tidligere ukeplan for å kopiere middager og notater til
-                samme relative dager i den nye perioden.
+                samme relative dager i den nye perioden. Dager som faller utenfor
+                det nye intervallet blir ikke kopiert.
               </p>
 
               <div className="grid gap-4 sm:grid-cols-2">

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -527,7 +527,8 @@ export default function FamilyRoute({
                   Denne uken
                 </h2>
                 <p className="mt-2 text-sm leading-6 text-slate-600">
-                  Middagsmeny for hver dag i inneværende kalenderuke.
+                  Viser bare inneværende kalenderuke (man–søn), også når
+                  ukeplanen strekker seg over flere uker.
                 </p>
 
                 {loaderData.weekDays.some((day) => day.mealPlanId) ? (


### PR DESCRIPTION
## Summary
- Raise the meal-plan date span cap from 7 to 14 days so families can plan across more than one week.
- When a plan range shrinks, prune out-of-range dinners and clamp shopping/postpone dates so orphan data does not linger.
- Switch auto-fill recipe exclusion to a 14-day lookback, and add light week separators plus clearer create/edit/home copy for longer plans.

## Related issue
Closes #160

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Create a 10–14 day meal plan and fill dinners across both weeks
- [ ] Shrink the end date and confirm out-of-range dinners are removed
- [ ] Copy a longer plan into a shorter range and confirm only fitting days copy
- [ ] Confirm family home still shows only the current calendar week

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck