### PR TITLE
Add shopping check history in store mode

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,36 @@
 
 ## Current Objective
 
-Issue #166 — Editable product notes in store mode with visible toggleable note indicator, on branch `issue/166-store-mode-product-notes`.
+Issue #168 — Track who marks shopping items bought/not bought and show collapsible Handlehistorikk in store mode, on branch `issue/168-shopping-check-history`.
 
 ## Completed
 
-- Added debounced autosave Notat field under Endre seksjon for MANUAL/FAMILY store-mode cards.
-- Added Notat badge that toggles the details panel open/closed.
-- Stopped auto-opening details solely because a note exists.
-- Reused existing category-update intents (no new migration or action intents).
-- Extended store-mode route tests for note set/clear/preserve.
+- Added append-only `ShoppingItemCheckEvent` model + migration.
+- Record check events from family and meal-plan toggle helpers (including override delete-on-uncheck).
+- Store mode shows collapsed **Handlehistorikk** under **Før handledato**.
+- History query covers all meal plans in the store-mode trip (not only the anchor) plus family items.
+- Hardened Prisma client reuse so missing model delegates force a fresh client after `prisma generate`.
 
 ## Files To Read First
 
-- `app/components/store-mode-shopping-item-card.tsx` — note UI, debounce, badge toggle, details open state
-- `app/routes/family-meal-plan-store-mode.tsx` — `handleUpdateCategory` already passes `note`
-- `app/routes/family-meal-plan-store-mode.test.ts` — note persistence coverage
+- `app/lib/shopping-check-history.server.ts` — record/list history helpers
+- `app/lib/family-shopping-write.server.ts` / `app/lib/shopping-write.server.ts` — toggle write paths
+- `app/routes/family-meal-plan-store-mode.tsx` — Handlehistorikk UI + history loader call
+- `prisma/schema.prisma` — `ShoppingItemCheckEvent`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (358 tests)
+- `npm run test:run` — passed (367 tests)
 - `npm run typecheck` — passed
 - `npm run build` — passed
 
 ## Open Items
 
-- Manual UI smoke after merge: type note → badge appears → toggle open/close → clear note → badge gone; category change preserves note
+- After deploy: run migration `20260806100000_add_shopping_item_check_event`
+- Manual smoke: two family members toggle generated/manual/family items across included weeks → expand Handlehistorikk
 
 ## Next Step
 
-Merge PR after CI is green (issue closes via `Closes #166`).
+Merge PR after CI is green (issue closes via `Closes #168`).

--- a/app/lib/db.server.ts
+++ b/app/lib/db.server.ts
@@ -12,27 +12,35 @@ type PrismaClientWithRuntimeModel = PrismaClient & {
   };
 };
 
