### PR TITLE
Fix ingredient search dropdown scroll in quick-add

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,22 +2,20 @@
 
 ## Current Objective
 
-Ship a new family dinner analytics overview page that surfaces usage patterns for ingredients and recipes, with timeframe filtering.
+Fix ingredient search dropdown scroll in `ManualShoppingQuickAdd` so long result lists remain reachable (issue #181).
 
 ## Completed
 
-- Added route registration for `families/:familyId/meal-plans/overview` and linked it from top and mobile family navigation.
-- Implemented `getDinnerAnalyticsForFamily` in `app/lib/meal-plan.server.ts` with `30d` / `90d` / `all` timeframe support, recipe usage counts, ingredient usage counts (normalized), and latest recipe usage rows.
-- Added `app/routes/family-meal-plans-overview.tsx` with timeframe selector, empty state, and three analytics sections: most used ingredients, most used recipes, latest recipes used.
-- Added tests for analytics loader serialization and timeframe handling in `app/routes/family-meal-plans-overview.test.ts`.
-- Added server-level analytics tests in `app/lib/meal-plan.server.test.ts` for aggregation behavior and all-time date filtering.
+- Removed `overflow-x-clip` from quick-add component root and fixed dock wrappers that were clipping the dropdown.
+- Split dropdown into a positioned shell and inner scrollable listbox with touch-friendly overflow classes.
+- Added viewport-aware max height for upward (`revealOnFocus`) and downward dropdown modes.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plans-overview.tsx` - new analytics route UI and loader behavior
-- `app/lib/meal-plan.server.ts` - analytics query and aggregation logic
-- `app/lib/meal-plan.server.test.ts` - server analytics coverage and expected aggregation outputs
-- `app/routes/family-meal-plans-overview.test.ts` - route-level serialization and timeframe tests
+- `app/components/manual-shopping-quick-add.tsx` - dropdown shell/scroll split and max-height measurement
+- `app/routes/family-shopping.tsx` - mobile dock wrapper overflow fix
+- `app/lib/store-mode-theme.ts` - store-mode dock class overflow fix
+- `app/routes/family-meal-plan-store-mode.tsx` - store-mode fixed shell overflow fix
 
 ## Validation
 
@@ -28,8 +26,8 @@ Ship a new family dinner analytics overview page that surfaces usage patterns fo
 
 ## Open Items
 
-- None identified during local validation.
+- Manual UI verification recommended on family shopping (desktop + mobile dock), meal-plan shopping, and store mode.
 
 ## Next Step
 
-Push branch and open PR that closes issue `#179`.
+Merge PR and confirm dropdown scroll on device/browser.

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useFetcher } from "react-router";
 
 import type {
@@ -47,6 +54,9 @@ const SEARCH_DEBOUNCE_MS = 250;
 const DEFAULT_QUICK_ADD_INTENT = "quick-add-manual-shopping-item";
 const DEFAULT_SEARCH_FETCHER_KEY = "manual-shopping-ingredient-search";
 const DEFAULT_QUICK_ADD_FETCHER_KEY = "manual-shopping-quick-add";
+const DROPDOWN_MAX_HEIGHT_PX = 256;
+const DROPDOWN_VIEWPORT_PADDING_PX = 16;
+const DROPDOWN_GAP_PX = 8;
 
 const quickAddStyles = {
   default: {
@@ -54,9 +64,11 @@ const quickAddStyles = {
       "flex w-full px-4 py-3 text-left text-sm font-medium text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60",
     description: "text-sm leading-6 text-slate-600",
     dropdown:
-      "absolute z-10 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg",
+      "absolute z-10 w-full rounded-2xl border border-slate-200 bg-white shadow-lg",
+    dropdownScroll:
+      "max-h-64 overflow-y-auto overscroll-y-contain touch-pan-y py-2",
     dropdownUp:
-      "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-slate-200 bg-white py-2 shadow-lg",
+      "absolute bottom-full z-10 mb-2 w-full rounded-2xl border border-slate-200 bg-white shadow-lg",
     error: "text-sm text-rose-600",
     input:
       "min-w-0 w-0 flex-1 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-base text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100",
@@ -78,9 +90,11 @@ const quickAddStyles = {
       "flex w-full px-4 py-3 text-left text-sm font-medium text-store-accent-text transition hover:bg-store-accent-light disabled:cursor-not-allowed disabled:opacity-60",
     description: "text-sm leading-6 text-stone-600",
     dropdown:
-      "absolute z-10 max-h-64 w-full overflow-y-auto rounded-2xl border border-stone-200 bg-white py-2 shadow-lg",
+      "absolute z-10 w-full rounded-2xl border border-stone-200 bg-white shadow-lg",
+    dropdownScroll:
+      "max-h-64 overflow-y-auto overscroll-y-contain touch-pan-y py-2",
     dropdownUp:
-      "absolute bottom-full z-10 mb-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-stone-200 bg-white py-2 shadow-lg",
+      "absolute bottom-full z-10 mb-2 w-full rounded-2xl border border-stone-200 bg-white shadow-lg",
     error: "text-sm text-rose-600",
     input:
       "min-w-0 w-0 flex-1 rounded-2xl border border-stone-300 bg-stone-50 px-4 py-3 text-base text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60",
@@ -128,6 +142,9 @@ export function ManualShoppingQuickAdd({
   const [displayedResults, setDisplayedResults] = useState<
     IngredientSearchResult[]
   >([]);
+  const [dropdownMaxHeight, setDropdownMaxHeight] = useState<number | null>(
+    null,
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const lastRequestedQueryRef = useRef<string | null>(null);
@@ -282,6 +299,50 @@ export function ManualShoppingQuickAdd({
     trimmedQuery.length > 0 && !hasExactMatch && !isSearching;
   const isExpanded =
     !revealOnFocus || isInputFocused || trimmedQuery.length > 0;
+
+  useLayoutEffect(() => {
+    if (!showDropdown) {
+      setDropdownMaxHeight(null);
+      return;
+    }
+
+    function updateDropdownMaxHeight() {
+      const input = inputRef.current;
+
+      if (!input) {
+        return;
+      }
+
+      const rect = input.getBoundingClientRect();
+
+      if (revealOnFocus) {
+        setDropdownMaxHeight(
+          Math.max(
+            120,
+            rect.top - DROPDOWN_GAP_PX - DROPDOWN_VIEWPORT_PADDING_PX,
+          ),
+        );
+        return;
+      }
+
+      setDropdownMaxHeight(
+        Math.min(
+          DROPDOWN_MAX_HEIGHT_PX,
+          window.innerHeight -
+            rect.bottom -
+            DROPDOWN_GAP_PX -
+            DROPDOWN_VIEWPORT_PADDING_PX,
+        ),
+      );
+    }
+
+    updateDropdownMaxHeight();
+    window.addEventListener("resize", updateDropdownMaxHeight);
+
+    return () => {
+      window.removeEventListener("resize", updateDropdownMaxHeight);
+    };
+  }, [revealOnFocus, showDropdown]);
   const recentsBlock =
     recentManualItems.length > 0 ? (
       <div className="space-y-2">
@@ -309,7 +370,7 @@ export function ManualShoppingQuickAdd({
 
   return (
     <div
-      className="flex min-w-0 max-w-full flex-col gap-3 overflow-x-clip"
+      className="flex min-w-0 max-w-full flex-col gap-3"
       ref={containerRef}
     >
       <label
@@ -409,51 +470,60 @@ export function ManualShoppingQuickAdd({
         </div>
 
         {showDropdown ? (
-          <ul
+          <div
             className={revealOnFocus ? styles.dropdownUp : styles.dropdown}
-            id={listboxId}
-            role="listbox"
           >
-            {isSearching ? (
-              <li className={styles.searchPending} role="presentation">
-                Søker...
-              </li>
-            ) : null}
-            {displayedResults.map((ingredient) => (
-              <li key={ingredient.id} role="option">
-                <button
-                  className={styles.option}
-                  disabled={isQuickAdding}
-                  onClick={() => {
-                    submitQuickAdd({
-                      ingredientId: ingredient.id,
-                      quantity,
-                    });
-                  }}
-                  type="button"
-                >
-                  <span className="font-medium">
-                    {ingredient.canonicalName}
-                  </span>
-                  <span className={styles.optionMeta}>Fra register</span>
-                </button>
-              </li>
-            ))}
-            {showCreateOption ? (
-              <li role="option">
-                <button
-                  className={styles.createOption}
-                  disabled={isQuickAdding}
-                  onClick={() => {
-                    submitQuickAdd({ name: trimmedQuery, quantity });
-                  }}
-                  type="button"
-                >
-                  Legg til «{trimmedQuery}»
-                </button>
-              </li>
-            ) : null}
-          </ul>
+            <ul
+              className={styles.dropdownScroll}
+              id={listboxId}
+              role="listbox"
+              style={
+                dropdownMaxHeight === null
+                  ? undefined
+                  : { maxHeight: dropdownMaxHeight }
+              }
+            >
+              {isSearching ? (
+                <li className={styles.searchPending} role="presentation">
+                  Søker...
+                </li>
+              ) : null}
+              {displayedResults.map((ingredient) => (
+                <li key={ingredient.id} role="option">
+                  <button
+                    className={styles.option}
+                    disabled={isQuickAdding}
+                    onClick={() => {
+                      submitQuickAdd({
+                        ingredientId: ingredient.id,
+                        quantity,
+                      });
+                    }}
+                    type="button"
+                  >
+                    <span className="font-medium">
+                      {ingredient.canonicalName}
+                    </span>
+                    <span className={styles.optionMeta}>Fra register</span>
+                  </button>
+                </li>
+              ))}
+              {showCreateOption ? (
+                <li role="option">
+                  <button
+                    className={styles.createOption}
+                    disabled={isQuickAdding}
+                    onClick={() => {
+                      submitQuickAdd({ name: trimmedQuery, quantity });
+                    }}
+                    type="button"
+                  >
+                    Legg til «{trimmedQuery}»
+                  </button>
+                </li>
+              ) : null}
+            </ul>
+          </div>
         ) : null}
       </div>
 

--- a/app/lib/store-mode-theme.ts
+++ b/app/lib/store-mode-theme.ts
@@ -38,7 +38,7 @@ export const storeModeLaterChipClass =
   "rounded-full bg-stone-100 px-3 py-1.5 text-xs font-medium text-stone-700";
 
 export const storeModeQuickAddDockClass =
-  "min-w-0 max-w-full overflow-x-clip rounded-[28px] bg-white p-4 shadow-2xl ring-2 ring-store-accent";
+  "min-w-0 max-w-full rounded-[28px] bg-white p-4 shadow-2xl ring-2 ring-store-accent";
 
 export type StoreModeBannerTone = "success" | "sync" | "error";
 

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1133,7 +1133,7 @@ export default function FamilyMealPlanStoreModeRoute({
         </div>
       ) : null}
 
-      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 overflow-x-clip px-4 pb-4 pt-3">
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3">
         <div className="pointer-events-auto mx-auto max-w-4xl min-w-0">
           <div className={storeModeQuickAddDockClass}>
             <ManualShoppingQuickAdd

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -775,9 +775,9 @@ export default function FamilyShoppingRoute({
       </div>
 
       {!isLg ? (
-        <div className="pointer-events-none fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom))] z-40 overflow-x-clip px-4 pt-3">
+        <div className="pointer-events-none fixed inset-x-0 bottom-[calc(4.5rem+env(safe-area-inset-bottom))] z-40 px-4 pt-3">
           <div className="pointer-events-auto mx-auto max-w-5xl min-w-0">
-            <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200 overflow-x-clip">
+            <div className="rounded-[28px] bg-white p-4 shadow-2xl ring-1 ring-slate-200">
               <ManualShoppingQuickAdd
                 {...quickAddProps}
                 autoFocus


### PR DESCRIPTION
## Summary
- Remove `overflow-x-clip` from quick-add component and fixed dock wrappers that were clipping the absolutely positioned dropdown
- Split the dropdown into a positioned shell and inner scrollable listbox with touch-friendly overflow
- Add viewport-aware max height for upward (`revealOnFocus`) and downward dropdown modes

## Related issue
Closes #181

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Family shopping (desktop): search broad term (e.g. `m`), confirm list scrolls and first/last + create option are tappable
- [ ] Family shopping (mobile dock): same search with upward dropdown
- [ ] Store mode dock: confirm scroll and selection
- [ ] Meal-plan shopping: confirm downward dropdown scroll

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (383 tests)
- npm run typecheck