### PR TITLE
Add family dinner analytics overview

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,29 +2,34 @@
 
 ## Current Objective
 
-Bump GitHub Actions off deprecated Node 20 runtimes on branch `chore/upgrade-github-actions-node24`.
+Ship a new family dinner analytics overview page that surfaces usage patterns for ingredients and recipes, with timeframe filtering.
 
 ## Completed
 
-- Upgraded `actions/checkout` from `@v4` to `@v7` and `actions/setup-node` from `@v4` to `@v7` in PR validation and Fly deploy workflows.
-- App CI still installs Node `20.19.0` for lint/test/build; only the action runtimes moved to Node 24.
+- Added route registration for `families/:familyId/meal-plans/overview` and linked it from top and mobile family navigation.
+- Implemented `getDinnerAnalyticsForFamily` in `app/lib/meal-plan.server.ts` with `30d` / `90d` / `all` timeframe support, recipe usage counts, ingredient usage counts (normalized), and latest recipe usage rows.
+- Added `app/routes/family-meal-plans-overview.tsx` with timeframe selector, empty state, and three analytics sections: most used ingredients, most used recipes, latest recipes used.
+- Added tests for analytics loader serialization and timeframe handling in `app/routes/family-meal-plans-overview.test.ts`.
+- Added server-level analytics tests in `app/lib/meal-plan.server.test.ts` for aggregation behavior and all-time date filtering.
 
 ## Files To Read First
 
