### PR TITLE
Add Rediger button on family recipe list cards

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,32 @@
 
 ## Current Objective
 
-Issue #170 — Show recipe tags in the meal plan day dinner `<select>` options, on branch `issue/170-meal-plan-select-tags`.
+Issue #172 — Add a Rediger control on family recipe list cards that opens the recipe editor in edit mode, on branch `issue/172-recipe-list-rediger-button`.
 
 ## Completed
 
-- Added `formatMealPlanRecipeSelectLabel` (`Title · tag1, tag2`; title-only when no tags).
-- Wired formatter into `MealPlanDayRow` recipe options.
-- Unit tests for empty, whitespace, single, and multiple tags.
+- Restructured `RecipeListCard` so family cards show separate **Åpne** and **Rediger** links (no full-card link wrapper).
+- **Rediger** navigates to `?edit=1`; recipe loader sets `startInEditMode` and passes `initialEditing` into `FamilyRecipeEditorCard`.
+- Loader tests cover `edit=1` vs default view mode.
 
 ## Files To Read First
 
-- `app/lib/meal-plan-display.ts` — select option label formatter
-- `app/routes/family-meal-plan.tsx` — dinner `<select>` usage
-- `app/lib/meal-plan-display.test.ts` — formatter coverage
+- `app/routes/family-recipes.tsx` — list card actions
+- `app/routes/family-recipe.tsx` — `startInEditMode` from query
+- `app/components/family-recipe-editor-card.tsx` — `initialEditing` prop
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (372 tests)
+- `npm run test:run` — passed (374 tests)
 - `npm run typecheck` — passed
 - `npm run build` — passed
 
 ## Open Items
 
-- Manual UI smoke after merge: open a day row → tagged recipes show `Title · tags`; untagged show title only; freezer options unchanged
+- Manual UI smoke after merge: family card **Åpne** → view mode; **Rediger** → edit form; global cards have no actions
 
 ## Next Step
 
-Merge PR after CI is green (issue closes via `Closes #170`).
+Merge PR after CI is green (issue closes via `Closes #172`).

--- a/app/components/family-recipe-editor-card.tsx
+++ b/app/components/family-recipe-editor-card.tsx
@@ -25,6 +25,7 @@ interface FamilyRecipeEditorCardProps {
   canManageRecipes: boolean;
   categories: RecipeCategory[];
   familyStores: RecipeStore[];
+  initialEditing?: boolean;
   mealPlanEntryCount: number;
   recipe: {
     defaultServings: number | null;
@@ -49,6 +50,7 @@ export function FamilyRecipeEditorCard({
   canManageRecipes,
   categories,
   familyStores,
+  initialEditing = false,
   mealPlanEntryCount,
   recipe,
   updateFieldErrors,
@@ -72,7 +74,9 @@ export function FamilyRecipeEditorCard({
   const [ignoreSubmittedValues, setIgnoreSubmittedValues] = useState(false);
   const sourceValues =
     updateValues && !ignoreSubmittedValues ? updateValues : persistedValues;
-  const [isEditing, setIsEditing] = useState(Boolean(updateValues));
+  const [isEditing, setIsEditing] = useState(
+    Boolean(updateValues) || initialEditing,
+  );
   const [draftValues, setDraftValues] = useState(sourceValues);
   const [focusIngredientIndex, setFocusIngredientIndex] = useState<number | null>(
     null,

--- a/app/routes/family-recipe.test.ts
+++ b/app/routes/family-recipe.test.ts
@@ -33,7 +33,7 @@ import {
   parseFamilyRecipeValues,
   updateFamilyRecipe,
 } from "../lib/recipe-write.server";
-import { action } from "./family-recipe";
+import { action, loader } from "./family-recipe";
 
 const mockUser = {
   displayName: "Ola",
@@ -86,6 +86,26 @@ describe("family recipe route", () => {
       },
       status: "FOUND",
     });
+  });
+
+  it("starts the recipe editor when edit=1 is present", async () => {
+    const data = await loader({
+      params: { familyId: "family-1", recipeId: "recipe-1" },
+      request: buildRequest(
+        "http://localhost/families/family-1/recipes/recipe-1?edit=1",
+      ),
+    });
+
+    expect(data.startInEditMode).toBe(true);
+  });
+
+  it("does not start the recipe editor without edit=1", async () => {
+    const data = await loader({
+      params: { familyId: "family-1", recipeId: "recipe-1" },
+      request: buildRequest(),
+    });
+
+    expect(data.startInEditMode).toBe(false);
   });
 
   it("returns a visible error when delete is blocked by meal plan usage", async () => {

--- a/app/routes/family-recipe.tsx
+++ b/app/routes/family-recipe.tsx
@@ -76,6 +76,7 @@ export async function loader({
     mealPlanEntryCount: detail.mealPlanEntryCount,
     notice: getRecipeDetailNotice(request),
     recipe: detail.recipe,
+    startInEditMode: shouldStartInEditMode(request),
     userRole: managementData.userRole,
   };
 }
@@ -244,6 +245,7 @@ export default function FamilyRecipeRoute({
           canManageRecipes={canManageRecipes}
           categories={loaderData.categories}
           familyStores={loaderData.familyStores}
+          initialEditing={loaderData.startInEditMode}
           mealPlanEntryCount={loaderData.mealPlanEntryCount}
           recipe={loaderData.recipe}
           updateFieldErrors={
@@ -302,6 +304,10 @@ function getRecipeDetailNotice(request: Request): RecipeDetailNotice | null {
   }
 
   return null;
+}
+
+function shouldStartInEditMode(request: Request) {
+  return new URL(request.url).searchParams.get("edit") === "1";
 }
 
 function getRecipeDetailNoticeContent(notice: RecipeDetailNotice) {

--- a/app/routes/family-recipes.tsx
+++ b/app/routes/family-recipes.tsx
@@ -498,9 +498,20 @@ function RecipeListCard({
           ) : null}
         </div>
         {!readOnly && to ? (
-          <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200">
-            Åpne
-          </span>
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <Link
+              className="rounded-full bg-white px-3 py-1 text-xs font-medium text-emerald-700 ring-1 ring-emerald-200"
+              to={to}
+            >
+              Åpne
+            </Link>
+            <Link
+              className="rounded-full bg-emerald-700 px-3 py-1 text-xs font-medium text-white"
+              to={`${to}?edit=1`}
+            >
+              Rediger
+            </Link>
+          </div>
         ) : null}
       </div>
       <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-slate-700">
@@ -524,14 +535,6 @@ function RecipeListCard({
       </div>
     </article>
   );
-
-  if (to) {
-    return (
-      <Link className="block" to={to}>
-        {content}
-      </Link>
-    );
-  }
 
   return content;
 }


### PR DESCRIPTION
## Summary
- Family recipe list cards show separate **Åpne** and **Rediger** actions instead of a full-card link
- **Rediger** opens the recipe with `?edit=1` so the editor starts in edit mode
- Global/read-only recipe cards remain without edit actions

## Related issue
Closes #172

## Test plan
- [ ] Family card shows **Åpne** and **Rediger**
- [ ] **Åpne** opens the recipe in view mode
- [ ] **Rediger** opens the recipe with the edit form visible
- [ ] Global/standard cards show no Rediger/Åpne actions
- [ ] Layout wraps cleanly on a narrow viewport

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck
- npm run build