### PR TITLE
Auto-suggest Uke N titles from meal plan dates

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,32 @@
 
 ## Current Objective
 
-Issue #162 — Distinguish past, active, and upcoming meal plans under Lagrede ukeplaner, on branch `issue/162-distinguish-meal-plan-status`.
+Issue #164 — Auto-generate `Uke N` title from Opprett ukeplan date range, on branch `issue/164-auto-uke-title`.
 
 ## Completed
 
-- Added `getMealPlanTimeStatus` and `partitionMealPlansByTimeStatus` in `meal-plan-week.ts` (Oslo today, date-window classification).
-- Regrouped Lagrede ukeplaner into Kommende → Aktiv → Tidligere with visual hierarchy; past plans collapse after three behind Vis flere / Vis færre.
-- Active cards keep emerald emphasis; copy-from select remains a flat list of all plans.
+- Added `getIsoWeekNumber`, `formatMealPlanAutoTitle`, `resolveAutoMealPlanTitle`, and `getNextCalendarWeekBounds` in `meal-plan-week.ts`.
+- Prefills create form with next Oslo calendar week and syncs title from `startDate` unless the user customized it.
+- Reordered Opprett ukeplan to dates → Navn → source copy via controlled `CreateMealPlanForm`.
 
 ## Files To Read First
 
-- `app/lib/meal-plan-week.ts` — time-status helpers and partition/sort rules
-- `app/routes/family-meal-plans.tsx` — Lagrede ukeplaner sections and MealPlanListCard
-- `app/lib/meal-plan-week.test.ts` — classification and partition coverage
+- `app/lib/meal-plan-week.ts` — ISO week / auto-title helpers and next-week bounds
+- `app/routes/family-meal-plans.tsx` — `CreateMealPlanForm` and form field order
+- `app/lib/meal-plan-week.test.ts` — coverage for week number, title resolve, next week
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (344 tests)
+- `npm run test:run` — passed (354 tests)
 - `npm run typecheck` — passed
 - `npm run build` — passed
 
 ## Open Items
 
-- Manual UI smoke still useful: active + upcoming + >3 past (Vis flere), empty categories omitted, delete in each section
+- Manual UI smoke after merge: prefilled next week + title, customize title then change dates, clear title then change dates, validation re-show, create-from-copy
 
 ## Next Step
 
-Merge PR after CI is green (issue closes via `Closes #162`).
+Merge PR after CI is green (issue closes via `Closes #164`).

--- a/app/lib/meal-plan-week.test.ts
+++ b/app/lib/meal-plan-week.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   dateRangesOverlap,
   filterMealPlansOverlappingWeek,
+  formatMealPlanAutoTitle,
   getCalendarWeekBounds,
   getCalendarWeekDates,
+  getIsoWeekNumber,
   getMealPlanTimeStatus,
+  getNextCalendarWeekBounds,
   isMealPlanPast,
   partitionMealPlansByTimeStatus,
+  resolveAutoMealPlanTitle,
 } from "./meal-plan-week";
 
 describe("getCalendarWeekBounds", () => {
@@ -21,6 +25,86 @@ describe("getCalendarWeekBounds", () => {
       weekEnd: "2026-06-07",
       weekStart: "2026-06-01",
     });
+  });
+});
+
+describe("getNextCalendarWeekBounds", () => {
+  it("returns the Monday through Sunday after the current Oslo week", () => {
+    const bounds = getNextCalendarWeekBounds(
+      new Date("2026-06-04T12:00:00.000Z"),
+      "Europe/Oslo",
+    );
+
+    expect(bounds).toEqual({
+      weekEnd: "2026-06-14",
+      weekStart: "2026-06-08",
+    });
+  });
+});
+
+describe("getIsoWeekNumber", () => {
+  it("returns the ISO week for a mid-year date", () => {
+    expect(getIsoWeekNumber("2026-06-01")).toBe(23);
+  });
+
+  it("handles year-boundary weeks that belong to the next year", () => {
+    expect(getIsoWeekNumber("2025-12-29")).toBe(1);
+  });
+
+  it("handles year-boundary weeks that belong to the previous year", () => {
+    expect(getIsoWeekNumber("2027-01-03")).toBe(53);
+  });
+});
+
+describe("formatMealPlanAutoTitle", () => {
+  it("returns an empty string when startDate is missing", () => {
+    expect(formatMealPlanAutoTitle("")).toBe("");
+  });
+
+  it("formats the ISO week as Uke N", () => {
+    expect(formatMealPlanAutoTitle("2026-06-01")).toBe("Uke 23");
+  });
+});
+
+describe("resolveAutoMealPlanTitle", () => {
+  it("fills an empty title with the auto title", () => {
+    expect(
+      resolveAutoMealPlanTitle({
+        currentTitle: "",
+        previousAutoTitle: "Uke 22",
+        startDate: "2026-06-01",
+      }),
+    ).toBe("Uke 23");
+  });
+
+  it("updates the title when it still matches the previous auto title", () => {
+    expect(
+      resolveAutoMealPlanTitle({
+        currentTitle: "Uke 22",
+        previousAutoTitle: "Uke 22",
+        startDate: "2026-06-01",
+      }),
+    ).toBe("Uke 23");
+  });
+
+  it("preserves a customized title", () => {
+    expect(
+      resolveAutoMealPlanTitle({
+        currentTitle: "Familieferie",
+        previousAutoTitle: "Uke 22",
+        startDate: "2026-06-01",
+      }),
+    ).toBe("Familieferie");
+  });
+
+  it("restores the auto title after the user clears a customized title", () => {
+    expect(
+      resolveAutoMealPlanTitle({
+        currentTitle: "",
+        previousAutoTitle: "Uke 22",
+        startDate: "2026-06-08",
+      }),
+    ).toBe("Uke 24");
   });
 });
 