-- `.github/workflows/pr-validation.yml` — PR CI action versions
-- `.github/workflows/fly-deploy.yml` — deploy/validate action versions
+- `app/routes/family-meal-plans-overview.tsx` - new analytics route UI and loader behavior
+- `app/lib/meal-plan.server.ts` - analytics query and aggregation logic
+- `app/lib/meal-plan.server.test.ts` - server analytics coverage and expected aggregation outputs
+- `app/routes/family-meal-plans-overview.test.ts` - route-level serialization and timeframe tests
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (374 tests)
+- `npm run test:run` — passed (383 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Confirm GitHub Actions no longer warns about Node 20 deprecation on the next workflow run
+- None identified during local validation.
 
 ## Next Step
 
-Merge PR after CI is green.
+Push branch and open PR that closes issue `#179`.

--- a/app/components/app-mobile-bottom-nav.tsx
+++ b/app/components/app-mobile-bottom-nav.tsx
@@ -15,6 +15,11 @@ function buildFamilyBottomNavItems(familyId: string): MobileBottomNavItem[] {
       to: `/families/${familyId}/meal-plans`,
     },
     {
+      end: true,
+      label: "Stats",
+      to: `/families/${familyId}/meal-plans/overview`,
+    },
+    {
       label: "Handleliste",
       to: `/families/${familyId}/store-mode`,
     },

--- a/app/components/app-top-nav.tsx
+++ b/app/components/app-top-nav.tsx
@@ -21,6 +21,11 @@ function buildFamilyNavItems(
     { end: false, label: "Ukeplaner", to: `/families/${familyId}/meal-plans` },
     {
       end: true,
+      label: "Middagstats",
+      to: `/families/${familyId}/meal-plans/overview`,
+    },
+    {
+      end: true,
       label: reviewLabel,
       to: `/families/${familyId}/meal-plans/reviews`,
     },

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -80,6 +80,7 @@ import {
   copyMealPlan,
   createMealPlan,
   deleteMealPlan,
+  getDinnerAnalyticsForFamily,
   formatDateOnly,
   getMealPlanForFamily,
   getMealPlanMaxSpanMessage,
@@ -1438,6 +1439,174 @@ describe("meal-plan.server", () => {
       },
     });
     expect(MEAL_PLAN_MAX_SPAN_DAYS).toBe(14);
+  });
+
+  it("aggregates dinner analytics by ingredient and recipe for a timeframe", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-10T10:00:00.000Z"));
+    dbMock.mealPlanEntry.findMany.mockResolvedValue([
+      {
+        date: new Date("2026-08-09T00:00:00.000Z"),
+        id: "entry-3",
+        recipe: {
+          id: "recipe-2",
+          ingredients: [{ displayName: "Lime" }],
+          title: "Fisketaco",
+        },
+        recipeId: "recipe-2",
+      },
+      {
+        date: new Date("2026-08-08T00:00:00.000Z"),
+        id: "entry-2",
+        recipe: {
+          id: "recipe-1",
+          ingredients: [
+            { displayName: "Tomat " },
+            { displayName: "LIME" },
+          ],
+          title: "Taco",
+        },
+        recipeId: "recipe-1",
+      },
+      {
+        date: new Date("2026-08-01T00:00:00.000Z"),
+        id: "entry-1",
+        recipe: {
+          id: "recipe-1",
+          ingredients: [{ displayName: "tomat" }],
+          title: "Taco",
+        },
+        recipeId: "recipe-1",
+      },
+    ]);
+
+    const result = await getDinnerAnalyticsForFamily({
+      familyId: "family-1",
+      timeframe: "90d",
+      userId: "user-1",
+    });
+
+    expect(dbMock.mealPlanEntry.findMany).toHaveBeenCalledWith({
+      orderBy: [{ date: "desc" }, { id: "desc" }],
+      select: {
+        date: true,
+        id: true,
+        recipe: {
+          select: {
+            id: true,
+            ingredients: {
+              orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+              select: {
+                displayName: true,
+              },
+            },
+            title: true,
+          },
+        },
+        recipeId: true,
+      },
+      where: {
+        date: {
+          gte: new Date("2026-05-12T00:00:00.000Z"),
+        },
+        mealPlan: {
+          familyId: "family-1",
+        },
+        mealType: "DINNER",
+        recipeId: {
+          not: null,
+        },
+      },
+    });
+    expect(result.family).toEqual({
+      id: "family-1",
+      name: "Solberg",
+    });
+    expect(result.mostUsedIngredients).toEqual([
+      {
+        count: 2,
+        ingredientName: "Lime",
+      },
+      {
+        count: 2,
+        ingredientName: "Tomat",
+      },
+    ]);
+    expect(result.mostUsedRecipes).toEqual([
+      {
+        count: 2,
+        recipeId: "recipe-1",
+        recipeTitle: "Taco",
+      },
+      {
+        count: 1,
+        recipeId: "recipe-2",
+        recipeTitle: "Fisketaco",
+      },
+    ]);
+    expect(result.latestRecipesUsed).toEqual([
+      {
+        date: new Date("2026-08-09T00:00:00.000Z"),
+        recipeId: "recipe-2",
+        recipeTitle: "Fisketaco",
+      },
+      {
+        date: new Date("2026-08-08T00:00:00.000Z"),
+        recipeId: "recipe-1",
+        recipeTitle: "Taco",
+      },
+      {
+        date: new Date("2026-08-01T00:00:00.000Z"),
+        recipeId: "recipe-1",
+        recipeTitle: "Taco",
+      },
+    ]);
+    expect(result.timeframe).toBe("90d");
+    expect(result.timeframeStartDate).toEqual(
+      new Date("2026-05-12T00:00:00.000Z"),
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("does not apply a date filter for all-time dinner analytics", async () => {
+    dbMock.mealPlanEntry.findMany.mockResolvedValue([]);
+
+    await getDinnerAnalyticsForFamily({
+      familyId: "family-1",
+      timeframe: "all",
+      userId: "user-1",
+    });
+
+    expect(dbMock.mealPlanEntry.findMany).toHaveBeenCalledWith({
+      orderBy: [{ date: "desc" }, { id: "desc" }],
+      select: {
+        date: true,
+        id: true,
+        recipe: {
+          select: {
+            id: true,
+            ingredients: {
+              orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+              select: {
+                displayName: true,
+              },
+            },
+            title: true,
+          },
+        },
+        recipeId: true,
+      },
+      where: {
+        mealPlan: {
+          familyId: "family-1",
+        },
+        mealType: "DINNER",
+        recipeId: {
+          not: null,
+        },
+      },
+    });
   });
 
   it("rejects auto-fill for approved meal plans", async () => {

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -19,6 +19,7 @@ import {
   validateFreezerStockDelta,
 } from "./freezer-stock.server";
 import { listActiveFreezerItemsForPlanning } from "./freezer.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import { formatDateOnly, MEAL_PLAN_MAX_SPAN_DAYS, getMealPlanMaxSpanMessage } from "./meal-plan-dates";
 import {
   logCollaborationFailure,
@@ -192,6 +193,24 @@ type MealPlanPlanningInput = GetMealPlanInput;
 type AutoFillMealPlanEntriesInput = DeleteMealPlanInput;
 
 type MealPlanApprovalAction = "APPROVE" | "REOPEN";
+export type DinnerAnalyticsTimeframe = "30d" | "90d" | "all";
+
+export interface DinnerIngredientUsageStat {
+  count: number;
+  ingredientName: string;
+}
+
+export interface DinnerRecipeUsageStat {
+  count: number;
+  recipeId: string;
+  recipeTitle: string;
+}
+
+export interface DinnerLatestRecipeUsageStat {
+  date: Date;
+  recipeId: string;
+  recipeTitle: string;
+}
 
 const AUTO_FILL_NOT_DRAFT_MESSAGE =
   "Godkjente ukeplaner kan ikke fylles automatisk.";
@@ -199,6 +218,9 @@ const AUTO_FILL_NO_ELIGIBLE_RECIPES_MESSAGE =
   `Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de siste ${MEAL_PLAN_MAX_SPAN_DAYS} dagene.`;
 const AUTO_FILL_REPEAT_WARNING_MESSAGE =
   "Noen middager ble valgt flere ganger fordi det var for fa oppskrifter igjen.";
+const ANALYTICS_TOP_INGREDIENT_LIMIT = 20;
+const ANALYTICS_TOP_RECIPE_LIMIT = 20;
+const ANALYTICS_LATEST_RECIPE_LIMIT = 15;
 
 export function getMealPlanDateRange(startDate: Date, endDate: Date) {
   let currentDate = new Date(startDate.getTime());
@@ -810,6 +832,129 @@ export async function deleteMealPlan({
   return {
     deletedMealPlan: mealPlan,
     status: "DELETED" as const,
+  };
+}
+
+export async function getDinnerAnalyticsForFamily({
+  familyId,
+  timeframe,
+  userId,
+}: {
+  familyId: string;
+  timeframe: DinnerAnalyticsTimeframe;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+  const startDate = getDinnerAnalyticsStartDate(timeframe, new Date());
+  const dinnerEntries = await db.mealPlanEntry.findMany({
+    orderBy: [{ date: "desc" }, { id: "desc" }],
+    select: {
+      date: true,
+      id: true,
+      recipe: {
+        select: {
+          id: true,
+          ingredients: {
+            orderBy: [{ sortOrder: "asc" }, { id: "asc" }],
+            select: {
+              displayName: true,
+            },
+          },
+          title: true,
+        },
+      },
+      recipeId: true,
+    },
+    where: {
+      ...(startDate ? { date: { gte: startDate } } : {}),
+      mealPlan: {
+        familyId,
+      },
+      mealType: PLANNING_MEAL_TYPE,
+      recipeId: {
+        not: null,
+      },
+    },
+  });
+  const recipeUsageById = new Map<string, DinnerRecipeUsageStat>();
+  const ingredientUsageByCanonicalName = new Map<
+    string,
+    DinnerIngredientUsageStat
+  >();
+
+  for (const entry of dinnerEntries) {
+    if (!entry.recipe) {
+      continue;
+    }
+
+    const existingRecipeUsage = recipeUsageById.get(entry.recipe.id);
+    recipeUsageById.set(entry.recipe.id, {
+      count: (existingRecipeUsage?.count ?? 0) + 1,
+      recipeId: entry.recipe.id,
+      recipeTitle: entry.recipe.title,
+    });
+
+    for (const ingredient of entry.recipe.ingredients) {
+      const ingredientName = ingredient.displayName.trim();
+
+      if (!ingredientName) {
+        continue;
+      }
+
+      const canonicalName = normalizeIngredientCanonicalName(ingredientName);
+      const existingIngredientUsage =
+        ingredientUsageByCanonicalName.get(canonicalName);
+
+      ingredientUsageByCanonicalName.set(canonicalName, {
+        count: (existingIngredientUsage?.count ?? 0) + 1,
+        ingredientName: existingIngredientUsage?.ingredientName ?? ingredientName,
+      });
+    }
+  }
+
+  return {
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    latestRecipesUsed: dinnerEntries
+      .flatMap((entry) => {
+        if (!entry.recipe) {
+          return [];
+        }
+
+        return [
+          {
+            date: entry.date,
+            recipeId: entry.recipe.id,
+            recipeTitle: entry.recipe.title,
+          },
+        ];
+      })
+      .slice(0, ANALYTICS_LATEST_RECIPE_LIMIT),
+    mostUsedIngredients: [...ingredientUsageByCanonicalName.values()]
+      .sort((left, right) => {
+        if (right.count !== left.count) {
+          return right.count - left.count;
+        }
+
+        return left.ingredientName.localeCompare(right.ingredientName, "nb");
+      })
+      .slice(0, ANALYTICS_TOP_INGREDIENT_LIMIT),
+    mostUsedRecipes: [...recipeUsageById.values()]
+      .sort((left, right) => {
+        if (right.count !== left.count) {
+          return right.count - left.count;
+        }
+
+        return left.recipeTitle.localeCompare(right.recipeTitle, "nb");
+      })
+      .slice(0, ANALYTICS_TOP_RECIPE_LIMIT),
+    timeframe,
+    timeframeStartDate: startDate,
   };
 }
 
@@ -1727,6 +1872,20 @@ function validateMealPlanEntries(
   }
 
   return null;
+}
+
+function getDinnerAnalyticsStartDate(
+  timeframe: DinnerAnalyticsTimeframe,
+  now: Date,
+) {
+  switch (timeframe) {
+    case "30d":
+      return addUtcDays(now, -30);
+    case "90d":
+      return addUtcDays(now, -90);
+    case "all":
+      return null;
+  }
 }
 
 export function parseDateOnly(value: string) {

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -9,6 +9,10 @@ export default [
     route("app", "routes/app.tsx"),
     route("families/:familyId", "routes/family.tsx"),
     route("families/:familyId/meal-plans", "routes/family-meal-plans.tsx"),
+    route(
+      "families/:familyId/meal-plans/overview",
+      "routes/family-meal-plans-overview.tsx",
+    ),
     route("families/:familyId/meal-plans/reviews", "routes/family-meal-plan-reviews.tsx"),
     route(
       "families/:familyId/meal-plans/:mealPlanId/review",

--- a/app/routes/family-meal-plans-overview.test.ts
+++ b/app/routes/family-meal-plans-overview.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/meal-plan.server", () => {
+  return {
+    formatDateOnly: vi.fn((date: Date) => date.toISOString().slice(0, 10)),
+    getDinnerAnalyticsForFamily: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { getDinnerAnalyticsForFamily } from "../lib/meal-plan.server";
+import { loader } from "./family-meal-plans-overview";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/meal-plans/overview",
+) {
+  return new Request(url);
+}
+
+describe("family meal plans overview route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads dinner analytics with default timeframe when query param is missing", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getDinnerAnalyticsForFamily).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      latestRecipesUsed: [
+        {
+          date: new Date("2026-08-09T00:00:00.000Z"),
+          recipeId: "recipe-1",
+          recipeTitle: "Taco",
+        },
+      ],
+      mostUsedIngredients: [
+        {
+          count: 4,
+          ingredientName: "Tomat",
+        },
+      ],
+      mostUsedRecipes: [
+        {
+          count: 2,
+          recipeId: "recipe-1",
+          recipeTitle: "Taco",
+        },
+      ],
+      timeframe: "90d",
+      timeframeStartDate: new Date("2026-05-11T00:00:00.000Z"),
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(getDinnerAnalyticsForFamily).toHaveBeenCalledWith({
+      familyId: "family-1",
+      timeframe: "90d",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      latestRecipesUsed: [
+        {
+          date: "2026-08-09",
+          recipeId: "recipe-1",
+          recipeTitle: "Taco",
+        },
+      ],
+      mostUsedIngredients: [
+        {
+          count: 4,
+          ingredientName: "Tomat",
+        },
+      ],
+      mostUsedRecipes: [
+        {
+          count: 2,
+          recipeId: "recipe-1",
+          recipeTitle: "Taco",
+        },
+      ],
+      timeframe: "90d",
+      timeframeStartDate: "2026-05-11",
+    });
+  });
+
+  it("uses the explicit timeframe from query params", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getDinnerAnalyticsForFamily).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      latestRecipesUsed: [],
+      mostUsedIngredients: [],
+      mostUsedRecipes: [],
+      timeframe: "all",
+      timeframeStartDate: null,
+    });
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/meal-plans/overview?timeframe=all",
+      ),
+    });
+
+    expect(getDinnerAnalyticsForFamily).toHaveBeenCalledWith({
+      familyId: "family-1",
+      timeframe: "all",
+      userId: "user-1",
+    });
+    expect(result.timeframeStartDate).toBeNull();
+  });
+});