-const generatedModelSignature = buildGeneratedModelSignature();
-const cachedModelSignature = buildCachedModelSignature(globalForPrisma.__db);
-const shouldReuseCachedClient =
-  globalForPrisma.__db && cachedModelSignature === generatedModelSignature;
-
-if (globalForPrisma.__db && !shouldReuseCachedClient) {
-  void globalForPrisma.__db.$disconnect().catch(() => undefined);
-}
-
-export const db = shouldReuseCachedClient
-  ? globalForPrisma.__db!
-  : new PrismaClient({
-      datasources: {
-        db: {
-          url: env.DATABASE_URL,
-        },
-      },
-    });
+export const db = createDbClient();
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.__db = db;
+}
+
+function createDbClient() {
+  const generatedModelSignature = buildGeneratedModelSignature();
+  const cachedClient = globalForPrisma.__db;
+  const shouldReuseCachedClient =
+    Boolean(cachedClient) &&
+    buildCachedModelSignature(cachedClient) === generatedModelSignature &&
+    clientHasAllGeneratedDelegates(cachedClient);
+
+  if (cachedClient && !shouldReuseCachedClient) {
+    void cachedClient.$disconnect().catch(() => undefined);
+  }
+
+  if (shouldReuseCachedClient && cachedClient) {
+    return cachedClient;
+  }
+
+  return new PrismaClient({
+    datasources: {
+      db: {
+        url: env.DATABASE_URL,
+      },
+    },
+  });
 }
 
 function buildGeneratedModelSignature() {
@@ -43,14 +51,36 @@ function buildGeneratedModelSignature() {
 }
 
 function buildCachedModelSignature(client: PrismaClient | undefined) {
-  const runtimeModels = (client as PrismaClientWithRuntimeModel | undefined)?._runtimeDataModel?.models;
+  const runtimeModels = (client as PrismaClientWithRuntimeModel | undefined)
+    ?._runtimeDataModel?.models;
 
   if (!runtimeModels) {
     return null;
   }
 
   return Object.entries(runtimeModels)
-    .map(([modelName, model]) => `${modelName}:${(model.fields ?? []).map((field) => field.name).join(",")}`)
+    .map(
+      ([modelName, model]) =>
+        `${modelName}:${(model.fields ?? []).map((field) => field.name).join(",")}`,
+    )
     .sort()
     .join("|");
+}
+
+function clientHasAllGeneratedDelegates(client: PrismaClient | undefined) {
+  if (!client) {
+    return false;
+  }
+
+  return Prisma.dmmf.datamodel.models.every((model) => {
+    const delegateKey = modelNameToDelegateKey(model.name);
+    const delegate = (client as unknown as Record<string, { findMany?: unknown }>)[
+      delegateKey
+    ];
+    return typeof delegate?.findMany === "function";
+  });
+}
+
+function modelNameToDelegateKey(modelName: string) {
+  return modelName.charAt(0).toLowerCase() + modelName.slice(1);
 }

--- a/app/lib/family-shopping-write.server.test.ts
+++ b/app/lib/family-shopping-write.server.test.ts
@@ -1,8 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+const { dbMock, requireFamilyMembershipMock, transactionMock } = vi.hoisted(() => {
+  const transactionMock = {
+    familyShoppingItem: {
+      updateMany: vi.fn(),
+    },
+    shoppingItemCheckEvent: {
+      create: vi.fn(),
+    },
+  };
+
   return {
     dbMock: {
+      $transaction: vi.fn(),
       familyShoppingItem: {
         create: vi.fn(),
         deleteMany: vi.fn(),
@@ -18,6 +28,7 @@ const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
       },
     },
     requireFamilyMembershipMock: vi.fn(),
+    transactionMock,
   };
 });
 
@@ -54,6 +65,16 @@ describe("family-shopping-write.server", () => {
       id: "category-other",
     });
     dbMock.store.findFirst.mockResolvedValue(null);
+    dbMock.$transaction.mockImplementation(
+      async (callback: (tx: typeof transactionMock) => unknown) =>
+        callback(transactionMock),
+    );
+    transactionMock.familyShoppingItem.updateMany.mockResolvedValue({
+      count: 1,
+    });
+    transactionMock.shoppingItemCheckEvent.create.mockResolvedValue({
+      id: "check-event-1",
+    });
   });
 
   it("rejects empty family shopping item names", async () => {
@@ -106,9 +127,9 @@ describe("family-shopping-write.server", () => {
     dbMock.familyShoppingItem.findFirst.mockResolvedValue({
       checked: false,
       id: "family-item-1",
+      name: "Batterier",
       updatedAt: new Date("2026-05-10T00:00:00.000Z"),
     });
-    dbMock.familyShoppingItem.updateMany.mockResolvedValue({ count: 1 });
 
     const result = await toggleFamilyShoppingItemChecked({
       checked: true,
@@ -119,13 +140,75 @@ describe("family-shopping-write.server", () => {
     });
 
     expect(result).toEqual({ status: "UPDATED" });
-    expect(dbMock.familyShoppingItem.updateMany).toHaveBeenCalledWith(
+    expect(transactionMock.familyShoppingItem.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           checked: true,
         }),
       }),
     );
+    expect(transactionMock.shoppingItemCheckEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorUserId: "user-1",
+        checked: true,
+        familyId: "family-1",
+        itemName: "Batterier",
+        mealPlanId: null,
+        targetKey: "family-item-1",
+        targetType: "FAMILY_ITEM",
+      }),
+    });
+  });
+
+  it("records a history event when unchecking a family shopping item", async () => {
+    dbMock.familyShoppingItem.findFirst.mockResolvedValue({
+      checked: true,
+      id: "family-item-1",
+      name: "Batterier",
+      updatedAt: new Date("2026-05-10T00:00:00.000Z"),
+    });
+
+    const result = await toggleFamilyShoppingItemChecked({
+      checked: false,
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(transactionMock.shoppingItemCheckEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorUserId: "user-1",
+        checked: false,
+        itemName: "Batterier",
+        targetKey: "family-item-1",
+        targetType: "FAMILY_ITEM",
+      }),
+    });
+  });
+
+  it("does not record history when the family toggle conflicts", async () => {
+    dbMock.familyShoppingItem.findFirst.mockResolvedValue({
+      checked: false,
+      id: "family-item-1",
+      name: "Batterier",
+      updatedAt: new Date("2026-05-10T00:00:00.000Z"),
+    });
+    transactionMock.familyShoppingItem.updateMany.mockResolvedValue({
+      count: 0,
+    });
+
+    const result = await toggleFamilyShoppingItemChecked({
+      checked: true,
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      familyItemId: "family-item-1",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("CONFLICT");
+    expect(transactionMock.shoppingItemCheckEvent.create).not.toHaveBeenCalled();
   });
 
   it("quick-add delegates to manual resolver before creating", async () => {

--- a/app/lib/family-shopping-write.server.ts
+++ b/app/lib/family-shopping-write.server.ts
@@ -6,6 +6,7 @@ import {
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
+import { recordShoppingCheckEvent } from "./shopping-check-history.server";
 import {
   buildRecentManualItemFromProjectedItem,
   projectCreatedFamilyShoppingItem,
@@ -388,6 +389,7 @@ export async function toggleFamilyShoppingItemChecked({
     select: {
       checked: true,
       id: true,
+      name: true,
       updatedAt: true,
     },
     where: {
@@ -411,19 +413,42 @@ export async function toggleFamilyShoppingItemChecked({
     });
   }
 
-  const updateResult = await db.familyShoppingItem.updateMany({
-    data: {
+  const outcome = await db.$transaction(async (tx) => {
+    const updateResult = await tx.familyShoppingItem.updateMany({
+      data: {
+        checked,
+        ...buildActorUpdate(userId),
+      },
+      where: {
+        familyId,
+        id: existingItem.id,
+        updatedAt: existingItem.updatedAt,
+      },
+    });
+
+    if (updateResult.count === 0) {
+      return {
+        status: "CONFLICT" as const,
+      };
+    }
+
+    await recordShoppingCheckEvent(tx, {
+      actorUserId: userId,
       checked,
-      ...buildActorUpdate(userId),
-    },
-    where: {
       familyId,
-      id: existingItem.id,
-      updatedAt: existingItem.updatedAt,
-    },
+      itemName: existingItem.name,
+      mealPlanId: null,
+      sourceType: null,
+      targetKey: existingItem.id,
+      targetType: "FAMILY_ITEM",
+    });
+
+    return {
+      status: "UPDATED" as const,
+    };
   });
 
-  if (updateResult.count === 0) {
+  if (outcome.status === "CONFLICT") {
     return buildFamilyShoppingConflictResult({
       action: "toggle-family-shopping-item-checked",
       entityId: existingItem.id,

--- a/app/lib/shopping-check-history.server.test.ts
+++ b/app/lib/shopping-check-history.server.test.ts
@@ -1,0 +1,169 @@
+import { ShoppingItemSource } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock } = vi.hoisted(() => ({
+  dbMock: {
+    shoppingItemCheckEvent: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+import {
+  listShoppingCheckHistoryForStoreMode,
+  recordShoppingCheckEvent,
+  resolveMealPlanShoppingItemName,
+  SHOPPING_CHECK_HISTORY_LIMIT,
+} from "./shopping-check-history.server";
+
+describe("shopping-check-history.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("records a shopping check event with a trimmed item name", async () => {
+    dbMock.shoppingItemCheckEvent.create.mockResolvedValue({
+      id: "event-1",
+    });
+
+    await recordShoppingCheckEvent(dbMock as never, {
+      actorUserId: "user-1",
+      checked: true,
+      familyId: "family-1",
+      itemName: "  Melk  ",
+      mealPlanId: null,
+      sourceType: null,
+      targetKey: "family-item-1",
+      targetType: "FAMILY_ITEM",
+    });
+
+    expect(dbMock.shoppingItemCheckEvent.create).toHaveBeenCalledWith({
+      data: {
+        actorUserId: "user-1",
+        checked: true,
+        familyId: "family-1",
+        itemName: "Melk",
+        mealPlanId: null,
+        sourceType: null,
+        targetKey: "family-item-1",
+        targetType: "FAMILY_ITEM",
+      },
+    });
+  });
+
+  it("resolves manual item names from the meal plan", async () => {
+    const client = {
+      manualShoppingItem: {
+        findFirst: vi.fn().mockResolvedValue({ name: "Kaffe" }),
+      },
+      recipeIngredient: {
+        findUnique: vi.fn(),
+      },
+    };
+
+    await expect(
+      resolveMealPlanShoppingItemName(client as never, {
+        mealPlanId: "meal-plan-1",
+        sourceKey: "manual-1",
+        sourceType: ShoppingItemSource.MANUAL,
+      }),
+    ).resolves.toBe("Kaffe");
+  });
+
+  it("resolves generated item names from the first occurrence key", async () => {
+    const client = {
+      manualShoppingItem: {
+        findFirst: vi.fn(),
+      },
+      recipeIngredient: {
+        findUnique: vi.fn().mockResolvedValue({ displayName: "Paprika" }),
+      },
+    };
+
+    await expect(
+      resolveMealPlanShoppingItemName(client as never, {
+        mealPlanId: "meal-plan-1",
+        sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2",
+        sourceType: ShoppingItemSource.GENERATED,
+      }),
+    ).resolves.toBe("Paprika");
+
+    expect(client.recipeIngredient.findUnique).toHaveBeenCalledWith({
+      select: {
+        displayName: true,
+      },
+      where: {
+        id: "ingredient-1",
+      },
+    });
+  });
+
+  it("lists capped store-mode history newest first", async () => {
+    dbMock.shoppingItemCheckEvent.findMany.mockResolvedValue([
+      {
+        actorUser: { displayName: "Sindre" },
+        checked: true,
+        createdAt: new Date("2026-05-16T10:00:00.000Z"),
+        id: "event-1",
+        itemName: "Melk",
+        sourceType: null,
+        targetKey: "family-item-1",
+        targetType: "FAMILY_ITEM",
+      },
+      {
+        actorUser: { displayName: "Kari" },
+        checked: false,
+        createdAt: new Date("2026-05-16T09:00:00.000Z"),
+        id: "event-2",
+        itemName: "Paprika",
+        sourceType: ShoppingItemSource.GENERATED,
+        targetKey: "entry-1:ingredient-1",
+        targetType: "MEAL_PLAN_ITEM",
+      },
+    ]);
+
+    const history = await listShoppingCheckHistoryForStoreMode({
+      familyId: "family-1",
+      mealPlanIds: ["meal-plan-1", "meal-plan-2"],
+    });
+
+    expect(dbMock.shoppingItemCheckEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        take: SHOPPING_CHECK_HISTORY_LIMIT,
+        where: {
+          familyId: "family-1",
+          OR: [
+            { mealPlanId: { in: ["meal-plan-1", "meal-plan-2"] } },
+            { targetType: "FAMILY_ITEM" },
+          ],
+        },
+      }),
+    );
+    expect(history).toEqual([
+      {
+        actorDisplayName: "Sindre",
+        checked: true,
+        id: "event-1",
+        itemName: "Melk",
+        occurredAt: "2026-05-16T10:00:00.000Z",
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+      {
+        actorDisplayName: "Kari",
+        checked: false,
+        id: "event-2",
+        itemName: "Paprika",
+        occurredAt: "2026-05-16T09:00:00.000Z",
+        sourceKey: "entry-1:ingredient-1",
+        sourceType: "GENERATED",
+      },
+    ]);
+  });
+});

--- a/app/lib/shopping-check-history.server.ts
+++ b/app/lib/shopping-check-history.server.ts
@@ -1,0 +1,174 @@
+import type { Prisma, ShoppingItemSource } from "@prisma/client";
+
+import { db } from "./db.server";
+
+export const SHOPPING_CHECK_HISTORY_LIMIT = 100;
+
+const FALLBACK_ITEM_NAME = "Ukjent vare";
+
+type DbClient = Prisma.TransactionClient | typeof db;
+
+type ShoppingCheckEventTarget = "FAMILY_ITEM" | "MEAL_PLAN_ITEM";
+
+export type ShoppingHistoryEntry = {
+  actorDisplayName: string;
+  checked: boolean;
+  id: string;
+  itemName: string;
+  occurredAt: string;
+  sourceKey: string;
+  sourceType: "FAMILY" | "GENERATED" | "MANUAL";
+};
+
+export async function recordShoppingCheckEvent(
+  client: DbClient,
+  {
+    actorUserId,
+    checked,
+    familyId,
+    itemName,
+    mealPlanId,
+    sourceType,
+    targetKey,
+    targetType,
+  }: {
+    actorUserId: string;
+    checked: boolean;
+    familyId: string;
+    itemName: string;
+    mealPlanId?: string | null;
+    sourceType?: ShoppingItemSource | null;
+    targetKey: string;
+    targetType: ShoppingCheckEventTarget;
+  },
+) {
+  const trimmedName = itemName.trim();
+
+  await client.shoppingItemCheckEvent.create({
+    data: {
+      actorUserId,
+      checked,
+      familyId,
+      itemName: trimmedName.length > 0 ? trimmedName : FALLBACK_ITEM_NAME,
+      mealPlanId: mealPlanId ?? null,
+      sourceType: sourceType ?? null,
+      targetKey,
+      targetType,
+    },
+  });
+}
+
+export async function resolveMealPlanShoppingItemName(
+  client: DbClient,
+  {
+    mealPlanId,
+    sourceKey,
+    sourceType,
+  }: {
+    mealPlanId: string;
+    sourceKey: string;
+    sourceType: ShoppingItemSource;
+  },
+) {
+  if (sourceType === "MANUAL") {
+    const manualItem = await client.manualShoppingItem.findFirst({
+      select: {
+        name: true,
+      },
+      where: {
+        id: sourceKey,
+        mealPlanId,
+      },
+    });
+
+    return manualItem?.name.trim() || FALLBACK_ITEM_NAME;
+  }
+
+  const firstOccurrenceKey = sourceKey.split("|")[0] ?? "";
+  const separatorIndex = firstOccurrenceKey.indexOf(":");
+
+  if (separatorIndex === -1) {
+    return FALLBACK_ITEM_NAME;
+  }
+
+  const recipeIngredientId = firstOccurrenceKey.slice(separatorIndex + 1);
+
+  if (!recipeIngredientId) {
+    return FALLBACK_ITEM_NAME;
+  }
+
+  const recipeIngredient = await client.recipeIngredient.findUnique({
+    select: {
+      displayName: true,
+    },
+    where: {
+      id: recipeIngredientId,
+    },
+  });
+
+  return recipeIngredient?.displayName.trim() || FALLBACK_ITEM_NAME;
+}
+
+export async function listShoppingCheckHistoryForStoreMode({
+  familyId,
+  mealPlanIds,
+}: {
+  familyId: string;
+  mealPlanIds: string[];
+}): Promise<ShoppingHistoryEntry[]> {
+  const uniqueMealPlanIds = [...new Set(mealPlanIds.filter(Boolean))];
+
+  const events = await db.shoppingItemCheckEvent.findMany({
+    include: {
+      actorUser: {
+        select: {
+          displayName: true,
+        },
+      },
+    },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: SHOPPING_CHECK_HISTORY_LIMIT,
+    where: {
+      familyId,
+      OR: [
+        ...(uniqueMealPlanIds.length > 0
+          ? [
+              {
+                mealPlanId: {
+                  in: uniqueMealPlanIds,
+                },
+              },
+            ]
+          : []),
+        {
+          targetType: "FAMILY_ITEM",
+        },
+      ],
+    },
+  });
+
+  return events.map((event) => ({
+    actorDisplayName: event.actorUser.displayName,
+    checked: event.checked,
+    id: event.id,
+    itemName: event.itemName,
+    occurredAt: event.createdAt.toISOString(),
+    sourceKey: event.targetKey,
+    sourceType: mapHistorySourceType(event.targetType, event.sourceType),
+  }));
+}
+
+function mapHistorySourceType(
+  targetType: ShoppingCheckEventTarget,
+  sourceType: ShoppingItemSource | null,
+): ShoppingHistoryEntry["sourceType"] {
+  if (targetType === "FAMILY_ITEM") {
+    return "FAMILY";
+  }
+
+  if (sourceType === "MANUAL") {
+    return "MANUAL";
+  }
+
+  return "GENERATED";
+}

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -13,9 +13,18 @@ const {
   const transactionMock = {
     manualShoppingItem: {
       delete: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    recipeIngredient: {
+      findUnique: vi.fn(),
+    },
+    shoppingItemCheckEvent: {
+      create: vi.fn(),
     },
     shoppingItemOverride: {
+      create: vi.fn(),
       deleteMany: vi.fn(),
+      updateMany: vi.fn(),
     },
   };
 
@@ -151,6 +160,24 @@ describe("shopping-write.server", () => {
     dbMock.$transaction.mockImplementation(async (callback: (tx: typeof transactionMock) => unknown) =>
       callback(transactionMock),
     );
+    transactionMock.shoppingItemOverride.create.mockResolvedValue({
+      id: "override-created",
+    });
+    transactionMock.shoppingItemOverride.deleteMany.mockResolvedValue({
+      count: 1,
+    });
+    transactionMock.shoppingItemOverride.updateMany.mockResolvedValue({
+      count: 1,
+    });
+    transactionMock.shoppingItemCheckEvent.create.mockResolvedValue({
+      id: "check-event-1",
+    });
+    transactionMock.manualShoppingItem.findFirst.mockResolvedValue({
+      name: "Kaffe",
+    });
+    transactionMock.recipeIngredient.findUnique.mockResolvedValue({
+      displayName: "Paprika",
+    });
   });
 
   it("returns manual item validation errors before writing", async () => {
@@ -529,15 +556,89 @@ describe("shopping-write.server", () => {
     expect(result).toEqual({
       status: "UPDATED",
     });
-    expect(dbMock.shoppingItemOverride.deleteMany).toHaveBeenCalledWith({
+    expect(transactionMock.shoppingItemOverride.deleteMany).toHaveBeenCalledWith({
       where: {
         id: "override-1",
         updatedAt: new Date("2026-05-15T00:00:00.000Z"),
       },
     });
-    expect(dbMock.shoppingItemOverride.updateMany).not.toHaveBeenCalled();
+    expect(transactionMock.shoppingItemOverride.updateMany).not.toHaveBeenCalled();
+    expect(transactionMock.shoppingItemCheckEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorUserId: "user-1",
+        checked: false,
+        familyId: "family-1",
+        itemName: "Kaffe",
+        mealPlanId: "meal-plan-1",
+        sourceType: ShoppingItemSource.MANUAL,
+        targetKey: "manual-item-1",
+        targetType: "MEAL_PLAN_ITEM",
+      }),
+    });
   });
 
+  it("records history when checking a generated shopping item", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue(null);
+
+    const result = await toggleShoppingItemChecked({
+      checked: true,
+      expectedUpdatedAt: "",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "entry-1:ingredient-1",
+      sourceType: ShoppingItemSource.GENERATED,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(transactionMock.shoppingItemOverride.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        checked: true,
+        sourceKey: "entry-1:ingredient-1",
+        sourceType: ShoppingItemSource.GENERATED,
+      }),
+    });
+    expect(transactionMock.recipeIngredient.findUnique).toHaveBeenCalledWith({
+      select: {
+        displayName: true,
+      },
+      where: {
+        id: "ingredient-1",
+      },
+    });
+    expect(transactionMock.shoppingItemCheckEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        actorUserId: "user-1",
+        checked: true,
+        itemName: "Paprika",
+        sourceType: ShoppingItemSource.GENERATED,
+        targetKey: "entry-1:ingredient-1",
+        targetType: "MEAL_PLAN_ITEM",
+      }),
+    });
+  });
+
+  it("does not record history for no-op uncheck without an override", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue(null);
+
+    const result = await toggleShoppingItemChecked({
+      checked: false,
+      expectedUpdatedAt: "",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "entry-1:ingredient-1",
+      sourceType: ShoppingItemSource.GENERATED,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.$transaction).not.toHaveBeenCalled();
+    expect(transactionMock.shoppingItemCheckEvent.create).not.toHaveBeenCalled();
+  });
   it("upserts generated override fields while preserving checked state", async () => {
     dbMock.store.findFirst.mockResolvedValue({
       id: "store-2",

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -9,6 +9,10 @@ import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import {
+  recordShoppingCheckEvent,
+  resolveMealPlanShoppingItemName,
+} from "./shopping-check-history.server";
+import {
   buildRecentManualItemFromProjectedItem,
   getStockIngredientsForMealPlan,
   loadShoppingMealPlan,
@@ -820,46 +824,70 @@ export async function toggleShoppingItemChecked({
         };
       }
 
-      if (shouldDeleteOverrideAfterUnchecked(existingOverride)) {
-        const deleteResult = await db.shoppingItemOverride.deleteMany({
-          where: {
-            id: existingOverride.id,
-            updatedAt: existingOverride.updatedAt,
-          },
+      const outcome = await db.$transaction(async (tx) => {
+        if (shouldDeleteOverrideAfterUnchecked(existingOverride)) {
+          const deleteResult = await tx.shoppingItemOverride.deleteMany({
+            where: {
+              id: existingOverride.id,
+              updatedAt: existingOverride.updatedAt,
+            },
+          });
+
+          if (deleteResult.count === 0) {
+            return {
+              status: "CONFLICT" as const,
+            };
+          }
+        } else {
+          const updateResult = await tx.shoppingItemOverride.updateMany({
+            data: {
+              checked: false,
+              ...buildActorUpdate(userId),
+            },
+            where: {
+              id: existingOverride.id,
+              updatedAt: existingOverride.updatedAt,
+            },
+          });
+
+          if (updateResult.count === 0) {
+            return {
+              status: "CONFLICT" as const,
+            };
+          }
+        }
+
+        const itemName = await resolveMealPlanShoppingItemName(tx, {
+          mealPlanId: mealPlan.id,
+          sourceKey,
+          sourceType,
         });
 
-        if (deleteResult.count === 0) {
-          return buildShoppingConflictResult({
-            action: "toggle-shopping-item-checked",
-            entityId: existingOverride.id,
-            entityType: "shopping-item-override",
-            familyId,
-            mealPlanId: mealPlan.id,
-            userId,
-          });
-        }
-      } else {
-        const updateResult = await db.shoppingItemOverride.updateMany({
-          data: {
-            checked: false,
-            ...buildActorUpdate(userId),
-          },
-          where: {
-            id: existingOverride.id,
-            updatedAt: existingOverride.updatedAt,
-          },
+        await recordShoppingCheckEvent(tx, {
+          actorUserId: userId,
+          checked: false,
+          familyId,
+          itemName,
+          mealPlanId: mealPlan.id,
+          sourceType,
+          targetKey: sourceKey,
+          targetType: "MEAL_PLAN_ITEM",
         });
 
-        if (updateResult.count === 0) {
-          return buildShoppingConflictResult({
-            action: "toggle-shopping-item-checked",
-            entityId: existingOverride.id,
-            entityType: "shopping-item-override",
-            familyId,
-            mealPlanId: mealPlan.id,
-            userId,
-          });
-        }
+        return {
+          status: "UPDATED" as const,
+        };
+      });
+
+      if (outcome.status === "CONFLICT") {
+        return buildShoppingConflictResult({
+          action: "toggle-shopping-item-checked",
+          entityId: existingOverride.id,
+          entityType: "shopping-item-override",
+          familyId,
+          mealPlanId: mealPlan.id,
+          userId,
+        });
       }
 
       logCollaborationWrite({
@@ -878,37 +906,66 @@ export async function toggleShoppingItemChecked({
       };
     }
 
-    if (existingOverride) {
-      const updateResult = await db.shoppingItemOverride.updateMany({
-        data: {
-          checked: true,
-          ...buildActorUpdate(userId),
-        },
-        where: {
-          id: existingOverride.id,
-          updatedAt: existingOverride.updatedAt,
-        },
-      });
+    const outcome = await db.$transaction(async (tx) => {
+      if (existingOverride) {
+        const updateResult = await tx.shoppingItemOverride.updateMany({
+          data: {
+            checked: true,
+            ...buildActorUpdate(userId),
+          },
+          where: {
+            id: existingOverride.id,
+            updatedAt: existingOverride.updatedAt,
+          },
+        });
 
-      if (updateResult.count === 0) {
-        return buildShoppingConflictResult({
-          action: "toggle-shopping-item-checked",
-          entityId: existingOverride.id,
-          entityType: "shopping-item-override",
-          familyId,
-          mealPlanId: mealPlan.id,
-          userId,
+        if (updateResult.count === 0) {
+          return {
+            status: "CONFLICT" as const,
+          };
+        }
+      } else {
+        await tx.shoppingItemOverride.create({
+          data: {
+            checked: true,
+            mealPlanId: mealPlan.id,
+            sourceKey,
+            sourceType,
+            ...buildActorUpdate(userId),
+          },
         });
       }
-    } else {
-      await db.shoppingItemOverride.create({
-        data: {
-          checked: true,
-          mealPlanId: mealPlan.id,
-          sourceKey,
-          sourceType,
-          ...buildActorUpdate(userId),
-        },
+
+      const itemName = await resolveMealPlanShoppingItemName(tx, {
+        mealPlanId: mealPlan.id,
+        sourceKey,
+        sourceType,
+      });
+
+      await recordShoppingCheckEvent(tx, {
+        actorUserId: userId,
+        checked: true,
+        familyId,
+        itemName,
+        mealPlanId: mealPlan.id,
+        sourceType,
+        targetKey: sourceKey,
+        targetType: "MEAL_PLAN_ITEM",
+      });
+
+      return {
+        status: "UPDATED" as const,
+      };
+    });
+
+    if (outcome.status === "CONFLICT") {
+      return buildShoppingConflictResult({
+        action: "toggle-shopping-item-checked",
+        entityId: existingOverride?.id ?? sourceKey,
+        entityType: "shopping-item-override",
+        familyId,
+        mealPlanId: mealPlan.id,
+        userId,
       });
     }
 

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -22,6 +22,9 @@ const {
           findFirst: vi.fn(),
           findMany: vi.fn(),
         },
+        shoppingItemCheckEvent: {
+          findMany: vi.fn(),
+        },
         store: {
           findMany: vi.fn(),
         },
@@ -89,6 +92,7 @@ describe("shopping.server", () => {
     });
     dbMock.userStorePreference.findUnique.mockResolvedValue(null);
     dbMock.familyShoppingItem.findMany.mockResolvedValue([]);
+    dbMock.shoppingItemCheckEvent.findMany.mockResolvedValue([]);
     dbMock.mealPlan.findMany.mockResolvedValue([
       {
         endDate: new Date("2026-05-18T00:00:00.000Z"),

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -22,6 +22,12 @@ vi.mock("../lib/shopping.server", () => {
   };
 });
 
+vi.mock("../lib/shopping-check-history.server", () => {
+  return {
+    listShoppingCheckHistoryForStoreMode: vi.fn(),
+  };
+});
+
 vi.mock("../lib/family-shopping-write.server", () => {
   return {
     createQuickFamilyShoppingItem: vi.fn(),
@@ -63,6 +69,7 @@ import {
 } from "../lib/family-shopping-write.server";
 import { requireUser } from "../lib/auth.server";
 import { resolveStoreModeAnchorMealPlan } from "../lib/meal-plan-for-date.server";
+import { listShoppingCheckHistoryForStoreMode } from "../lib/shopping-check-history.server";
 import {
   getFamilyStoreModeData,
   listRecentManualShoppingItemsForFamily,
@@ -222,6 +229,7 @@ describe("family store mode route", () => {
       ],
       visibleDates: ["2026-05-15", "2026-05-16", "2026-05-17", "2026-05-18"],
     });
+    vi.mocked(listShoppingCheckHistoryForStoreMode).mockResolvedValue([]);
 
     const result = await loader({
       params: {
@@ -234,6 +242,10 @@ describe("family store mode route", () => {
       familyId: "family-1",
       userId: "user-1",
     });
+    expect(listShoppingCheckHistoryForStoreMode).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanIds: ["meal-plan-1"],
+    });
     expect(listRecentManualShoppingItemsForFamily).toHaveBeenCalledWith({
       familyId: "family-1",
     });
@@ -244,6 +256,7 @@ describe("family store mode route", () => {
         id: "category-dairy",
       },
     ]);
+    expect(result.shoppingHistory).toEqual([]);
     expect(result.recentManualItems).toEqual([
       {
         categoryId: "",
@@ -278,6 +291,87 @@ describe("family store mode route", () => {
         name: "Paprika",
       }),
     );
+  });
+
+  it("passes shopping history through the store-mode loader", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([]);
+    vi.mocked(listIngredientCategories).mockResolvedValue([]);
+    vi.mocked(getFamilyStoreModeData).mockResolvedValue({
+      activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
+      dueSectionGroups: [],
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      includedMealPlans: [
+        {
+          id: "meal-plan-1",
+          status: "DRAFT",
+          title: "Langhelg",
+        },
+      ],
+      laterItems: [],
+      mealPlan: {
+        activeShoppingDate: new Date("2026-05-16T00:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        entries: [],
+        id: "meal-plan-1",
+        manualShoppingItems: [],
+        shoppingOverrides: [],
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+      progress: {
+        checkedCount: 0,
+        totalCount: 0,
+      },
+      selectedStore: {
+        id: "store-1",
+        name: "Meny",
+      },
+      stores: [
+        {
+          id: "store-1",
+          name: "Meny",
+        },
+      ],
+      userRole: "ADMIN",
+      selectableShoppingDates: ["2026-05-15", "2026-05-16"],
+      visibleDates: ["2026-05-15", "2026-05-16"],
+    });
+    vi.mocked(listShoppingCheckHistoryForStoreMode).mockResolvedValue([
+      {
+        actorDisplayName: "Sindre",
+        checked: true,
+        id: "event-1",
+        itemName: "Melk",
+        occurredAt: "2026-05-16T10:00:00.000Z",
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+    ]);
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(),
+    } as never);
+
+    expect(result.shoppingHistory).toEqual([
+      {
+        actorDisplayName: "Sindre",
+        checked: true,
+        id: "event-1",
+        itemName: "Melk",
+        occurredAt: "2026-05-16T10:00:00.000Z",
+        sourceKey: "family-item-1",
+        sourceType: "FAMILY",
+      },
+    ]);
   });
 
   it("redirects to meal plans when the family has none", async () => {

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -50,6 +50,7 @@ import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
 import { scrollToShoppingItem } from "../lib/shopping-quick-add-feedback.client";
 import { serializeProjectedShoppingItem } from "../lib/shopping-serialize";
 import { resolveStoreModeAnchorMealPlan } from "../lib/meal-plan-for-date.server";
+import { listShoppingCheckHistoryForStoreMode } from "../lib/shopping-check-history.server";
 import {
   getFamilyStoreModeData,
   listRecentManualShoppingItemsForFamily,
@@ -159,6 +160,11 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect(`/families/${familyId}/meal-plans`);
   }
 
+  const shoppingHistory = await listShoppingCheckHistoryForStoreMode({
+    familyId,
+    mealPlanIds: result.includedMealPlans.map((plan) => plan.id),
+  });
+
   return {
     activeShoppingDate: formatDateOnly(result.activeShoppingDate),
     categories,
@@ -186,6 +192,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     recentManualItems,
     selectedStore: result.selectedStore,
     selectableShoppingDates: result.selectableShoppingDates,
+    shoppingHistory,
     stores: result.stores,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
@@ -1060,6 +1067,47 @@ export default function FamilyMealPlanStoreModeRoute({
             )}
           </div>
         </section>
+
+        <details className={storeModeMutedPanelClass}>
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-3 marker:content-none [&::-webkit-details-marker]:hidden">
+            <span className="text-lg font-semibold tracking-tight text-stone-950">
+              Handlehistorikk
+            </span>
+            <span className={storeModeCountChipClass}>
+              {loaderData.shoppingHistory.length} hendelser
+            </span>
+          </summary>
+
+          {loaderData.shoppingHistory.length > 0 ? (
+            <ul className="mt-4 space-y-3">
+              {loaderData.shoppingHistory.map((event) => (
+                <li
+                  key={event.id}
+                  className="border-t border-stone-200/80 pt-3 first:border-t-0 first:pt-0"
+                >
+                  <p className="text-sm leading-6 text-stone-800">
+                    <span className="font-medium text-stone-950">
+                      {event.actorDisplayName}
+                    </span>
+                    {event.checked
+                      ? " krysset av "
+                      : " fjernet avkryssing for "}
+                    <span className="font-medium text-stone-950">
+                      {event.itemName}
+                    </span>
+                  </p>
+                  <p className="mt-0.5 text-xs leading-5 text-stone-500">
+                    {formatHistoryTimestamp(event.occurredAt)}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-4 text-sm leading-6 text-stone-600">
+              Ingen handlehistorikk for denne turen ennå.
+            </p>
+          )}
+        </details>
       </div>
 
       {syncBannerMessage ? (
@@ -1348,4 +1396,13 @@ function formatDateLabel(value: string) {
     month: "long",
     timeZone: "UTC",
   }).format(new Date(`${value}T00:00:00.000Z`));
+}
+
+function formatHistoryTimestamp(value: string) {
+  return new Intl.DateTimeFormat("nb-NO", {
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    month: "short",
+  }).format(new Date(value));
 }

--- a/prisma/migrations/20260806100000_add_shopping_item_check_event/migration.sql
+++ b/prisma/migrations/20260806100000_add_shopping_item_check_event/migration.sql
@@ -1,0 +1,36 @@
+-- CreateEnum
+CREATE TYPE "ShoppingCheckEventTarget" AS ENUM ('FAMILY_ITEM', 'MEAL_PLAN_ITEM');
+
+-- CreateTable
+CREATE TABLE "ShoppingItemCheckEvent" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "mealPlanId" TEXT,
+    "targetType" "ShoppingCheckEventTarget" NOT NULL,
+    "targetKey" TEXT NOT NULL,
+    "sourceType" "ShoppingItemSource",
+    "itemName" TEXT NOT NULL,
+    "checked" BOOLEAN NOT NULL,
+    "actorUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ShoppingItemCheckEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ShoppingItemCheckEvent_familyId_createdAt_idx" ON "ShoppingItemCheckEvent"("familyId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ShoppingItemCheckEvent_mealPlanId_createdAt_idx" ON "ShoppingItemCheckEvent"("mealPlanId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ShoppingItemCheckEvent_actorUserId_idx" ON "ShoppingItemCheckEvent"("actorUserId");
+
+-- AddForeignKey
+ALTER TABLE "ShoppingItemCheckEvent" ADD CONSTRAINT "ShoppingItemCheckEvent_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShoppingItemCheckEvent" ADD CONSTRAINT "ShoppingItemCheckEvent_mealPlanId_fkey" FOREIGN KEY ("mealPlanId") REFERENCES "MealPlan"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShoppingItemCheckEvent" ADD CONSTRAINT "ShoppingItemCheckEvent_actorUserId_fkey" FOREIGN KEY ("actorUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,11 @@ enum ShoppingItemSource {
   MANUAL
 }
 
+enum ShoppingCheckEventTarget {
+  FAMILY_ITEM
+  MEAL_PLAN_ITEM
+}
+
 model User {
   id                String             @id @default(cuid())
   email             String             @unique
@@ -81,6 +86,7 @@ model User {
   mealPlanReviewComments       MealPlanReviewComment[] @relation("MealPlanReviewCommentAuthor")
   addressedMealPlanReviewComments MealPlanReviewComment[] @relation("MealPlanReviewCommentAddressedBy")
   responsibleMealPlanEntries      MealPlanEntry[]        @relation("MealPlanEntryResponsible")
+  shoppingItemCheckEvents         ShoppingItemCheckEvent[] @relation("ShoppingItemCheckEventActor")
 
   @@index([displayName])
 }
@@ -102,6 +108,7 @@ model Family {
   stockIngredients           FamilyStockIngredient[]
   freezerItems               FamilyFreezerItem[]
   shoppingItems       FamilyShoppingItem[]
+  shoppingItemCheckEvents ShoppingItemCheckEvent[]
 
   @@index([createdByUserId])
   @@index([name])
@@ -256,6 +263,7 @@ model MealPlan {
   entries              MealPlanEntry[]
   manualShoppingItems  ManualShoppingItem[]
   shoppingOverrides    ShoppingItemOverride[]
+  shoppingItemCheckEvents ShoppingItemCheckEvent[]
   shares               MealPlanShare[]
   reviewComments       MealPlanReviewComment[]
 
@@ -421,6 +429,26 @@ model ShoppingItemOverride {
   @@index([mealPlanId, sourceType])
   @@index([preferredStoreId])
   @@index([postponedUntilDate])
+}
+
+model ShoppingItemCheckEvent {
+  id          String                   @id @default(cuid())
+  familyId    String
+  mealPlanId  String?
+  targetType  ShoppingCheckEventTarget
+  targetKey   String
+  sourceType  ShoppingItemSource?
+  itemName    String
+  checked     Boolean
+  actorUserId String
+  createdAt   DateTime                 @default(now())
+  family      Family                   @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  mealPlan    MealPlan?                @relation(fields: [mealPlanId], references: [id], onDelete: Cascade)
+  actorUser   User                     @relation("ShoppingItemCheckEventActor", fields: [actorUserId], references: [id], onDelete: Cascade)
+
+  @@index([familyId, createdAt])
+  @@index([mealPlanId, createdAt])
+  @@index([actorUserId])
 }
 
 model Store {


### PR DESCRIPTION
## Summary
- Record who marks shopping items bought or not bought (family, manual, and generated) as append-only history events
- Show a collapsed **Handlehistorikk** section under **Før handledato** in store mode, covering all meal plans in the current trip
- Harden Prisma client reuse after schema changes so new models are available without a silent stale-client failure

## Related issue
Closes #168

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck, build
- [ ] Open store mode, toggle generated/manual/family items across included weeks
- [ ] Expand Handlehistorikk and confirm actor names, item names, and bought/unbought wording
- [ ] Confirm history stays collapsed by default and items have no “bought by” badges
- [ ] After deploy: apply migration `20260806100000_add_shopping_item_check_event`

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck
- npm run build