### PR TITLE
Add editable product notes in store mode

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,34 @@
 
 ## Current Objective
 
-Issue #164 — Auto-generate `Uke N` title from Opprett ukeplan date range, on branch `issue/164-auto-uke-title`.
+Issue #166 — Editable product notes in store mode with visible toggleable note indicator, on branch `issue/166-store-mode-product-notes`.
 
 ## Completed
 
-- Added `getIsoWeekNumber`, `formatMealPlanAutoTitle`, `resolveAutoMealPlanTitle`, and `getNextCalendarWeekBounds` in `meal-plan-week.ts`.
-- Prefills create form with next Oslo calendar week and syncs title from `startDate` unless the user customized it.
-- Reordered Opprett ukeplan to dates → Navn → source copy via controlled `CreateMealPlanForm`.
+- Added debounced autosave Notat field under Endre seksjon for MANUAL/FAMILY store-mode cards.
+- Added Notat badge that toggles the details panel open/closed.
+- Stopped auto-opening details solely because a note exists.
+- Reused existing category-update intents (no new migration or action intents).
+- Extended store-mode route tests for note set/clear/preserve.
 
 ## Files To Read First
 
-- `app/lib/meal-plan-week.ts` — ISO week / auto-title helpers and next-week bounds
-- `app/routes/family-meal-plans.tsx` — `CreateMealPlanForm` and form field order
-- `app/lib/meal-plan-week.test.ts` — coverage for week number, title resolve, next week
+- `app/components/store-mode-shopping-item-card.tsx` — note UI, debounce, badge toggle, details open state
+- `app/routes/family-meal-plan-store-mode.tsx` — `handleUpdateCategory` already passes `note`
+- `app/routes/family-meal-plan-store-mode.test.ts` — note persistence coverage
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (354 tests)
+- `npm run test:run` — passed (358 tests)
 - `npm run typecheck` — passed
 - `npm run build` — passed
 
 ## Open Items
 
-- Manual UI smoke after merge: prefilled next week + title, customize title then change dates, clear title then change dates, validation re-show, create-from-copy
+- Manual UI smoke after merge: type note → badge appears → toggle open/close → clear note → badge gone; category change preserves note
 
 ## Next Step
 
-Merge PR after CI is green (issue closes via `Closes #164`).
+Merge PR after CI is green (issue closes via `Closes #166`).

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -97,6 +97,7 @@ interface StoreModeShoppingItemCardProps {
 }
 
 const badgeClass = "rounded-full px-2 py-0.5 text-[11px] font-medium leading-4";