--- a/app/routes/family-meal-plans-overview.tsx
+++ b/app/routes/family-meal-plans-overview.tsx
@@ -1,0 +1,286 @@
+import { Link, type MetaFunction } from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import {
+  formatDateOnly,
+  getDinnerAnalyticsForFamily,
+  type DinnerAnalyticsTimeframe,
+} from "../lib/meal-plan.server";
+
+const TIMEFRAME_OPTIONS: Array<{
+  description: string;
+  label: string;
+  value: DinnerAnalyticsTimeframe;
+}> = [
+  {
+    description: "Gir deg et raskt bilde av den siste måneden.",
+    label: "Siste 30 dager",
+    value: "30d",
+  },
+  {
+    description: "Passer for å se sesongmønstre over et kvartal.",
+    label: "Siste 90 dager",
+    value: "90d",
+  },
+  {
+    description: "Bruk hele historikken for et langsiktig bilde.",
+    label: "Hele historikken",
+    value: "all",
+  },
+];
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Middagstatistikk | Mealplanner" },
+    {
+      name: "description",
+      content:
+        "Se hvilke oppskrifter og ingredienser som brukes mest i familiens middager.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const timeframe = parseDinnerAnalyticsTimeframe(
+    new URL(request.url).searchParams.get("timeframe"),
+  );
+  const result = await getDinnerAnalyticsForFamily({
+    familyId,
+    timeframe,
+    userId: user.id,
+  });
+
+  return {
+    family: result.family,
+    latestRecipesUsed: result.latestRecipesUsed.map((usage) => ({
+      ...usage,
+      date: formatDateOnly(usage.date),
+    })),
+    mostUsedIngredients: result.mostUsedIngredients,
+    mostUsedRecipes: result.mostUsedRecipes,
+    timeframe: result.timeframe,
+    timeframeStartDate: result.timeframeStartDate
+      ? formatDateOnly(result.timeframeStartDate)
+      : null,
+  };
+}
+
+export default function FamilyMealPlansOverviewRoute({
+  loaderData,
+}: {
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}) {
+  const hasData =
+    loaderData.mostUsedIngredients.length > 0 ||
+    loaderData.mostUsedRecipes.length > 0 ||
+    loaderData.latestRecipesUsed.length > 0;
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-4xl bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Middagstatistikk
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Se hvilke middager som går igjen, og bruk innsikten til å variere
+                ukeplanene mer.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/meal-plans`}
+              >
+                Til ukeplaner
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-[28px] border border-slate-200 bg-white px-6 py-5 shadow-sm">
+          <h2 className="text-base font-semibold text-slate-900">Tidsrom</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Bytt tidsrom for å sammenligne nyere vaner med hele historikken.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            {TIMEFRAME_OPTIONS.map((option) => {
+              const isActive = loaderData.timeframe === option.value;
+
+              return (
+                <Link
+                  key={option.value}
+                  className={[
+                    "rounded-2xl border px-4 py-3 text-sm transition",
+                    isActive
+                      ? "border-emerald-400 bg-emerald-50 text-emerald-900"
+                      : "border-slate-200 bg-white text-slate-700 hover:border-slate-300",
+                  ].join(" ")}
+                  to={`?timeframe=${option.value}`}
+                >
+                  <p className="font-medium">{option.label}</p>
+                  <p className="mt-1 text-xs leading-5 text-slate-500">
+                    {option.description}
+                  </p>
+                </Link>
+              );
+            })}
+          </div>
+          <p className="mt-4 text-xs text-slate-500">
+            {getTimeframeDescription(
+              loaderData.timeframe,
+              loaderData.timeframeStartDate,
+            )}
+          </p>
+        </section>
+
+        {!hasData ? (
+          <section className="rounded-[28px] border border-slate-200 bg-white px-6 py-8 text-slate-700 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">
+              Ingen middager å analysere ennå
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6">
+              Legg til middager i ukeplanene, så får dere fort oversikt over hvilke
+              oppskrifter og ingredienser som brukes mest.
+            </p>
+          </section>
+        ) : null}
+
+        {hasData ? (
+          <section className="grid gap-6 md:grid-cols-2">
+            <article className="rounded-[28px] border border-slate-200 bg-white px-6 py-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-slate-900">
+                Mest brukte ingredienser
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Antall ganger ingrediensen forekommer i planlagte middager.
+              </p>
+              <ol className="mt-4 space-y-3">
+                {loaderData.mostUsedIngredients.map((ingredient) => (
+                  <li
+                    className="flex items-center justify-between rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3"
+                    key={ingredient.ingredientName}
+                  >
+                    <span className="text-sm font-medium text-slate-800">
+                      {ingredient.ingredientName}
+                    </span>
+                    <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold text-slate-700">
+                      {ingredient.count}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </article>
+
+            <article className="rounded-[28px] border border-slate-200 bg-white px-6 py-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-slate-900">
+                Mest brukte oppskrifter
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Oppskrifter som går igjen oftest i middagene.
+              </p>
+              <ol className="mt-4 space-y-3">
+                {loaderData.mostUsedRecipes.map((recipe) => (
+                  <li
+                    className="flex items-center justify-between rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3"
+                    key={recipe.recipeId}
+                  >
+                    <Link
+                      className="text-sm font-medium text-emerald-800 hover:text-emerald-900 hover:underline"
+                      to={`/families/${loaderData.family.id}/recipes/${recipe.recipeId}`}
+                    >
+                      {recipe.recipeTitle}
+                    </Link>
+                    <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold text-slate-700">
+                      {recipe.count}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </article>
+          </section>
+        ) : null}
+
+        {loaderData.latestRecipesUsed.length > 0 ? (
+          <section className="rounded-[28px] border border-slate-200 bg-white px-6 py-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">
+              Sist brukte oppskrifter
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Siste registrerte middager i valgt tidsrom.
+            </p>
+            <ol className="mt-4 space-y-3">
+              {loaderData.latestRecipesUsed.map((usage, index) => (
+                <li
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3"
+                  key={`${usage.recipeId}-${usage.date}-${index}`}
+                >
+                  <Link
+                    className="text-sm font-medium text-emerald-800 hover:text-emerald-900 hover:underline"
+                    to={`/families/${loaderData.family.id}/recipes/${usage.recipeId}`}
+                  >
+                    {usage.recipeTitle}
+                  </Link>
+                  <span className="text-xs font-medium text-slate-500">
+                    {usage.date}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </section>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}
+
+function parseDinnerAnalyticsTimeframe(
+  value: string | null,
+): DinnerAnalyticsTimeframe {
+  if (value === "30d" || value === "90d" || value === "all") {
+    return value;
+  }
+
+  return "90d";
+}
+
+function getTimeframeDescription(
+  timeframe: DinnerAnalyticsTimeframe,
+  timeframeStartDate: string | null,
+) {
+  if (timeframe === "all") {
+    return "Viser alle registrerte middager.";
+  }
+
+  if (!timeframeStartDate) {
+    return "Viser et avgrenset tidsrom.";
+  }
+
+  return `Viser middager fra og med ${timeframeStartDate}.`;
+}


### PR DESCRIPTION
## Summary
- Add a new family meal-plan overview page with timeframe filters (`30d`, `90d`, `all`) to analyze dinner habits.
- Surface most-used ingredients, most-used recipes, and latest recipes used to make repetition visible and support meal variety decisions.
- Wire the page into top/mobile navigation and add route/server tests for serialization, aggregation, and timeframe behavior.

## Related issue
Closes #179

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual checks: open `/families/:familyId/meal-plans/overview`, switch timeframe, verify empty/data states

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck