### PR TITLE
Distinguish past, active, and upcoming meal plans

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,38 +2,32 @@
 
 ## Current Objective
 
-Issue #160 — Allow meal plans longer than 7 days (up to 14), on branch `issue/160-allow-meal-plans-longer-than-7-days`. PR #161.
+Issue #162 — Distinguish past, active, and upcoming meal plans under Lagrede ukeplaner, on branch `issue/162-distinguish-meal-plan-status`.
 
 ## Completed
 
-- Raised `MEAL_PLAN_MAX_SPAN_DAYS` to 14 and centralized max-span validation/UI copy via `getMealPlanMaxSpanMessage()`.
-- `updateMealPlan` now prunes out-of-range entries and clamps manual buy-on / postpone dates in a transaction.
-- Auto-fill exclusion switched from “last 2 plans” to a 14-day calendar lookback before the plan start.
-- Planning UI shows week-chunk separators when a plan has more than 7 days; create/edit/home copy updated.
-- Fixed CI build failure: moved `MEAL_PLAN_MAX_SPAN_DAYS` / `getMealPlanMaxSpanMessage` to client-safe `meal-plan-dates.ts` so route components no longer import `.server` for UI copy.
+- Added `getMealPlanTimeStatus` and `partitionMealPlansByTimeStatus` in `meal-plan-week.ts` (Oslo today, date-window classification).
+- Regrouped Lagrede ukeplaner into Kommende → Aktiv → Tidligere with visual hierarchy; past plans collapse after three behind Vis flere / Vis færre.
+- Active cards keep emerald emphasis; copy-from select remains a flat list of all plans.
 
 ## Files To Read First
 
-- `app/lib/meal-plan-dates.ts` — shared max-span constant/message
-- `app/lib/meal-plan.server.ts` — span cap, prune-on-shrink, auto-fill lookback
-- `app/routes/family-meal-plan.tsx` — week separators + edit-range copy
-- `app/routes/family-meal-plans.tsx` — create/copy max-span and copy-truncation notes
+- `app/lib/meal-plan-week.ts` — time-status helpers and partition/sort rules
+- `app/routes/family-meal-plans.tsx` — Lagrede ukeplaner sections and MealPlanListCard
+- `app/lib/meal-plan-week.test.ts` — classification and partition coverage
 
 ## Validation
 
-- `npm run prisma:generate` — passed (earlier ship run)
-- `npm run lint` — passed (earlier ship run)
-- `npm run test:run` — passed earlier; targeted re-run after fix passed (51 tests)
-- `npm run typecheck` — passed after fix
-- `npm run build` — passed after fix
-- Manual create/shrink/home smoke — not run yet
+- `npm run prisma:generate` — passed
+- `npm run lint` — passed
+- `npm run test:run` — passed (344 tests)
+- `npm run typecheck` — passed
+- `npm run build` — passed
 
 ## Open Items
 
-- Confirm CI Validate on PR #161 goes green after push
-- Optional: manual smoke of 14-day create, shrink prune, and family home kalenderuke
-- Merge PR when review is complete (issue closes via `Closes #160`)
+- Manual UI smoke still useful: active + upcoming + >3 past (Vis flere), empty categories omitted, delete in each section
 
 ## Next Step
 
-Wait for CI on PR #161, then merge.
+Merge PR after CI is green (issue closes via `Closes #162`).