+const NOTE_SAVE_DEBOUNCE_MS = 450;
 
 export function StoreModeShoppingItemCard({
   categories,
@@ -113,37 +114,61 @@ export function StoreModeShoppingItemCard({
 }: StoreModeShoppingItemCardProps) {
   const quantityBadge = formatGeneratedQuantityBadge(item);
   const shouldAutoOpenDetails = shouldAutoOpenStoreModeDetails(item);
+  const [isDetailsOpen, setIsDetailsOpen] = useState(shouldAutoOpenDetails);
   const [isQuantityModalOpen, setIsQuantityModalOpen] = useState(false);
   const [quantityDraft, setQuantityDraft] = useState(item.quantityLabel ?? "");
   const [categoryDraft, setCategoryDraft] = useState(item.category.id);
+  const [noteDraft, setNoteDraft] = useState(item.note ?? "");
   const quantityInputRef = useRef<HTMLInputElement>(null);
   const showCategoryEdit =
     item.sourceType === "FAMILY" || item.sourceType === "MANUAL";
+  const savedNote = item.note ?? "";
+  const hasNote = Boolean(noteDraft.trim());
+  const isNoteDirty = noteDraft.trim() !== savedNote.trim();
 
   useEffect(() => {
     setCategoryDraft(item.category.id);
   }, [item.category.id]);
 
   useEffect(() => {
+    setNoteDraft(item.note ?? "");
+    setCategoryDraft(item.category.id);
+    // Only reset drafts when the card switches to a different item.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- item.note/category sync is handled elsewhere so typing is not clobbered mid-save
+  }, [item.sourceKey]);
+
+  useEffect(() => {
+    const saved = item.note ?? "";
+    setNoteDraft((current) =>
+      current.trim() === saved.trim() ? saved : current,
+    );
+  }, [item.note]);
+
+  useEffect(() => {
+    if (shouldAutoOpenDetails) {
+      setIsDetailsOpen(true);
+    }
+  }, [shouldAutoOpenDetails]);
+
+  useEffect(() => {
     if (categoryError) {
       setCategoryDraft(item.category.id);
+      setNoteDraft(item.note ?? "");
     }
-  }, [categoryError, item.category.id]);
+  }, [categoryError, item.category.id, item.note]);
 
-  const handleCategoryChange = useCallback(
-    (nextCategoryId: string) => {
-      if (nextCategoryId === item.category.id || isSavingCategory) {
+  const submitItemFields = useCallback(
+    (next: { categoryId: string; note: string }) => {
+      if (isSavingCategory) {
         return;
       }
 
-      setCategoryDraft(nextCategoryId);
-
       if (item.sourceType === "FAMILY") {
         onUpdateCategory?.({
-          categoryId: nextCategoryId,
+          categoryId: next.categoryId,
           expectedUpdatedAt: item.collaborationVersion,
           name: item.name,
-          note: item.note ?? "",
+          note: next.note,
           preferredStoreId: item.preferredStore?.id ?? "",
           quantity: item.quantity?.trim() || item.quantityLabel || "",
           sourceKey: item.sourceKey,
@@ -159,11 +184,11 @@ export function StoreModeShoppingItemCard({
 
         onUpdateCategory?.({
           buyOnDate: item.buyOnDate ?? "",
-          categoryId: nextCategoryId,
+          categoryId: next.categoryId,
           expectedUpdatedAt: item.collaborationVersion,
           mealPlanId: item.mealPlanId,
           name: item.name,
-          note: item.note ?? "",
+          note: next.note,
           preferredStoreId: item.preferredStore?.id ?? "",
           quantity: item.quantity?.trim() || item.quantityLabel || "",
           sourceKey: item.sourceKey,
@@ -173,6 +198,45 @@ export function StoreModeShoppingItemCard({
     },
     [isSavingCategory, item, onUpdateCategory],
   );
+
+  const handleCategoryChange = useCallback(
+    (nextCategoryId: string) => {
+      if (nextCategoryId === item.category.id || isSavingCategory) {
+        return;
+      }
+
+      setCategoryDraft(nextCategoryId);
+      submitItemFields({
+        categoryId: nextCategoryId,
+        note: noteDraft,
+      });
+    },
+    [isSavingCategory, item.category.id, noteDraft, submitItemFields],
+  );
+
+  useEffect(() => {
+    if (!showCategoryEdit || !isNoteDirty || isSavingCategory) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      submitItemFields({
+        categoryId: categoryDraft,
+        note: noteDraft,
+      });
+    }, NOTE_SAVE_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    categoryDraft,
+    isNoteDirty,
+    isSavingCategory,
+    noteDraft,
+    showCategoryEdit,
+    submitItemFields,
+  ]);
 
   const cardStateClass = isRecentlyAdded
     ? "border-emerald-300 bg-emerald-100"
@@ -272,12 +336,34 @@ export function StoreModeShoppingItemCard({
                 Foretrekker {item.preferredStore.name}
               </span>
             ) : null}
+            {hasNote ? (
+              <button
+                aria-expanded={isDetailsOpen}
+                aria-label={
+                  isDetailsOpen
+                    ? `Skjul notat for ${item.name}`
+                    : `Vis notat for ${item.name}`
+                }
+                className={`${badgeClass} pointer-events-auto inline-flex items-center gap-1 bg-sky-100 text-sky-900 ring-1 ring-sky-200 transition hover:bg-sky-200/80`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setIsDetailsOpen((open) => !open);
+                }}
+                type="button"
+              >
+                <StoreModeNoteIcon className="h-3 w-3" />
+                Notat
+              </button>
+            ) : null}
           </span>
         </div>
 
         <details
           className="group mt-auto flex w-7 min-w-7 flex-col-reverse items-stretch self-start pointer-events-auto open:w-1/2 open:min-w-[50%] open:max-w-full"
-          open={shouldAutoOpenDetails}
+          onToggle={(event) => {
+            setIsDetailsOpen(event.currentTarget.open);
+          }}
+          open={isDetailsOpen}
         >
           <summary
             aria-label={`Vis informasjon om ${item.name}`}
@@ -294,7 +380,7 @@ export function StoreModeShoppingItemCard({
             <p className="break-words text-xs leading-4 text-stone-600">
               {formatStoreModeItemSourceLine(item)}
             </p>
-            {item.note ? (
+            {!showCategoryEdit && item.note ? (
               <p className="break-words text-xs leading-4 text-stone-700">
                 Notat: {item.note}
               </p>
@@ -318,6 +404,17 @@ export function StoreModeShoppingItemCard({
                       </option>
                     ))}
                   </select>
+                </label>
+                <label className="block text-xs font-medium text-stone-700">
+                  Notat
+                  <input
+                    aria-busy={isSavingCategory}
+                    className="mt-1 box-border w-full max-w-full min-w-0 rounded-xl border border-stone-300 bg-white px-3 py-2 text-sm text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60"
+                    onChange={(event) => setNoteDraft(event.currentTarget.value)}
+                    placeholder="F.eks. Tine lettmelk"
+                    type="text"
+                    value={noteDraft}
+                  />
                 </label>
                 {categoryError ? (
                   <p className="text-xs text-rose-600">{categoryError}</p>
@@ -410,10 +507,6 @@ export function StoreModeShoppingItemCard({
 }
 
 function shouldAutoOpenStoreModeDetails(item: StoreModeShoppingItemCardItem) {
-  if (item.note) {
-    return true;
-  }
-
   if (item.sourceType === "GENERATED" && item.postponedUntilDate) {
     return true;
   }
@@ -423,6 +516,37 @@ function shouldAutoOpenStoreModeDetails(item: StoreModeShoppingItemCardItem) {
   }
 
   return false;
+}
+
+function StoreModeNoteIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 4h7l3 3v13H7V4Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M14 4v3h3"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M9 12h6M9 16h4"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.75"
+      />
+    </svg>
+  );
 }
 
 function formatStoreModeItemSourceLine(item: StoreModeShoppingItemCardItem) {

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -682,6 +682,312 @@ describe("family store mode route", () => {
     });
   });
 
+  it("persists a note on manual item category update", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(resolveStoreModeAnchorMealPlan).mockResolvedValue({
+      id: "meal-plan-1",
+    });
+    vi.mocked(parseManualShoppingItemValues).mockReturnValue({
+      buyOnDate: "",
+      categoryId: "category-dairy",
+      name: "Melk",
+      note: "Tine lettmelk",
+      preferredStoreId: "",
+      quantity: "1",
+    });
+    vi.mocked(updateManualShoppingItem).mockResolvedValue({
+      status: "UPDATED",
+    });
+    vi.mocked(projectCreatedManualShoppingItem).mockResolvedValue({
+      buyOnDate: null,
+      category: { id: "category-dairy", name: "Meieri" },
+      checked: false,
+      collaborationVersion: "2026-05-31T00:00:00.000Z",
+      mealPlanId: "meal-plan-2",
+      mealPlanTitle: "Neste uke",
+      name: "Melk",
+      note: "Tine lettmelk",
+      overrideVersion: "",
+      preferredStore: null,
+      quantity: "1",
+      quantityLabel: "1",
+      section: { displayName: "Meieri", sortOrder: 1 },
+      sourceKey: "manual-item-1",
+      sourceType: "MANUAL",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-manual-shopping-item-category");
+    formData.set("sourceKey", "manual-item-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("categoryId", "category-dairy");
+    formData.set("name", "Melk");
+    formData.set("note", "Tine lettmelk");
+    formData.set("preferredStoreId", "");
+    formData.set("quantity", "1");
+    formData.set("buyOnDate", "");
+    formData.set("itemMealPlanId", "meal-plan-2");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(undefined, formData),
+    } as never);
+
+    expect(updateManualShoppingItem).toHaveBeenCalledWith({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      manualItemId: "manual-item-1",
+      mealPlanId: "meal-plan-2",
+      userId: "user-1",
+      values: {
+        buyOnDate: "",
+        categoryId: "category-dairy",
+        name: "Melk",
+        note: "Tine lettmelk",
+        preferredStoreId: "",
+        quantity: "1",
+      },
+    });
+    expect(result).toEqual({
+      intent: "update-manual-shopping-item-category",
+      item: {
+        buyOnDate: null,
+        category: { id: "category-dairy", name: "Meieri" },
+        checked: false,
+        collaborationVersion: "2026-05-31T00:00:00.000Z",
+        mealPlanId: "meal-plan-2",
+        mealPlanTitle: "Neste uke",
+        name: "Melk",
+        note: "Tine lettmelk",
+        overrideVersion: "",
+        preferredStore: null,
+        quantity: "1",
+        quantityLabel: "1",
+        section: { displayName: "Meieri", sortOrder: 1 },
+        sourceKey: "manual-item-1",
+        sourceType: "MANUAL",
+      },
+      ok: true,
+    });
+  });
+
+  it("clears a note on manual item category update", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(resolveStoreModeAnchorMealPlan).mockResolvedValue({
+      id: "meal-plan-1",
+    });
+    vi.mocked(parseManualShoppingItemValues).mockReturnValue({
+      buyOnDate: "",
+      categoryId: "category-dairy",
+      name: "Melk",
+      note: "",
+      preferredStoreId: "",
+      quantity: "1",
+    });
+    vi.mocked(updateManualShoppingItem).mockResolvedValue({
+      status: "UPDATED",
+    });
+    vi.mocked(projectCreatedManualShoppingItem).mockResolvedValue({
+      buyOnDate: null,
+      category: { id: "category-dairy", name: "Meieri" },
+      checked: false,
+      collaborationVersion: "2026-05-31T00:00:00.000Z",
+      mealPlanId: "meal-plan-2",
+      mealPlanTitle: "Neste uke",
+      name: "Melk",
+      note: null,
+      overrideVersion: "",
+      preferredStore: null,
+      quantity: "1",
+      quantityLabel: "1",
+      section: { displayName: "Meieri", sortOrder: 1 },
+      sourceKey: "manual-item-1",
+      sourceType: "MANUAL",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-manual-shopping-item-category");
+    formData.set("sourceKey", "manual-item-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("categoryId", "category-dairy");
+    formData.set("name", "Melk");
+    formData.set("note", "");
+    formData.set("preferredStoreId", "");
+    formData.set("quantity", "1");
+    formData.set("buyOnDate", "");
+    formData.set("itemMealPlanId", "meal-plan-2");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(undefined, formData),
+    } as never);
+
+    expect(updateManualShoppingItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({
+          note: "",
+        }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        intent: "update-manual-shopping-item-category",
+        item: expect.objectContaining({
+          note: null,
+        }),
+        ok: true,
+      }),
+    );
+  });
+
+  it("preserves an existing note when changing manual item category", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(resolveStoreModeAnchorMealPlan).mockResolvedValue({
+      id: "meal-plan-1",
+    });
+    vi.mocked(parseManualShoppingItemValues).mockReturnValue({
+      buyOnDate: "",
+      categoryId: "category-produce",
+      name: "Melk",
+      note: "Tine lettmelk",
+      preferredStoreId: "",
+      quantity: "1",
+    });
+    vi.mocked(updateManualShoppingItem).mockResolvedValue({
+      status: "UPDATED",
+    });
+    vi.mocked(projectCreatedManualShoppingItem).mockResolvedValue({
+      buyOnDate: null,
+      category: { id: "category-produce", name: "Frukt og gront" },
+      checked: false,
+      collaborationVersion: "2026-05-31T00:00:00.000Z",
+      mealPlanId: "meal-plan-2",
+      mealPlanTitle: "Neste uke",
+      name: "Melk",
+      note: "Tine lettmelk",
+      overrideVersion: "",
+      preferredStore: null,
+      quantity: "1",
+      quantityLabel: "1",
+      section: { displayName: "Frukt og gront", sortOrder: 1 },
+      sourceKey: "manual-item-1",
+      sourceType: "MANUAL",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-manual-shopping-item-category");
+    formData.set("sourceKey", "manual-item-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("categoryId", "category-produce");
+    formData.set("name", "Melk");
+    formData.set("note", "Tine lettmelk");
+    formData.set("preferredStoreId", "");
+    formData.set("quantity", "1");
+    formData.set("buyOnDate", "");
+    formData.set("itemMealPlanId", "meal-plan-2");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(undefined, formData),
+    } as never);
+
+    expect(updateManualShoppingItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({
+          categoryId: "category-produce",
+          note: "Tine lettmelk",
+        }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        item: expect.objectContaining({
+          category: expect.objectContaining({ id: "category-produce" }),
+          note: "Tine lettmelk",
+        }),
+        ok: true,
+      }),
+    );
+  });
+
+  it("persists a note on family item category update", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(resolveStoreModeAnchorMealPlan).mockResolvedValue({
+      id: "meal-plan-1",
+    });
+    vi.mocked(parseFamilyShoppingItemValues).mockReturnValue({
+      categoryId: "category-dairy",
+      name: "Melk",
+      note: "Helmelk",
+      preferredStoreId: "",
+      quantity: "1",
+    });
+    vi.mocked(updateFamilyShoppingItem).mockResolvedValue({
+      status: "UPDATED",
+    });
+    vi.mocked(projectCreatedFamilyShoppingItem).mockResolvedValue({
+      category: { id: "category-dairy", name: "Meieri" },
+      checked: false,
+      collaborationVersion: "2026-05-31T00:00:00.000Z",
+      mealPlanId: null,
+      mealPlanTitle: null,
+      name: "Melk",
+      note: "Helmelk",
+      preferredStore: null,
+      quantity: "1",
+      quantityLabel: "1",
+      section: { displayName: "Meieri", sortOrder: 1 },
+      sourceKey: "family-item-1",
+      sourceType: "FAMILY",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-family-shopping-item-category");
+    formData.set("sourceKey", "family-item-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("categoryId", "category-dairy");
+    formData.set("name", "Melk");
+    formData.set("note", "Helmelk");
+    formData.set("preferredStoreId", "");
+    formData.set("quantity", "1");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(undefined, formData),
+    } as never);
+
+    expect(updateFamilyShoppingItem).toHaveBeenCalledWith({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-dairy",
+        name: "Melk",
+        note: "Helmelk",
+        preferredStoreId: "",
+        quantity: "1",
+      },
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        intent: "update-family-shopping-item-category",
+        item: expect.objectContaining({
+          note: "Helmelk",
+        }),
+        ok: true,
+      }),
+    );
+  });
+
   it("uses itemMealPlanId when toggling meal-plan shopping items", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(resolveStoreModeAnchorMealPlan).mockResolvedValue({


### PR DESCRIPTION
## Summary
- Add a debounced autosave Notat field under Endre seksjon for MANUAL and FAMILY store-mode items
- Show a Notat badge when a note exists; clicking toggles the details panel open/closed
- Stop auto-opening details just because a note is present; reuse existing category-update write paths

## Related issue
Closes #166

## Test plan
- [ ] Open store mode, expand a manual item, type a note (e.g. “Tine lettmelk”) — saves without a Lagre button
- [ ] Collapse details — Notat badge visible; click to open, click again to close
- [ ] Clear the note — badge disappears after save
- [ ] Change section with an existing note — note still present after reload
- [ ] Validation run locally: lint, test:run, typecheck, build

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck
- npm run build