--- a/app/lib/meal-plan-week.ts
+++ b/app/lib/meal-plan-week.ts
@@ -131,6 +131,53 @@ export function getCalendarWeekBounds(
   };
 }
 
+export function getNextCalendarWeekBounds(
+  referenceDate = new Date(),
+  timeZone = "Europe/Oslo",
+): CalendarWeekBounds {
+  const currentWeek = getCalendarWeekBounds(referenceDate, timeZone);
+
+  return {
+    weekEnd: addDaysToDateOnly(currentWeek.weekEnd, 7),
+    weekStart: addDaysToDateOnly(currentWeek.weekStart, 7),
+  };
+}
+
+export function getIsoWeekNumber(dateOnly: string) {
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  const day = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+
+  return Math.ceil(((date.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+}
+
+export function formatMealPlanAutoTitle(startDate: string) {
+  if (!startDate) {
+    return "";
+  }
+
+  return `Uke ${getIsoWeekNumber(startDate)}`;
+}
+
+export function resolveAutoMealPlanTitle({
+  currentTitle,
+  previousAutoTitle,
+  startDate,
+}: {
+  currentTitle: string;
+  previousAutoTitle: string;
+  startDate: string;
+}) {
+  const nextAutoTitle = formatMealPlanAutoTitle(startDate);
+
+  if (currentTitle === "" || currentTitle === previousAutoTitle) {
+    return nextAutoTitle;
+  }
+
+  return currentTitle;
+}
+
 export function dateRangesOverlap(
   rangeAStart: string,
   rangeAEnd: string,

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -12,7 +12,10 @@ import {
 } from "../lib/meal-plan.server";
 import { MEAL_PLAN_MAX_SPAN_DAYS } from "../lib/meal-plan-dates";
 import {
+  formatMealPlanAutoTitle,
+  getNextCalendarWeekBounds,
   partitionMealPlansByTimeStatus,
+  resolveAutoMealPlanTitle,
   type MealPlanTimeStatus,
 } from "../lib/meal-plan-week";
 
@@ -211,10 +214,6 @@ export default function FamilyMealPlansRoute({
     navigation.state === "submitting" && pendingIntent === "create-meal-plan";
   const isDeletingMealPlan =
     navigation.state === "submitting" && pendingIntent === "delete-meal-plan";
-  const sourceMealPlanValue =
-    actionData?.intent === "create-meal-plan"
-      ? (actionData.values?.sourceMealPlanId ?? "")
-      : "";
   const partitionedMealPlans = partitionMealPlansByTimeStatus(
     loaderData.mealPlans,
   );
@@ -288,120 +287,19 @@ export default function FamilyMealPlansRoute({
                 Opprett ukeplan
               </h2>
               <p className="text-sm leading-6 text-slate-600">
-                Velg et navn og et datointervall på maks {MEAL_PLAN_MAX_SPAN_DAYS}{" "}
-                dager. Du kan starte fra en tom ukeplan eller gjenbruke middager
-                og notater fra en tidligere plan.
+                Velg datointervall (maks {MEAL_PLAN_MAX_SPAN_DAYS} dager). Navnet
+                foreslås som Uke-nummer fra startdatoen. Du kan starte tomt eller
+                gjenbruke middager og notater fra en tidligere plan.
               </p>
             </div>
 
-            <Form className="mt-6 space-y-4" method="post">
-              <input name="intent" type="hidden" value="create-meal-plan" />
-
-              <label className="block text-sm font-medium text-slate-700">
-                Navn
-                <input
-                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                  defaultValue={
-                    actionData?.intent === "create-meal-plan"
-                      ? (actionData.values?.title ?? "")
-                      : ""
-                  }
-                  name="title"
-                  placeholder="For eksempel Uke 20"
-                  type="text"
-                />
-              </label>
-
-              {actionData?.intent === "create-meal-plan" &&
-              actionData.fieldErrors?.title ? (
-                <p className="text-sm text-rose-600">
-                  {actionData.fieldErrors.title}
-                </p>
-              ) : null}
-
-              <label className="block text-sm font-medium text-slate-700">
-                Start med eksisterende ukeplan
-                <select
-                  className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                  defaultValue={sourceMealPlanValue}
-                  name="sourceMealPlanId"
-                >
-                  <option value="">Tom ukeplan</option>
-                  {loaderData.mealPlans.map((mealPlan) => (
-                    <option key={mealPlan.id} value={mealPlan.id}>
-                      {mealPlan.title} (
-                      {formatMealPlanWindow(
-                        mealPlan.startDate,
-                        mealPlan.endDate,
-                      )}
-                      )
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <p className="text-sm leading-6 text-slate-500">
-                Velg en tidligere ukeplan for å kopiere middager og notater til
-                samme relative dager i den nye perioden. Dager som faller utenfor
-                det nye intervallet blir ikke kopiert.
-              </p>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <label className="block text-sm font-medium text-slate-700">
-                  Startdato
-                  <input
-                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                    defaultValue={
-                      actionData?.intent === "create-meal-plan"
-                        ? (actionData.values?.startDate ?? "")
-                        : ""
-                    }
-                    name="startDate"
-                    type="date"
-                  />
-                </label>
-
-                <label className="block text-sm font-medium text-slate-700">
-                  Sluttdato
-                  <input
-                    className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
-                    defaultValue={
-                      actionData?.intent === "create-meal-plan"
-                        ? (actionData.values?.endDate ?? "")
-                        : ""
-                    }
-                    name="endDate"
-                    type="date"
-                  />
-                </label>
-              </div>
-
-              {actionData?.intent === "create-meal-plan" &&
-              actionData.fieldErrors?.startDate ? (
-                <p className="text-sm text-rose-600">
-                  {actionData.fieldErrors.startDate}
-                </p>
-              ) : null}
-              {actionData?.intent === "create-meal-plan" &&
-              actionData.fieldErrors?.endDate ? (
-                <p className="text-sm text-rose-600">
-                  {actionData.fieldErrors.endDate}
-                </p>
-              ) : null}
-              {actionData?.formError ? (
-                <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-                  {actionData.formError}
-                </p>
-              ) : null}
-
-              <button
-                className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-                disabled={isCreatingMealPlan}
-                type="submit"
-              >
-                {isCreatingMealPlan ? "Lagrer..." : "Opprett ukeplan"}
-              </button>
-            </Form>
+            <CreateMealPlanForm
+              actionData={
+                actionData?.intent === "create-meal-plan" ? actionData : undefined
+              }
+              isCreatingMealPlan={isCreatingMealPlan}
+              mealPlans={loaderData.mealPlans}
+            />
           </article>
 
           <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
@@ -534,6 +432,171 @@ export default function FamilyMealPlansRoute({
 }
 
 type MealPlanListItem = MealPlanListRouteProps["loaderData"]["mealPlans"][number];
+
+function getCreateMealPlanInitialState(actionData?: MealPlanActionData) {
+  if (actionData?.intent === "create-meal-plan") {
+    const startDate = actionData.values?.startDate ?? "";
+    const title = actionData.values?.title ?? "";
+    const autoTitle = formatMealPlanAutoTitle(startDate);
+
+    return {
+      endDate: actionData.values?.endDate ?? "",
+      previousAutoTitle: title === "" || title === autoTitle ? autoTitle : "",
+      sourceMealPlanId: actionData.values?.sourceMealPlanId ?? "",
+      startDate,
+      title,
+    };
+  }
+
+  const nextWeek = getNextCalendarWeekBounds();
+  const title = formatMealPlanAutoTitle(nextWeek.weekStart);
+
+  return {
+    endDate: nextWeek.weekEnd,
+    previousAutoTitle: title,
+    sourceMealPlanId: "",
+    startDate: nextWeek.weekStart,
+    title,
+  };
+}
+
+function CreateMealPlanForm({
+  actionData,
+  isCreatingMealPlan,
+  mealPlans,
+}: {
+  actionData?: MealPlanActionData;
+  isCreatingMealPlan: boolean;
+  mealPlans: MealPlanListItem[];
+}) {
+  const [formState, setFormState] = useState(() =>
+    getCreateMealPlanInitialState(actionData),
+  );
+  const { endDate, previousAutoTitle, sourceMealPlanId, startDate, title } =
+    formState;
+
+  function handleStartDateChange(nextStartDate: string) {
+    const nextTitle = resolveAutoMealPlanTitle({
+      currentTitle: title,
+      previousAutoTitle,
+      startDate: nextStartDate,
+    });
+    const nextAutoTitle = formatMealPlanAutoTitle(nextStartDate);
+
+    setFormState((current) => ({
+      ...current,
+      previousAutoTitle: nextAutoTitle,
+      startDate: nextStartDate,
+      title: nextTitle,
+    }));
+  }
+
+  return (
+    <Form className="mt-6 space-y-4" method="post">
+      <input name="intent" type="hidden" value="create-meal-plan" />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="block text-sm font-medium text-slate-700">
+          Startdato
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            name="startDate"
+            onChange={(event) => handleStartDateChange(event.target.value)}
+            type="date"
+            value={startDate}
+          />
+        </label>
+
+        <label className="block text-sm font-medium text-slate-700">
+          Sluttdato
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            name="endDate"
+            onChange={(event) =>
+              setFormState((current) => ({
+                ...current,
+                endDate: event.target.value,
+              }))
+            }
+            type="date"
+            value={endDate}
+          />
+        </label>
+      </div>
+
+      {actionData?.fieldErrors?.startDate ? (
+        <p className="text-sm text-rose-600">{actionData.fieldErrors.startDate}</p>
+      ) : null}
+      {actionData?.fieldErrors?.endDate ? (
+        <p className="text-sm text-rose-600">{actionData.fieldErrors.endDate}</p>
+      ) : null}
+
+      <label className="block text-sm font-medium text-slate-700">
+        Navn
+        <input
+          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+          name="title"
+          onChange={(event) =>
+            setFormState((current) => ({
+              ...current,
+              title: event.target.value,
+            }))
+          }
+          placeholder="For eksempel Uke 20"
+          type="text"
+          value={title}
+        />
+      </label>
+
+      {actionData?.fieldErrors?.title ? (
+        <p className="text-sm text-rose-600">{actionData.fieldErrors.title}</p>
+      ) : null}
+
+      <label className="block text-sm font-medium text-slate-700">
+        Start med eksisterende ukeplan
+        <select
+          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+          name="sourceMealPlanId"
+          onChange={(event) =>
+            setFormState((current) => ({
+              ...current,
+              sourceMealPlanId: event.target.value,
+            }))
+          }
+          value={sourceMealPlanId}
+        >
+          <option value="">Tom ukeplan</option>
+          {mealPlans.map((mealPlan) => (
+            <option key={mealPlan.id} value={mealPlan.id}>
+              {mealPlan.title} (
+              {formatMealPlanWindow(mealPlan.startDate, mealPlan.endDate)})
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <p className="text-sm leading-6 text-slate-500">
+        Velg en tidligere ukeplan for å kopiere middager og notater til samme
+        relative dager i den nye perioden. Dager som faller utenfor det nye
+        intervallet blir ikke kopiert.
+      </p>
+
+      {actionData?.formError ? (
+        <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {actionData.formError}
+        </p>
+      ) : null}
+
+      <button
+        className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+        disabled={isCreatingMealPlan}
+        type="submit"
+      >
+        {isCreatingMealPlan ? "Lagrer..." : "Opprett ukeplan"}
+      </button>
+    </Form>
+  );
+}
 
 function MealPlanListCard({
   deleteError,


### PR DESCRIPTION
## Summary
- Prefills Opprett ukeplan with the next Oslo calendar week and suggests `Uke N` from the start date ISO week number.
- Keeps a customized title when dates change; clearing the title allows auto-fill again.
- Reorders the form to dates → name → copy-from source for a faster create flow.

## Related issue
Closes #164

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck, build
- [ ] Open Opprett ukeplan → next week dates and matching `Uke N` are prefilled
- [ ] Change startdato → title updates when still auto
- [ ] Edit title, then change startdato → custom title is preserved
- [ ] Clear title, then change startdato → auto title returns
- [ ] Create empty plan and create-from-copy still work; validation errors re-show values

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck
- npm run build