--- a/app/lib/meal-plan-week.test.ts
+++ b/app/lib/meal-plan-week.test.ts
@@ -5,7 +5,9 @@ import {
   filterMealPlansOverlappingWeek,
   getCalendarWeekBounds,
   getCalendarWeekDates,
+  getMealPlanTimeStatus,
   isMealPlanPast,
+  partitionMealPlansByTimeStatus,
 } from "./meal-plan-week";
 
 describe("getCalendarWeekBounds", () => {
@@ -49,6 +51,101 @@ describe("isMealPlanPast", () => {
   it("returns false when the plan ends today or later", () => {
     expect(isMealPlanPast("2026-06-04", "2026-06-04")).toBe(false);
     expect(isMealPlanPast("2026-06-10", "2026-06-04")).toBe(false);
+  });
+});
+
+describe("getMealPlanTimeStatus", () => {
+  const today = "2026-06-04";
+
+  it("returns past when the plan ended before today", () => {
+    expect(getMealPlanTimeStatus("2026-05-15", "2026-05-18", today)).toBe(
+      "past",
+    );
+  });
+
+  it("returns active when today is the start date", () => {
+    expect(getMealPlanTimeStatus("2026-06-04", "2026-06-10", today)).toBe(
+      "active",
+    );
+  });
+
+  it("returns active when today is the end date", () => {
+    expect(getMealPlanTimeStatus("2026-05-28", "2026-06-04", today)).toBe(
+      "active",
+    );
+  });
+
+  it("returns active when today falls inside the range", () => {
+    expect(getMealPlanTimeStatus("2026-06-01", "2026-06-07", today)).toBe(
+      "active",
+    );
+  });
+
+  it("returns upcoming when the plan starts after today", () => {
+    expect(getMealPlanTimeStatus("2026-06-08", "2026-06-14", today)).toBe(
+      "upcoming",
+    );
+  });
+});
+
+describe("partitionMealPlansByTimeStatus", () => {
+  const today = "2026-06-04";
+  const plans = [
+    {
+      endDate: "2026-05-20",
+      id: "past-older",
+      startDate: "2026-05-10",
+    },
+    {
+      endDate: "2026-05-28",
+      id: "past-recent",
+      startDate: "2026-05-22",
+    },
+    {
+      endDate: "2026-06-07",
+      id: "active-later-start",
+      startDate: "2026-06-02",
+    },
+    {
+      endDate: "2026-06-10",
+      id: "active-earlier-start",
+      startDate: "2026-05-28",
+    },
+    {
+      endDate: "2026-06-20",
+      id: "upcoming-later",
+      startDate: "2026-06-15",
+    },
+    {
+      endDate: "2026-06-14",
+      id: "upcoming-soon",
+      startDate: "2026-06-08",
+    },
+  ];
+
+  it("groups plans into active, upcoming, and past", () => {
+    const partitioned = partitionMealPlansByTimeStatus(plans, today);
+
+    expect(partitioned.active.map((plan) => plan.id)).toEqual([
+      "active-later-start",
+      "active-earlier-start",
+    ]);
+    expect(partitioned.upcoming.map((plan) => plan.id)).toEqual([
+      "upcoming-soon",
+      "upcoming-later",
+    ]);
+    expect(partitioned.past.map((plan) => plan.id)).toEqual([
+      "past-recent",
+      "past-older",
+    ]);
+  });
+
+  it("returns empty groups when there are no plans", () => {
+    expect(partitionMealPlansByTimeStatus([], today)).toEqual({
+      active: [],
+      upcoming: [],
+      past: [],
+    });
   });
 });
 

--- a/app/lib/meal-plan-week.ts
+++ b/app/lib/meal-plan-week.ts
@@ -33,8 +33,73 @@ export function getTodayDateOnly(timeZone = "Europe/Oslo") {
   return formatDateOnlyInTimeZone(new Date(), timeZone);
 }
 
+export type MealPlanTimeStatus = "active" | "upcoming" | "past";
+
 export function isMealPlanPast(endDate: string, today = getTodayDateOnly()) {
   return endDate < today;
+}
+
+export function getMealPlanTimeStatus(
+  startDate: string,
+  endDate: string,
+  today = getTodayDateOnly(),
+): MealPlanTimeStatus {
+  if (isMealPlanPast(endDate, today)) {
+    return "past";
+  }
+
+  if (startDate > today) {
+    return "upcoming";
+  }
+
+  return "active";
+}
+
+export function partitionMealPlansByTimeStatus<T extends DateRange>(
+  plans: T[],
+  today = getTodayDateOnly(),
+) {
+  const active: T[] = [];
+  const upcoming: T[] = [];
+  const past: T[] = [];
+
+  for (const plan of plans) {
+    const status = getMealPlanTimeStatus(plan.startDate, plan.endDate, today);
+
+    if (status === "active") {
+      active.push(plan);
+    } else if (status === "upcoming") {
+      upcoming.push(plan);
+    } else {
+      past.push(plan);
+    }
+  }
+
+  active.sort((a, b) => {
+    if (a.startDate === b.startDate) {
+      return b.endDate.localeCompare(a.endDate);
+    }
+
+    return b.startDate.localeCompare(a.startDate);
+  });
+
+  upcoming.sort((a, b) => {
+    if (a.startDate === b.startDate) {
+      return a.endDate.localeCompare(b.endDate);
+    }
+
+    return a.startDate.localeCompare(b.startDate);
+  });
+
+  past.sort((a, b) => {
+    if (a.endDate === b.endDate) {
+      return b.startDate.localeCompare(a.startDate);
+    }
+
+    return b.endDate.localeCompare(a.endDate);
+  });
+
+  return { active, upcoming, past };
 }
 
 function getIsoWeekdayInTimeZone(date: Date, timeZone: string) {

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Form, Link, useNavigation, type MetaFunction } from "react-router";
 
 import { requireUser } from "../lib/auth.server";
@@ -10,6 +11,12 @@ import {
   listMealPlansForFamily,
 } from "../lib/meal-plan.server";
 import { MEAL_PLAN_MAX_SPAN_DAYS } from "../lib/meal-plan-dates";
+import {
+  partitionMealPlansByTimeStatus,
+  type MealPlanTimeStatus,
+} from "../lib/meal-plan-week";
+
+const PAST_MEAL_PLANS_VISIBLE_COUNT = 3;
 
 type MealPlanNotice =
   | "meal-plan-copied"
@@ -192,6 +199,7 @@ export default function FamilyMealPlansRoute({
   loaderData,
 }: MealPlanListRouteProps) {
   const navigation = useNavigation();
+  const [showAllPastMealPlans, setShowAllPastMealPlans] = useState(false);
   const noticeContent = loaderData.notice
     ? getMealPlanNoticeContent(loaderData.notice)
     : null;
@@ -207,6 +215,14 @@ export default function FamilyMealPlansRoute({
     actionData?.intent === "create-meal-plan"
       ? (actionData.values?.sourceMealPlanId ?? "")
       : "";
+  const partitionedMealPlans = partitionMealPlansByTimeStatus(
+    loaderData.mealPlans,
+  );
+  const visiblePastMealPlans = showAllPastMealPlans
+    ? partitionedMealPlans.past
+    : partitionedMealPlans.past.slice(0, PAST_MEAL_PLANS_VISIBLE_COUNT);
+  const hiddenPastMealPlanCount =
+    partitionedMealPlans.past.length - PAST_MEAL_PLANS_VISIBLE_COUNT;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -394,90 +410,110 @@ export default function FamilyMealPlansRoute({
                 Lagrede ukeplaner
               </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Velg en ukeplan for å redigere navn og datoer, eller slett
-                planer familien ikke trenger lenger.
+                Kommende planer vises før den aktive, deretter tidligere planer.
+                Åpne eller slett det familien ikke trenger lenger.
               </p>
             </div>
 
             {loaderData.mealPlans.length > 0 ? (
-              <div className="mt-6 grid gap-4">
-                {loaderData.mealPlans.map((mealPlan) => {
-                  const isPendingDelete =
-                    isDeletingMealPlan && pendingMealPlanId === mealPlan.id;
-                  const deleteError =
-                    actionData?.targetMealPlanId === mealPlan.id
-                      ? actionData.formError
-                      : undefined;
+              <div className="mt-6 grid gap-6">
+                {partitionedMealPlans.upcoming.length > 0 ? (
+                  <div className="grid gap-3">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Kommende
+                    </h3>
+                    <div className="grid gap-4">
+                      {partitionedMealPlans.upcoming.map((mealPlan) => (
+                        <MealPlanListCard
+                          key={mealPlan.id}
+                          deleteError={
+                            actionData?.targetMealPlanId === mealPlan.id
+                              ? actionData.formError
+                              : undefined
+                          }
+                          familyId={loaderData.family.id}
+                          isDeletingMealPlan={isDeletingMealPlan}
+                          isPendingDelete={
+                            isDeletingMealPlan &&
+                            pendingMealPlanId === mealPlan.id
+                          }
+                          mealPlan={mealPlan}
+                          timeStatus="upcoming"
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
 
-                  return (
-                    <article
-                      key={mealPlan.id}
-                      className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
-                    >
-                      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                        <div>
-                          <div className="flex flex-wrap items-center gap-3">
-                            <h3 className="text-base font-semibold text-slate-950">
-                              {mealPlan.title}
-                            </h3>
-                            <span
-                              className={
-                                mealPlan.status === "APPROVED"
-                                  ? "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-emerald-800 ring-1 ring-emerald-200"
-                                  : "rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200"
-                              }
-                            >
-                              {mealPlan.status === "APPROVED"
-                                ? "Godkjent"
-                                : "Utkast"}
-                            </span>
-                          </div>
-                          <p className="mt-2 text-sm leading-6 text-slate-600">
-                            {formatMealPlanWindow(
-                              mealPlan.startDate,
-                              mealPlan.endDate,
-                            )}
-                          </p>
-                        </div>
+                {partitionedMealPlans.active.length > 0 ? (
+                  <div className="grid gap-3">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-emerald-800">
+                      Aktiv
+                    </h3>
+                    <div className="grid gap-4">
+                      {partitionedMealPlans.active.map((mealPlan) => (
+                        <MealPlanListCard
+                          key={mealPlan.id}
+                          deleteError={
+                            actionData?.targetMealPlanId === mealPlan.id
+                              ? actionData.formError
+                              : undefined
+                          }
+                          familyId={loaderData.family.id}
+                          isDeletingMealPlan={isDeletingMealPlan}
+                          isPendingDelete={
+                            isDeletingMealPlan &&
+                            pendingMealPlanId === mealPlan.id
+                          }
+                          mealPlan={mealPlan}
+                          timeStatus="active"
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
 
-                        <div className="flex flex-wrap gap-3">
-                          <Link
-                            className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
-                            to={`/families/${loaderData.family.id}/meal-plans/${mealPlan.id}`}
-                          >
-                            Åpne ukeplan
-                          </Link>
-
-                          <Form method="post">
-                            <input
-                              name="intent"
-                              type="hidden"
-                              value="delete-meal-plan"
-                            />
-                            <input
-                              name="mealPlanId"
-                              type="hidden"
-                              value={mealPlan.id}
-                            />
-                            <button
-                              className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
-                              disabled={isDeletingMealPlan}
-                              type="submit"
-                            >
-                              {isPendingDelete ? "Sletter..." : "Slett"}
-                            </button>
-                          </Form>
-                        </div>
-                      </div>
-
-                      {deleteError ? (
-                        <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-                          {deleteError}
-                        </p>
-                      ) : null}
-                    </article>
-                  );
-                })}
+                {partitionedMealPlans.past.length > 0 ? (
+                  <div className="grid gap-3">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-400">
+                      Tidligere
+                    </h3>
+                    <div className="grid gap-4">
+                      {visiblePastMealPlans.map((mealPlan) => (
+                        <MealPlanListCard
+                          key={mealPlan.id}
+                          deleteError={
+                            actionData?.targetMealPlanId === mealPlan.id
+                              ? actionData.formError
+                              : undefined
+                          }
+                          familyId={loaderData.family.id}
+                          isDeletingMealPlan={isDeletingMealPlan}
+                          isPendingDelete={
+                            isDeletingMealPlan &&
+                            pendingMealPlanId === mealPlan.id
+                          }
+                          mealPlan={mealPlan}
+                          timeStatus="past"
+                        />
+                      ))}
+                    </div>
+                    {hiddenPastMealPlanCount > 0 ? (
+                      <button
+                        aria-expanded={showAllPastMealPlans}
+                        className="justify-self-start text-sm font-medium text-slate-600 underline decoration-slate-300 underline-offset-4 transition hover:text-slate-950"
+                        onClick={() =>
+                          setShowAllPastMealPlans((current) => !current)
+                        }
+                        type="button"
+                      >
+                        {showAllPastMealPlans
+                          ? "Vis færre"
+                          : `Vis flere (${hiddenPastMealPlanCount})`}
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
             ) : (
               <div className="mt-6 rounded-[24px] border border-dashed border-slate-300 bg-slate-50 px-5 py-6">
@@ -494,6 +530,115 @@ export default function FamilyMealPlansRoute({
         </section>
       </div>
     </main>
+  );
+}
+
+type MealPlanListItem = MealPlanListRouteProps["loaderData"]["mealPlans"][number];
+
+function MealPlanListCard({
+  deleteError,
+  familyId,
+  isDeletingMealPlan,
+  isPendingDelete,
+  mealPlan,
+  timeStatus,
+}: {
+  deleteError?: string;
+  familyId: string;
+  isDeletingMealPlan: boolean;
+  isPendingDelete: boolean;
+  mealPlan: MealPlanListItem;
+  timeStatus: MealPlanTimeStatus;
+}) {
+  const articleClassName =
+    timeStatus === "active"
+      ? "rounded-[24px] border border-emerald-200 bg-emerald-50 p-5 shadow-sm"
+      : timeStatus === "upcoming"
+        ? "rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+        : "rounded-[24px] border border-slate-200 bg-slate-50/70 p-5 opacity-90";
+  const titleClassName =
+    timeStatus === "past"
+      ? "text-base font-semibold text-slate-700"
+      : "text-base font-semibold text-slate-950";
+  const windowClassName =
+    timeStatus === "past"
+      ? "mt-2 text-sm leading-6 text-slate-500"
+      : "mt-2 text-sm leading-6 text-slate-600";
+  const openLinkClassName =
+    timeStatus === "active"
+      ? "inline-flex items-center justify-center rounded-2xl bg-emerald-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-emerald-950"
+      : timeStatus === "past"
+        ? "inline-flex items-center justify-center rounded-2xl bg-slate-700 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+        : "inline-flex items-center justify-center rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800";
+  const timeStatusBadge =
+    timeStatus === "active"
+      ? {
+          className:
+            "rounded-full bg-emerald-200 px-3 py-1 text-xs font-medium uppercase tracking-wide text-emerald-950 ring-1 ring-emerald-300",
+          label: "Aktiv",
+        }
+      : timeStatus === "upcoming"
+        ? {
+            className:
+              "rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-700 ring-1 ring-slate-200",
+            label: "Kommende",
+          }
+        : null;
+
+  return (
+    <article className={articleClassName}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-3">
+            <h3 className={titleClassName}>{mealPlan.title}</h3>
+            {timeStatusBadge ? (
+              <span className={timeStatusBadge.className}>
+                {timeStatusBadge.label}
+              </span>
+            ) : null}
+            <span
+              className={
+                mealPlan.status === "APPROVED"
+                  ? "rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-emerald-800 ring-1 ring-emerald-200"
+                  : "rounded-full bg-white px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200"
+              }
+            >
+              {mealPlan.status === "APPROVED" ? "Godkjent" : "Utkast"}
+            </span>
+          </div>
+          <p className={windowClassName}>
+            {formatMealPlanWindow(mealPlan.startDate, mealPlan.endDate)}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <Link
+            className={openLinkClassName}
+            to={`/families/${familyId}/meal-plans/${mealPlan.id}`}
+          >
+            Åpne ukeplan
+          </Link>
+
+          <Form method="post">
+            <input name="intent" type="hidden" value="delete-meal-plan" />
+            <input name="mealPlanId" type="hidden" value={mealPlan.id} />
+            <button
+              className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+              disabled={isDeletingMealPlan}
+              type="submit"
+            >
+              {isPendingDelete ? "Sletter..." : "Slett"}
+            </button>
+          </Form>
+        </div>
+      </div>
+
+      {deleteError ? (
+        <p className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {deleteError}
+        </p>
+      ) : null}
+    </article>
   );
 }
 


### PR DESCRIPTION
## Summary
- Groups Lagrede ukeplaner into Kommende → Aktiv → Tidligere based on date windows vs Oslo today
- Emphasizes the active plan visually; shows only the three most recent past plans until Vis flere
- Adds shared `getMealPlanTimeStatus` / `partitionMealPlansByTimeStatus` helpers with unit coverage

## Related issue
Closes #162

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck, build
- [ ] Family with upcoming + active + past plans: section order and styling look right
- [ ] More than three past plans: Vis flere / Vis færre expands and collapses
- [ ] Empty categories are omitted; zero plans still shows empty state
- [ ] Open and delete still work in each section
- [ ] Copy-from-existing select still lists all plans

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck
- npm run build