### PR TITLE
Show recipe tags in meal plan dinner select

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,36 +2,32 @@
 
 ## Current Objective
 
-Issue #168 — Track who marks shopping items bought/not bought and show collapsible Handlehistorikk in store mode, on branch `issue/168-shopping-check-history`.
+Issue #170 — Show recipe tags in the meal plan day dinner `<select>` options, on branch `issue/170-meal-plan-select-tags`.
 
 ## Completed
 
-- Added append-only `ShoppingItemCheckEvent` model + migration.
-- Record check events from family and meal-plan toggle helpers (including override delete-on-uncheck).
-- Store mode shows collapsed **Handlehistorikk** under **Før handledato**.
-- History query covers all meal plans in the store-mode trip (not only the anchor) plus family items.
-- Hardened Prisma client reuse so missing model delegates force a fresh client after `prisma generate`.
+- Added `formatMealPlanRecipeSelectLabel` (`Title · tag1, tag2`; title-only when no tags).
+- Wired formatter into `MealPlanDayRow` recipe options.
+- Unit tests for empty, whitespace, single, and multiple tags.
 
 ## Files To Read First
 
-- `app/lib/shopping-check-history.server.ts` — record/list history helpers
-- `app/lib/family-shopping-write.server.ts` / `app/lib/shopping-write.server.ts` — toggle write paths
-- `app/routes/family-meal-plan-store-mode.tsx` — Handlehistorikk UI + history loader call
-- `prisma/schema.prisma` — `ShoppingItemCheckEvent`
+- `app/lib/meal-plan-display.ts` — select option label formatter
+- `app/routes/family-meal-plan.tsx` — dinner `<select>` usage
+- `app/lib/meal-plan-display.test.ts` — formatter coverage
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (367 tests)
+- `npm run test:run` — passed (372 tests)
 - `npm run typecheck` — passed
 - `npm run build` — passed
 
 ## Open Items
 
-- After deploy: run migration `20260806100000_add_shopping_item_check_event`
-- Manual smoke: two family members toggle generated/manual/family items across included weeks → expand Handlehistorikk
+- Manual UI smoke after merge: open a day row → tagged recipes show `Title · tags`; untagged show title only; freezer options unchanged
 
 ## Next Step
 
-Merge PR after CI is green (issue closes via `Closes #168`).
+Merge PR after CI is green (issue closes via `Closes #170`).

--- a/app/lib/meal-plan-display.test.ts
+++ b/app/lib/meal-plan-display.test.ts
@@ -1,6 +1,39 @@
 import { describe, expect, it } from "vitest";
 
-import { getDinnerMenuLabel } from "./meal-plan-display";
+import {
+  formatMealPlanRecipeSelectLabel,
+  getDinnerMenuLabel,
+} from "./meal-plan-display";
+
+describe("formatMealPlanRecipeSelectLabel", () => {
+  it("returns title only when tags are empty", () => {
+    expect(formatMealPlanRecipeSelectLabel("Laksegryte", [])).toBe("Laksegryte");
+  });
+
+  it("returns title only when tags are whitespace-only", () => {
+    expect(formatMealPlanRecipeSelectLabel("Laksegryte", ["  ", ""])).toBe(
+      "Laksegryte",
+    );
+  });
+
+  it("appends a single tag after a middle dot", () => {
+    expect(formatMealPlanRecipeSelectLabel("Laksegryte", ["fisk"])).toBe(
+      "Laksegryte · fisk",
+    );
+  });
+
+  it("joins multiple tags with commas", () => {
+    expect(
+      formatMealPlanRecipeSelectLabel("Laksegryte", ["fisk", "hverdag"]),
+    ).toBe("Laksegryte · fisk, hverdag");
+  });
+
+  it("trims tags before joining", () => {
+    expect(
+      formatMealPlanRecipeSelectLabel("Taco", ["  hverdag  ", "komfort"]),
+    ).toBe("Taco · hverdag, komfort");
+  });
+});
 
 describe("getDinnerMenuLabel", () => {
   it("prefers recipe title over note", () => {

--- a/app/lib/meal-plan-display.ts
+++ b/app/lib/meal-plan-display.ts
@@ -1,3 +1,12 @@
+export function formatMealPlanRecipeSelectLabel(title: string, tags: string[]) {
+  const cleaned = tags.map((tag) => tag.trim()).filter(Boolean);
+  if (cleaned.length === 0) {
+    return title;
+  }
+
+  return `${title} · ${cleaned.join(", ")}`;
+}
+
 export function formatMealPlanWindow(startDate: string, endDate: string) {
   const formatter = new Intl.DateTimeFormat("nb-NO", {
     day: "numeric",

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -22,6 +22,7 @@ import {
 import { isPlanDateToday, formatDateOnly, MEAL_PLAN_MAX_SPAN_DAYS } from "../lib/meal-plan-dates";
 import {
   encodeMealSelection,
+  formatMealPlanRecipeSelectLabel,
   getDinnerMenuLabel,
   parseMealSelection,
 } from "../lib/meal-plan-display";
@@ -1874,7 +1875,7 @@ function MealPlanDayRow({
               <optgroup label="Oppskrifter">
                 {recipes.map((recipe) => (
                   <option key={recipe.id} value={`recipe:${recipe.id}`}>
-                    {recipe.title}
+                    {formatMealPlanRecipeSelectLabel(recipe.title, recipe.tags)}
                   </option>
                 ))}
               </optgroup>


### PR DESCRIPTION
## Summary
- Dinner `<select>` options now show recipe tags as `Title · tag1, tag2` so dish type is visible while planning
- Untagged recipes still show title only; freezer options unchanged

## Related issue
Closes #170

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck, build
- [ ] Open a meal plan day row and confirm tagged recipes show tags in the dinner select
- [ ] Confirm untagged recipes show title only
- [ ] Confirm freezer options still look and save correctly

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck
- npm run build