### PR TITLE
Allow editing quantity on recipe-generated shopping items

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,32 @@
 
 ## Current Objective
 
-Fix ingredient search dropdown scroll in `ManualShoppingQuickAdd` so long result lists remain reachable (issue #181).
+Ship issue #183: editable quantity on recipe-generated shopping list items.
 
 ## Completed
 
-- Removed `overflow-x-clip` from quick-add component root and fixed dock wrappers that were clipping the dropdown.
-- Split dropdown into a positioned shell and inner scrollable listbox with touch-friendly overflow classes.
-- Added viewport-aware max height for upward (`revealOnFocus`) and downward dropdown modes.
+- Generated shopping lines can be quantity-edited on the meal-plan list and in store mode, without a renamed manual item.
+- Override persists until cleared, including after merge-key changes.
+- Validation passed and the branch is ready to push/PR.
 
 ## Files To Read First
 
-- `app/components/manual-shopping-quick-add.tsx` - dropdown shell/scroll split and max-height measurement
-- `app/routes/family-shopping.tsx` - mobile dock wrapper overflow fix
-- `app/lib/store-mode-theme.ts` - store-mode dock class overflow fix
-- `app/routes/family-meal-plan-store-mode.tsx` - store-mode fixed shell overflow fix
+- `app/lib/shopping-write.server.ts` - quantity update and override preservation
+- `app/lib/shopping.server.ts` - projection and overlapping override lookup
+- `app/components/shopping-quantity-edit-modal.tsx` - shared quantity modal
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (383 tests)
+- `npm run test:run` — passed (391 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual UI verification recommended on family shopping (desktop + mobile dock), meal-plan shopping, and store mode.
+- Apply migration `20260817100000_add_shopping_item_override_quantity` on deploy.
+- Manual UI check after merge: edit a generated quantity on the meal-plan list, confirm it in store mode, then Tilbakestill.
 
 ## Next Step
 
-Merge PR and confirm dropdown scroll on device/browser.
+Merge the pull request for issue #183 after review.

--- a/app/components/shopping-list-item-expanded.tsx
+++ b/app/components/shopping-list-item-expanded.tsx
@@ -239,6 +239,20 @@ export function ShoppingListItemExpanded({
             />
 
             <label className="block min-w-0 text-sm font-medium text-slate-700">
+              Mengde
+              <input
+                className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={overrideValues.quantity}
+                name="quantity"
+                placeholder="F.eks. 4 flasker"
+                type="text"
+              />
+            </label>
+            <p className="text-xs leading-5 text-slate-500">
+              La feltet stå tomt for å bruke mengden fra oppskriftene.
+            </p>
+
+            <label className="block min-w-0 text-sm font-medium text-slate-700">
               Foretrukket butikk
               <select
                 className="mt-2 box-border w-full max-w-full min-w-0 rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"

--- a/app/components/shopping-quantity-edit-modal.tsx
+++ b/app/components/shopping-quantity-edit-modal.tsx
@@ -1,0 +1,92 @@
+import type { RefObject } from "react";
+
+export function ShoppingQuantityEditModal({
+  canReset = false,
+  name,
+  onCancel,
+  onReset,
+  onSave,
+  quantity,
+  quantityInputRef,
+  setQuantity,
+}: {
+  canReset?: boolean;
+  name: string;
+  onCancel: () => void;
+  onReset?: () => void;
+  onSave: () => void;
+  quantity: string;
+  quantityInputRef: RefObject<HTMLInputElement | null>;
+  setQuantity: (value: string) => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/35 p-4"
+      onClick={onCancel}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          onCancel();
+        }
+      }}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-sm rounded-2xl border border-stone-200 bg-white p-4 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <h3 className="text-sm font-semibold text-stone-950">Oppdater mengde</h3>
+        <p className="mt-1 text-xs text-stone-600">{name}</p>
+        <label className="mt-3 block text-xs font-medium text-stone-700">
+          Mengde
+          <input
+            className="mt-1 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 text-base text-stone-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            onChange={(event) => setQuantity(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                onSave();
+              }
+            }}
+            placeholder="F.eks. 4 flasker"
+            ref={quantityInputRef}
+            type="text"
+            value={quantity}
+          />
+        </label>
+        <p className="mt-2 text-xs leading-5 text-stone-500">
+          La feltet stå tomt for å bruke mengden fra oppskriftene.
+        </p>
+        <div className="mt-4 flex items-center justify-between gap-2">
+          {canReset && onReset ? (
+            <button
+              className="rounded-xl px-3 py-2 text-sm text-stone-600 transition hover:bg-stone-100"
+              onClick={onReset}
+              type="button"
+            >
+              Tilbakestill
+            </button>
+          ) : (
+            <span />
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              className="rounded-xl border border-stone-300 px-3 py-2 text-sm text-stone-700 transition hover:bg-stone-100"
+              onClick={onCancel}
+              type="button"
+            >
+              Avbryt
+            </button>
+            <button
+              className="rounded-xl bg-stone-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-stone-800"
+              onClick={onSave}
+              type="button"
+            >
+              Lagre
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -6,6 +6,7 @@ import {
 } from "../lib/shopping-display";
 import type { StoreModeShoppingView } from "../lib/shopping-store-mode-client";
 import type { StoreCategory } from "../lib/store.server";
+import { ShoppingQuantityEditModal } from "./shopping-quantity-edit-modal";
 
 interface StoreModeShoppingItemCardBase {
   category: {
@@ -89,8 +90,10 @@ interface StoreModeShoppingItemCardProps {
   onUpdateCategory?: (request: StoreModeCategoryUpdateRequest) => void;
   onUpdateQuantity?: (item: {
     expectedUpdatedAt: string;
+    mealPlanId?: string | null;
     quantity: string;
     sourceKey: string;
+    sourceType: "FAMILY" | "GENERATED";
   }) => void;
   onToggle: () => void;
   selectedStoreId: string | undefined;
@@ -252,7 +255,8 @@ export function StoreModeShoppingItemCard({
   const nameClass = item.checked
     ? "text-sm font-semibold leading-5 text-stone-500 line-through decoration-stone-400"
     : "text-sm font-semibold leading-5 text-stone-950";
-  const showQuantityEdit = item.sourceType === "FAMILY";
+  const showQuantityEdit =
+    item.sourceType === "FAMILY" || item.sourceType === "GENERATED";
 
   useEffect(() => {
     if (!isQuantityModalOpen) {
@@ -291,34 +295,26 @@ export function StoreModeShoppingItemCard({
                 </span>
               ) : null}
             </span>
-            {quantityBadge ? (
-              showQuantityEdit ? (
-                <button
-                  className={`${badgeClass} pointer-events-auto bg-store-accent-light text-store-accent-text ring-1 ring-store-accent/40 transition hover:bg-store-accent-light/80`}
-                  onClick={() => {
-                    setQuantityDraft(item.quantityLabel ?? "");
-                    setIsQuantityModalOpen(true);
-                  }}
-                  type="button"
-                >
-                  <span className="inline-flex items-center gap-1">
-                    {quantityBadge}
-                    <EditPencilIcon className="h-3 w-3 opacity-80" />
-                  </span>
-                </button>
-              ) : (
-                <span
-                  className={
-                    item.sourceType === "GENERATED" &&
-                    !item.quantityLabel &&
-                    item.occurrenceCount > 1
-                      ? `${badgeClass} bg-amber-100 text-amber-800`
-                      : `${badgeClass} bg-white text-stone-700 ring-1 ring-stone-200`
-                  }
-                >
-                  {quantityBadge}
+            {showQuantityEdit ? (
+              <button
+                className={`${badgeClass} pointer-events-auto bg-store-accent-light text-store-accent-text ring-1 ring-store-accent/40 transition hover:bg-store-accent-light/80`}
+                onClick={() => {
+                  setQuantityDraft(
+                    item.quantity ?? item.quantityLabel ?? "",
+                  );
+                  setIsQuantityModalOpen(true);
+                }}
+                type="button"
+              >
+                <span className="inline-flex items-center gap-1">
+                  {quantityBadge ?? "Sett mengde"}
+                  <EditPencilIcon className="h-3 w-3 opacity-80" />
                 </span>
-              )
+              </button>
+            ) : quantityBadge ? (
+              <span className={`${badgeClass} bg-white text-stone-700 ring-1 ring-stone-200`}>
+                {quantityBadge}
+              </span>
             ) : null}
             {item.sourceType === "GENERATED" && item.recipeCount > 1 ? (
               <span className={`${badgeClass} bg-emerald-100 text-emerald-800`}>
@@ -445,62 +441,36 @@ export function StoreModeShoppingItemCard({
         </details>
       </div>
 
-      {isQuantityModalOpen ? (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-stone-950/35 p-4"
-          onClick={() => setIsQuantityModalOpen(false)}
-          onKeyDown={(event) => {
-            if (event.key === "Escape") {
-              setIsQuantityModalOpen(false);
-            }
+      {isQuantityModalOpen &&
+      (item.sourceType === "FAMILY" || item.sourceType === "GENERATED") ? (
+        <ShoppingQuantityEditModal
+          canReset={Boolean((item.quantity ?? item.quantityLabel)?.trim())}
+          name={item.name}
+          onCancel={() => setIsQuantityModalOpen(false)}
+          onReset={() => {
+            onUpdateQuantity?.({
+              expectedUpdatedAt: item.collaborationVersion,
+              mealPlanId: item.mealPlanId,
+              quantity: "",
+              sourceKey: item.sourceKey,
+              sourceType: item.sourceType,
+            });
+            setIsQuantityModalOpen(false);
           }}
-          role="presentation"
-        >
-          <div
-            className="w-full max-w-sm rounded-2xl border border-stone-200 bg-white p-4 shadow-xl"
-            onClick={(event) => event.stopPropagation()}
-            role="dialog"
-          >
-            <h3 className="text-sm font-semibold text-stone-950">
-              Oppdater mengde
-            </h3>
-            <p className="mt-1 text-xs text-stone-600">{item.name}</p>
-            <label className="mt-3 block text-xs font-medium text-stone-700">
-              Mengde
-              <input
-                className="mt-1 w-full rounded-xl border border-stone-300 bg-white px-3 py-2 text-base text-stone-900 outline-none transition focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60"
-                onChange={(event) => setQuantityDraft(event.target.value)}
-                placeholder="F.eks. 4 flasker"
-                ref={quantityInputRef}
-                type="text"
-                value={quantityDraft}
-              />
-            </label>
-            <div className="mt-4 flex justify-end gap-2">
-              <button
-                className="rounded-xl border border-stone-300 px-3 py-2 text-sm text-stone-700 transition hover:bg-stone-100"
-                onClick={() => setIsQuantityModalOpen(false)}
-                type="button"
-              >
-                Avbryt
-              </button>
-              <button
-                className="rounded-xl bg-stone-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-stone-800"
-                onClick={() => {
-                  onUpdateQuantity?.({
-                    expectedUpdatedAt: item.collaborationVersion,
-                    quantity: quantityDraft,
-                    sourceKey: item.sourceKey,
-                  });
-                  setIsQuantityModalOpen(false);
-                }}
-                type="button"
-              >
-                Lagre
-              </button>
-            </div>
-          </div>
-        </div>
+          onSave={() => {
+            onUpdateQuantity?.({
+              expectedUpdatedAt: item.collaborationVersion,
+              mealPlanId: item.mealPlanId,
+              quantity: quantityDraft,
+              sourceKey: item.sourceKey,
+              sourceType: item.sourceType,
+            });
+            setIsQuantityModalOpen(false);
+          }}
+          quantity={quantityDraft}
+          quantityInputRef={quantityInputRef}
+          setQuantity={setQuantityDraft}
+        />
       ) : null}
     </div>
   );

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -56,6 +56,7 @@ const {
         delete: vi.fn(),
         deleteMany: vi.fn(),
         findUnique: vi.fn(),
+        findMany: vi.fn(),
         update: vi.fn(),
         updateMany: vi.fn(),
         upsert: vi.fn(),
@@ -127,6 +128,7 @@ import {
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
   updateGeneratedShoppingItemOverride,
+  updateGeneratedShoppingItemQuantity,
 } from "./shopping-write.server";
 
 const mockMealPlan = {
@@ -157,6 +159,7 @@ describe("shopping-write.server", () => {
     dbMock.manualShoppingItem.deleteMany.mockResolvedValue({ count: 1 });
     dbMock.shoppingItemOverride.updateMany.mockResolvedValue({ count: 1 });
     dbMock.shoppingItemOverride.deleteMany.mockResolvedValue({ count: 1 });
+    dbMock.shoppingItemOverride.findMany.mockResolvedValue([]);
     dbMock.$transaction.mockImplementation(async (callback: (tx: typeof transactionMock) => unknown) =>
       callback(transactionMock),
     );
@@ -664,6 +667,7 @@ describe("shopping-write.server", () => {
         note: "  Husk tilbud  ",
         postponedUntilDate: "2026-05-17",
         preferredStoreId: "store-2",
+        quantity: " 4 flasker ",
       },
     });
 
@@ -678,6 +682,8 @@ describe("shopping-write.server", () => {
         note: "Husk tilbud",
         postponedUntilDate: new Date("2026-05-17T00:00:00.000Z"),
         preferredStoreId: "store-2",
+        quantity: "4 flasker",
+        sourceKey: "entry-1:ingredient-1",
         updatedByUserId: "user-1",
       },
       where: {
@@ -710,6 +716,7 @@ describe("shopping-write.server", () => {
         note: null,
         postponedUntilDate: null,
         preferredStoreId: null,
+        quantity: null,
         sourceKey: "entry-1:ingredient-1",
         sourceType: ShoppingItemSource.GENERATED,
         updatedByUserId: "user-1",
@@ -747,6 +754,177 @@ describe("shopping-write.server", () => {
       },
     });
     expect(dbMock.shoppingItemOverride.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("updates quantity on a generated shopping item", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue({
+      checked: false,
+      excludedFromList: false,
+      id: "override-1",
+      includeDespiteStock: false,
+      note: null,
+      postponedUntilDate: null,
+      preferredStoreId: null,
+      quantity: "2 stk",
+      sourceKey: "entry-1:ingredient-1",
+      sourceType: ShoppingItemSource.GENERATED,
+      updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+    });
+
+    const result = await updateGeneratedShoppingItemQuantity({
+      expectedUpdatedAt: new Date("2026-05-15T00:00:00.000Z").toISOString(),
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      quantity: " 4 flasker ",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.shoppingItemOverride.updateMany).toHaveBeenCalledWith({
+      data: {
+        checked: false,
+        excludedFromList: false,
+        includeDespiteStock: false,
+        note: null,
+        postponedUntilDate: null,
+        preferredStoreId: null,
+        quantity: "4 flasker",
+        sourceKey: "entry-1:ingredient-1",
+        updatedByUserId: "user-1",
+      },
+      where: {
+        id: "override-1",
+        updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+      },
+    });
+  });
+
+  it("clears a quantity-only generated override", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue({
+      checked: false,
+      excludedFromList: false,
+      id: "override-1",
+      includeDespiteStock: false,
+      note: null,
+      postponedUntilDate: null,
+      preferredStoreId: null,
+      quantity: "4 flasker",
+      sourceKey: "entry-1:ingredient-1",
+      sourceType: ShoppingItemSource.GENERATED,
+      updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+    });
+
+    const result = await updateGeneratedShoppingItemQuantity({
+      expectedUpdatedAt: new Date("2026-05-15T00:00:00.000Z").toISOString(),
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      quantity: "  ",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.shoppingItemOverride.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: "override-1",
+        updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+      },
+    });
+    expect(dbMock.shoppingItemOverride.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps a quantity-only override when unchecking a generated item", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue({
+      checked: true,
+      excludedFromList: false,
+      id: "override-1",
+      includeDespiteStock: false,
+      note: null,
+      postponedUntilDate: null,
+      preferredStoreId: null,
+      quantity: "4 flasker",
+      sourceType: ShoppingItemSource.GENERATED,
+      updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+    });
+
+    const result = await toggleShoppingItemChecked({
+      checked: false,
+      expectedUpdatedAt: new Date("2026-05-15T00:00:00.000Z").toISOString(),
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      sourceKey: "entry-1:ingredient-1",
+      sourceType: ShoppingItemSource.GENERATED,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(transactionMock.shoppingItemOverride.updateMany).toHaveBeenCalledWith({
+      data: {
+        checked: false,
+        updatedByUserId: "user-1",
+      },
+      where: {
+        id: "override-1",
+        updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+      },
+    });
+    expect(transactionMock.shoppingItemOverride.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("migrates an overlapping generated quantity override onto the current source key", async () => {
+    dbMock.shoppingItemOverride.findUnique.mockResolvedValue(null);
+    dbMock.shoppingItemOverride.findMany.mockResolvedValue([
+      {
+        checked: false,
+        excludedFromList: false,
+        id: "override-1",
+        includeDespiteStock: false,
+        note: null,
+        postponedUntilDate: null,
+        preferredStoreId: null,
+        quantity: "4 flasker",
+        sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2",
+        sourceType: ShoppingItemSource.GENERATED,
+        updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await updateGeneratedShoppingItemQuantity({
+      expectedUpdatedAt: new Date("2026-05-15T00:00:00.000Z").toISOString(),
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      quantity: "6 flasker",
+      sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2|entry-3:ingredient-3",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "UPDATED",
+    });
+    expect(dbMock.shoppingItemOverride.updateMany).toHaveBeenCalledWith({
+      data: {
+        checked: false,
+        excludedFromList: false,
+        includeDespiteStock: false,
+        note: null,
+        postponedUntilDate: null,
+        preferredStoreId: null,
+        quantity: "6 flasker",
+        sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2|entry-3:ingredient-3",
+        updatedByUserId: "user-1",
+      },
+      where: {
+        id: "override-1",
+        updatedAt: new Date("2026-05-15T00:00:00.000Z"),
+      },
+    });
   });
 
   it("opts stock ingredients into the generated shopping list", async () => {

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -64,6 +64,7 @@ export interface GeneratedShoppingItemOverrideValues {
   note: string;
   postponedUntilDate: string;
   preferredStoreId: string;
+  quantity: string;
 }
 
 export interface GeneratedShoppingItemOverrideFieldErrors {
@@ -494,6 +495,7 @@ export async function excludeGeneratedShoppingItem({
       note: true,
       postponedUntilDate: true,
       preferredStoreId: true,
+      quantity: true,
       updatedAt: true,
     },
     where: {
@@ -523,6 +525,7 @@ export async function excludeGeneratedShoppingItem({
     note: existingOverride?.note ?? null,
     postponedUntilDate: existingOverride?.postponedUntilDate ?? null,
     preferredStoreId: existingOverride?.preferredStoreId ?? null,
+    quantity: existingOverride?.quantity ?? null,
   };
 
   try {
@@ -625,6 +628,7 @@ export async function restoreGeneratedShoppingItem({
       note: true,
       postponedUntilDate: true,
       preferredStoreId: true,
+      quantity: true,
       updatedAt: true,
     },
     where: {
@@ -661,6 +665,7 @@ export async function restoreGeneratedShoppingItem({
     note: existingOverride.note,
     postponedUntilDate: existingOverride.postponedUntilDate,
     preferredStoreId: existingOverride.preferredStoreId,
+    quantity: existingOverride.quantity,
   };
 
   try {
@@ -793,6 +798,7 @@ export async function toggleShoppingItemChecked({
       note: true,
       postponedUntilDate: true,
       preferredStoreId: true,
+      quantity: true,
       sourceType: true,
       updatedAt: true,
     },
@@ -1075,6 +1081,7 @@ export async function optInStockShoppingItems({
           note: true,
           postponedUntilDate: true,
           preferredStoreId: true,
+          quantity: true,
         },
         where: {
           mealPlanId_sourceType_sourceKey: {
@@ -1094,6 +1101,7 @@ export async function optInStockShoppingItems({
           note: existingOverride?.note ?? null,
           postponedUntilDate: existingOverride?.postponedUntilDate ?? null,
           preferredStoreId: existingOverride?.preferredStoreId ?? null,
+          quantity: existingOverride?.quantity ?? null,
           sourceKey,
           sourceType: ShoppingItemSource.GENERATED,
           ...buildActorUpdate(userId),
@@ -1184,24 +1192,9 @@ export async function updateGeneratedShoppingItemOverride({
     };
   }
 
-  const existingOverride = await db.shoppingItemOverride.findUnique({
-    select: {
-      checked: true,
-      excludedFromList: true,
-      id: true,
-      includeDespiteStock: true,
-      note: true,
-      postponedUntilDate: true,
-      preferredStoreId: true,
-      updatedAt: true,
-    },
-    where: {
-      mealPlanId_sourceType_sourceKey: {
-        mealPlanId: mealPlan.id,
-        sourceKey,
-        sourceType: ShoppingItemSource.GENERATED,
-      },
-    },
+  const existingOverride = await findGeneratedShoppingItemOverrideForWrite({
+    mealPlanId: mealPlan.id,
+    sourceKey,
   });
 
   if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingOverride?.updatedAt)) {
@@ -1222,6 +1215,8 @@ export async function updateGeneratedShoppingItemOverride({
     note: string | null;
     postponedUntilDate: Date | null;
     preferredStoreId: string | null;
+    quantity: string | null;
+    sourceKey: string;
   } = {
     checked: existingOverride?.checked ?? false,
     excludedFromList: existingOverride?.excludedFromList ?? false,
@@ -1229,6 +1224,8 @@ export async function updateGeneratedShoppingItemOverride({
     note: validation.values.note || null,
     postponedUntilDate: validation.postponedUntilDate ?? null,
     preferredStoreId: validation.preferredStoreId,
+    quantity: normalizeOverrideQuantity(validation.values.quantity),
+    sourceKey,
   };
 
   try {
@@ -1320,6 +1317,162 @@ export async function updateGeneratedShoppingItemOverride({
   } catch (error) {
     logCollaborationFailure({
       action: "update-generated-shopping-item",
+      domain: "shopping",
+      entityId: existingOverride?.id ?? sourceKey,
+      entityType: "shopping-item-override",
+      error,
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "VALIDATION_ERROR",
+      userId,
+    });
+
+    throw error;
+  }
+}
+
+export async function updateGeneratedShoppingItemQuantity({
+  expectedUpdatedAt,
+  familyId,
+  mealPlanId,
+  quantity,
+  sourceKey,
+  userId,
+}: {
+  expectedUpdatedAt: string;
+  familyId: string;
+  mealPlanId: string;
+  quantity: string;
+  sourceKey: string;
+  userId: string;
+}) {
+  const mealPlan = await getScopedMealPlan({
+    familyId,
+    mealPlanId,
+    userId,
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const existingOverride = await findGeneratedShoppingItemOverrideForWrite({
+    mealPlanId: mealPlan.id,
+    sourceKey,
+  });
+
+  if (!matchesExpectedUpdatedAt(expectedUpdatedAt, existingOverride?.updatedAt)) {
+    return buildShoppingConflictResult({
+      action: "update-generated-shopping-item-quantity",
+      entityId: existingOverride?.id ?? sourceKey,
+      entityType: "shopping-item-override",
+      familyId,
+      mealPlanId: mealPlan.id,
+      userId,
+    });
+  }
+
+  const nextData = {
+    checked: existingOverride?.checked ?? false,
+    excludedFromList: existingOverride?.excludedFromList ?? false,
+    includeDespiteStock: existingOverride?.includeDespiteStock ?? false,
+    note: existingOverride?.note ?? null,
+    postponedUntilDate: existingOverride?.postponedUntilDate ?? null,
+    preferredStoreId: existingOverride?.preferredStoreId ?? null,
+    quantity: normalizeOverrideQuantity(quantity),
+    sourceKey,
+  };
+
+  try {
+    if (isOverrideEmpty(nextData)) {
+      if (existingOverride) {
+        const deleteResult = await db.shoppingItemOverride.deleteMany({
+          where: {
+            id: existingOverride.id,
+            updatedAt: existingOverride.updatedAt,
+          },
+        });
+
+        if (deleteResult.count === 0) {
+          return buildShoppingConflictResult({
+            action: "update-generated-shopping-item-quantity",
+            entityId: existingOverride.id,
+            entityType: "shopping-item-override",
+            familyId,
+            mealPlanId: mealPlan.id,
+            userId,
+          });
+        }
+      }
+
+      logCollaborationWrite({
+        action: "update-generated-shopping-item-quantity",
+        domain: "shopping",
+        entityId: existingOverride?.id ?? sourceKey,
+        entityType: "shopping-item-override",
+        familyId,
+        mealPlanId: mealPlan.id,
+        outcome: "UPDATED",
+        userId,
+      });
+
+      return {
+        status: "UPDATED" as const,
+      };
+    }
+
+    if (existingOverride) {
+      const updateResult = await db.shoppingItemOverride.updateMany({
+        data: {
+          ...nextData,
+          ...buildActorUpdate(userId),
+        },
+        where: {
+          id: existingOverride.id,
+          updatedAt: existingOverride.updatedAt,
+        },
+      });
+
+      if (updateResult.count === 0) {
+        return buildShoppingConflictResult({
+          action: "update-generated-shopping-item-quantity",
+          entityId: existingOverride.id,
+          entityType: "shopping-item-override",
+          familyId,
+          mealPlanId: mealPlan.id,
+          userId,
+        });
+      }
+    } else {
+      await db.shoppingItemOverride.create({
+        data: {
+          ...nextData,
+          mealPlanId: mealPlan.id,
+          sourceType: ShoppingItemSource.GENERATED,
+          ...buildActorUpdate(userId),
+        },
+      });
+    }
+
+    logCollaborationWrite({
+      action: "update-generated-shopping-item-quantity",
+      domain: "shopping",
+      entityId: existingOverride?.id ?? sourceKey,
+      entityType: "shopping-item-override",
+      familyId,
+      mealPlanId: mealPlan.id,
+      outcome: "UPDATED",
+      userId,
+    });
+
+    return {
+      status: "UPDATED" as const,
+    };
+  } catch (error) {
+    logCollaborationFailure({
+      action: "update-generated-shopping-item-quantity",
       domain: "shopping",
       entityId: existingOverride?.id ?? sourceKey,
       entityType: "shopping-item-override",
@@ -1820,7 +1973,76 @@ function normalizeGeneratedShoppingItemOverrideValues(
     note: values.note.trim(),
     postponedUntilDate: values.postponedUntilDate.trim(),
     preferredStoreId: values.preferredStoreId.trim(),
+    quantity: values.quantity.trim(),
   };
+}
+
+const generatedOverrideWriteSelect = {
+  checked: true,
+  excludedFromList: true,
+  id: true,
+  includeDespiteStock: true,
+  note: true,
+  postponedUntilDate: true,
+  preferredStoreId: true,
+  quantity: true,
+  sourceKey: true,
+  sourceType: true,
+  updatedAt: true,
+} as const;
+
+async function findGeneratedShoppingItemOverrideForWrite({
+  mealPlanId,
+  sourceKey,
+}: {
+  mealPlanId: string;
+  sourceKey: string;
+}) {
+  const exact = await db.shoppingItemOverride.findUnique({
+    select: generatedOverrideWriteSelect,
+    where: {
+      mealPlanId_sourceType_sourceKey: {
+        mealPlanId,
+        sourceKey,
+        sourceType: ShoppingItemSource.GENERATED,
+      },
+    },
+  });
+
+  if (exact) {
+    return exact;
+  }
+
+  const occurrenceKeySet = new Set(sourceKey.split("|").filter(Boolean));
+
+  if (occurrenceKeySet.size === 0) {
+    return null;
+  }
+
+  const overrides = await db.shoppingItemOverride.findMany({
+    select: generatedOverrideWriteSelect,
+    where: {
+      mealPlanId,
+      sourceType: ShoppingItemSource.GENERATED,
+    },
+  });
+
+  return (
+    overrides
+      .filter((override) =>
+        override.sourceKey
+          .split("|")
+          .some((part) => occurrenceKeySet.has(part)),
+      )
+      .sort(
+        (left, right) => right.updatedAt.getTime() - left.updatedAt.getTime(),
+      )[0] ?? null
+  );
+}
+
+function normalizeOverrideQuantity(quantity: string | null | undefined) {
+  const trimmed = quantity?.trim() ?? "";
+  return trimmed || null;
 }
 
 async function resolveScopedStoreId(preferredStoreId: string, familyId: string) {
@@ -1924,6 +2146,7 @@ function shouldDeleteOverrideAfterUnchecked(existingOverride: {
   note: string | null;
   postponedUntilDate: Date | null;
   preferredStoreId: string | null;
+  quantity?: string | null;
   sourceType: ShoppingItemSource;
 }) {
   if (existingOverride.sourceType === ShoppingItemSource.MANUAL) {
@@ -1935,7 +2158,8 @@ function shouldDeleteOverrideAfterUnchecked(existingOverride: {
     !existingOverride.includeDespiteStock &&
     !existingOverride.note &&
     !existingOverride.postponedUntilDate &&
-    !existingOverride.preferredStoreId
+    !existingOverride.preferredStoreId &&
+    !existingOverride.quantity
   );
 }
 
@@ -1946,6 +2170,7 @@ function isOverrideEmpty(values: {
   note: string | null;
   postponedUntilDate: Date | null;
   preferredStoreId: string | null;
+  quantity?: string | null;
 }) {
   return (
     !values.checked &&
@@ -1953,6 +2178,7 @@ function isOverrideEmpty(values: {
     !values.includeDespiteStock &&
     !values.note &&
     !values.postponedUntilDate &&
-    !values.preferredStoreId
+    !values.preferredStoreId &&
+    !values.quantity
   );
 }

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -1192,6 +1192,191 @@ describe("shopping.server", () => {
     );
   });
 
+  it("uses an override quantity instead of the merged recipe amount", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: null,
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-dairy", name: "Meieri" },
+                categoryId: "category-dairy",
+                displayName: "Yoghurt",
+                id: "ingredient-1",
+                ingredientId: "canonical-yoghurt",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "beger",
+              },
+            ],
+            title: "Frokostbolle",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [
+        {
+          checked: false,
+          excludedFromList: false,
+          includeDespiteStock: false,
+          note: null,
+          postponedUntilDate: null,
+          preferredStore: null,
+          preferredStoreId: null,
+          quantity: " 4 beger ",
+          sourceKey: "entry-1:ingredient-1",
+          sourceType: "GENERATED",
+          updatedAt: new Date("2026-05-16T12:00:00.000Z"),
+        },
+      ],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+    });
+    dbMock.store.findMany.mockResolvedValue([]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.projectedItems[0]).toEqual(
+      expect.objectContaining({
+        quantity: "4 beger",
+        quantityLabel: "4 beger",
+        sourceType: "GENERATED",
+      }),
+    );
+  });
+
+  it("keeps an overlapping quantity override after the generated source key changes", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      activeShoppingDate: null,
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-15T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-dairy", name: "Meieri" },
+                categoryId: "category-dairy",
+                displayName: "Yoghurt",
+                id: "ingredient-1",
+                ingredientId: "canonical-yoghurt",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "beger",
+              },
+            ],
+            title: "Frokostbolle",
+          },
+          recipeId: "recipe-1",
+        },
+        {
+          date: new Date("2026-05-16T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "2",
+                category: { id: "category-dairy", name: "Meieri" },
+                categoryId: "category-dairy",
+                displayName: "Yoghurt",
+                id: "ingredient-2",
+                ingredientId: "canonical-yoghurt",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "beger",
+              },
+            ],
+            title: "Parfait",
+          },
+          recipeId: "recipe-2",
+        },
+        {
+          date: new Date("2026-05-17T00:00:00.000Z"),
+          id: "entry-3",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-3",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-dairy", name: "Meieri" },
+                categoryId: "category-dairy",
+                displayName: "Yoghurt",
+                id: "ingredient-3",
+                ingredientId: "canonical-yoghurt",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "beger",
+              },
+            ],
+            title: "Smoothie",
+          },
+          recipeId: "recipe-3",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [
+        {
+          checked: false,
+          excludedFromList: false,
+          includeDespiteStock: false,
+          note: null,
+          postponedUntilDate: null,
+          preferredStore: null,
+          preferredStoreId: null,
+          quantity: "6 beger",
+          sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2",
+          sourceType: "GENERATED",
+          updatedAt: new Date("2026-05-16T12:00:00.000Z"),
+        },
+      ],
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Langhelg",
+    });
+    dbMock.store.findMany.mockResolvedValue([]);
+
+    const result = await getMealPlanShoppingData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.projectedItems[0]).toEqual(
+      expect.objectContaining({
+        quantity: "6 beger",
+        quantityLabel: "6 beger",
+        sourceKey: "entry-1:ingredient-1|entry-2:ingredient-2|entry-3:ingredient-3",
+        sourceType: "GENERATED",
+      }),
+    );
+  });
+
   describe("getMealPlanStoreModeData", () => {
     function registerStoreModePlans(
       anchorPlan: Record<string, unknown>,
@@ -2631,6 +2816,7 @@ describe("shopping.server", () => {
         postponedUntilDate: null,
         preferredStore: null,
         preferredStoreConflict: false,
+        quantity: null,
         quantityLabel: "1 l",
         recipeCount: 1,
         section: { displayName: "Meieri", sortOrder: 1 },

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -79,6 +79,7 @@ const shoppingOverrideSelect =
       select: storeSummarySelect,
     },
     preferredStoreId: true,
+    quantity: true,
     sourceKey: true,
     sourceType: true,
     updatedAt: true,
@@ -268,6 +269,7 @@ export interface ProjectedGeneratedShoppingItem extends ProjectedShoppingItemBas
   occurrences: ProjectedShoppingOccurrence[];
   postponedUntilDate: Date | null;
   preferredStoreConflict: boolean;
+  quantity: string | null;
   sourceType: "GENERATED";
   unit: string | null;
 }
@@ -1176,7 +1178,11 @@ function mapGeneratedProjectionBucketToItem({
     postponedUntilDate: override?.postponedUntilDate ?? null,
     preferredStore,
     preferredStoreConflict: bucket.preferredStoreConflict,
-    quantityLabel: buildMergedQuantityLabel(occurrences),
+    quantity: override?.quantity?.trim() || null,
+    quantityLabel: buildGeneratedQuantityLabel({
+      occurrences,
+      overrideQuantity: override?.quantity,
+    }),
     section,
     sourceKey,
     sourceType: ShoppingItemSource.GENERATED,
@@ -1650,13 +1656,11 @@ function resolveGeneratedOverride(
     return directOverride;
   }
 
-  // Legacy overrides may still be keyed by a single occurrence before merge.
+  const occurrenceKeySet = new Set(bucket.occurrenceKeys);
   let fallbackOverride: ShoppingOverride | undefined;
 
-  for (const occurrenceKey of bucket.occurrenceKeys) {
-    const candidate = overrideBySourceKey.get(occurrenceKey);
-
-    if (!candidate) {
+  for (const [sourceKey, candidate] of overrideBySourceKey) {
+    if (!generatedOverrideSourceKeyOverlaps(sourceKey, occurrenceKeySet)) {
       continue;
     }
 
@@ -1669,6 +1673,29 @@ function resolveGeneratedOverride(
   }
 
   return fallbackOverride;
+}
+
+function generatedOverrideSourceKeyOverlaps(
+  sourceKey: string,
+  occurrenceKeySet: Set<string>,
+) {
+  return sourceKey.split("|").some((part) => occurrenceKeySet.has(part));
+}
+
+function buildGeneratedQuantityLabel({
+  occurrences,
+  overrideQuantity,
+}: {
+  occurrences: ProjectedShoppingOccurrence[];
+  overrideQuantity?: string | null;
+}) {
+  const trimmedOverride = overrideQuantity?.trim();
+
+  if (trimmedOverride) {
+    return trimmedOverride;
+  }
+
+  return buildMergedQuantityLabel(occurrences);
 }
 
 function hasIncludeDespiteStockKey(

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -24,6 +24,7 @@ vi.mock("../lib/shopping-write.server", () => {
     optInStockShoppingItems: vi.fn(),
     toggleShoppingItemChecked: vi.fn(),
     updateGeneratedShoppingItemOverride: vi.fn(),
+    updateGeneratedShoppingItemQuantity: vi.fn(),
     updateManualShoppingItem: vi.fn(),
   };
 });
@@ -36,6 +37,7 @@ import {
   optInStockShoppingItems,
   toggleShoppingItemChecked,
   updateGeneratedShoppingItemOverride,
+  updateGeneratedShoppingItemQuantity,
 } from "../lib/shopping-write.server";
 import { action, loader } from "./family-meal-plan-shopping";
 
@@ -131,6 +133,7 @@ describe("family meal plan shopping route", () => {
             id: "store-1",
             name: "Meny",
           },
+          quantity: null,
           quantityLabel: "1 stk",
           section: {
             displayName: "Frukt og gront",
@@ -211,6 +214,7 @@ describe("family meal plan shopping route", () => {
                     id: "store-1",
                     name: "Meny",
                   },
+                  quantity: null,
                   quantityLabel: "1 stk",
                   section: {
                     displayName: "Frukt og gront",
@@ -378,6 +382,7 @@ describe("family meal plan shopping route", () => {
                     id: "store-1",
                     name: "Meny",
                   },
+                  quantity: null,
                   quantityLabel: "1 stk",
                   section: {
                     displayName: "Frukt og gront",
@@ -755,6 +760,7 @@ describe("family meal plan shopping route", () => {
         note: "Kjøp senere",
         postponedUntilDate: "2026-05-21",
         preferredStoreId: "store-1",
+        quantity: "",
       },
     });
 
@@ -783,6 +789,7 @@ describe("family meal plan shopping route", () => {
         note: "Kjøp senere",
         postponedUntilDate: "2026-05-21",
         preferredStoreId: "store-1",
+        quantity: "",
       },
     });
     expect(result).toEqual({
@@ -798,7 +805,45 @@ describe("family meal plan shopping route", () => {
         note: "Kjøp senere",
         postponedUntilDate: "2026-05-21",
         preferredStoreId: "store-1",
+        quantity: "",
       },
+    });
+  });
+
+  it("updates generated shopping item quantity without creating a manual item", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateGeneratedShoppingItemQuantity).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-generated-shopping-item-quantity");
+    formData.set("sourceKey", "entry-1:ingredient-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("quantity", "4 flasker");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping",
+        formData,
+      ),
+    });
+
+    expect(updateGeneratedShoppingItemQuantity).toHaveBeenCalledWith({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      quantity: "4 flasker",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      intent: "update-generated-shopping-item-quantity",
+      ok: true,
     });
   });
 });

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1,9 +1,10 @@
 import { ShoppingItemSource } from "@prisma/client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Form,
   Link,
   isRouteErrorResponse,
+  useFetcher,
   useNavigation,
   useRevalidator,
   type MetaFunction,
@@ -20,6 +21,7 @@ import {
   ShoppingDateSelect,
   ShoppingListItemExpanded,
 } from "../components/shopping-list-item-expanded";
+import { ShoppingQuantityEditModal } from "../components/shopping-quantity-edit-modal";
 import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
   insertProjectedItemIntoStoreGroups,
@@ -42,6 +44,7 @@ import {
   restoreGeneratedShoppingItem,
   toggleShoppingItemChecked,
   updateGeneratedShoppingItemOverride,
+  updateGeneratedShoppingItemQuantity,
   updateManualShoppingItem,
   type GeneratedShoppingItemOverrideFieldErrors,
   type GeneratedShoppingItemOverrideValues,
@@ -71,6 +74,7 @@ type ShoppingIntent =
   | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
   | "update-generated-shopping-item"
+  | "update-generated-shopping-item-quantity"
   | "update-manual-shopping-item";
 
 interface ShoppingActionData {
@@ -597,6 +601,42 @@ export async function action({
     });
   }
 
+  if (intent === "update-generated-shopping-item-quantity") {
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+
+    if (!sourceKey) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    const result = await updateGeneratedShoppingItemQuantity({
+      expectedUpdatedAt: parseExpectedUpdatedAt(formData),
+      familyId,
+      mealPlanId,
+      quantity: String(formData.get("quantity") ?? ""),
+      sourceKey,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies ShoppingActionData;
+    }
+
+    return {
+      intent,
+      ok: true,
+    } satisfies ShoppingActionData;
+  }
+
   return {
     formError: "Ukjent handling.",
   } satisfies ShoppingActionData;
@@ -609,12 +649,21 @@ export default function FamilyMealPlanShoppingRoute({
   const navigation = useNavigation();
   const revalidator = useRevalidator();
   const scheduleRevalidate = useDebouncedRevalidate(revalidator.revalidate);
+  const quantityFetcher = useFetcher<ShoppingActionData>();
   const pendingIntent = navigation.formData?.get("intent");
   const pendingSourceKey = getPendingSourceKey(navigation.formData);
   const [storeGroups, setStoreGroups] = useState(loaderData.storeGroups);
   const [recentManualItems, setRecentManualItems] = useState(
     loaderData.recentManualItems,
   );
+  const [quantityEditItem, setQuantityEditItem] = useState<{
+    collaborationVersion: string;
+    name: string;
+    quantity: string;
+    sourceKey: string;
+  } | null>(null);
+  const [quantityDraft, setQuantityDraft] = useState("");
+  const quantityInputRef = useRef<HTMLInputElement>(null);
   const addManualValues =
     actionData?.intent === "add-manual-shopping-item" && actionData.manualValues
       ? actionData.manualValues
@@ -641,6 +690,45 @@ export default function FamilyMealPlanShoppingRoute({
     },
     [scheduleRevalidate],
   );
+
+  const closeQuantityEdit = useCallback(() => {
+    setQuantityEditItem(null);
+  }, []);
+
+  const submitGeneratedQuantity = useCallback(
+    (item: { collaborationVersion: string; sourceKey: string }, quantity: string) => {
+      const formData = new FormData();
+      formData.set("intent", "update-generated-shopping-item-quantity");
+      formData.set("sourceKey", item.sourceKey);
+      formData.set("expectedUpdatedAt", item.collaborationVersion);
+      formData.set("quantity", quantity);
+      quantityFetcher.submit(formData, { method: "post" });
+      closeQuantityEdit();
+    },
+    [closeQuantityEdit, quantityFetcher],
+  );
+
+  useEffect(() => {
+    if (!quantityEditItem) {
+      return;
+    }
+
+    quantityInputRef.current?.focus();
+    quantityInputRef.current?.select();
+  }, [quantityEditItem]);
+
+  useEffect(() => {
+    if (
+      quantityFetcher.state !== "idle" ||
+      quantityFetcher.data?.intent !==
+        "update-generated-shopping-item-quantity" ||
+      !quantityFetcher.data.ok
+    ) {
+      return;
+    }
+
+    scheduleRevalidate();
+  }, [quantityFetcher.data, quantityFetcher.state, scheduleRevalidate]);
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -1270,6 +1358,7 @@ export default function FamilyMealPlanShoppingRoute({
                                       item.postponedUntilDate ?? "",
                                     preferredStoreId:
                                       item.preferredStore?.id ?? "",
+                                    quantity: item.quantity ?? "",
                                   }
                                 : null;
                           const quantityBadge =
@@ -1308,15 +1397,39 @@ export default function FamilyMealPlanShoppingRoute({
                                 <h4 className="text-base font-semibold text-slate-950">
                                   {item.name}
                                 </h4>
-                                {quantityBadge ? (
-                                  <span
+                                {item.sourceType === "GENERATED" ? (
+                                  <button
                                     className={
-                                      item.sourceType === "GENERATED" &&
+                                      quantityBadge &&
                                       !item.quantityLabel &&
                                       item.occurrenceCount > 1
-                                        ? "rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800"
-                                        : "rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                                        ? "rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-800 transition hover:bg-amber-200"
+                                        : "rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200 transition hover:bg-slate-100"
                                     }
+                                    onClick={() => {
+                                      setQuantityDraft(
+                                        item.quantity ??
+                                          item.quantityLabel ??
+                                          "",
+                                      );
+                                      setQuantityEditItem({
+                                        collaborationVersion:
+                                          item.collaborationVersion,
+                                        name: item.name,
+                                        quantity: item.quantity ?? "",
+                                        sourceKey: item.sourceKey,
+                                      });
+                                    }}
+                                    type="button"
+                                  >
+                                    <span className="inline-flex items-center gap-1">
+                                      {quantityBadge ?? "Sett mengde"}
+                                      <QuantityEditIcon className="h-3 w-3 opacity-80" />
+                                    </span>
+                                  </button>
+                                ) : quantityBadge ? (
+                                  <span
+                                    className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
                                   >
                                     {quantityBadge}
                                   </span>
@@ -1438,6 +1551,22 @@ export default function FamilyMealPlanShoppingRoute({
           </section>
         )}
       </div>
+      {quantityEditItem ? (
+        <ShoppingQuantityEditModal
+          canReset={Boolean(quantityEditItem.quantity.trim())}
+          name={quantityEditItem.name}
+          onCancel={closeQuantityEdit}
+          onReset={() =>
+            submitGeneratedQuantity(quantityEditItem, "")
+          }
+          onSave={() =>
+            submitGeneratedQuantity(quantityEditItem, quantityDraft)
+          }
+          quantity={quantityDraft}
+          quantityInputRef={quantityInputRef}
+          setQuantity={setQuantityDraft}
+        />
+      ) : null}
     </main>
   );
 }
@@ -1549,6 +1678,7 @@ function parseGeneratedShoppingItemOverrideValues(
     note: String(formData.get("note") ?? ""),
     postponedUntilDate: String(formData.get("postponedUntilDate") ?? ""),
     preferredStoreId: String(formData.get("preferredStoreId") ?? ""),
+    quantity: String(formData.get("quantity") ?? ""),
   };
 }
 
@@ -1691,4 +1821,29 @@ function formatDateLabel(value: string) {
 
 function formatMealPlanWindow(startDate: string, endDate: string) {
   return `${formatDateLabel(startDate)} til ${formatDateLabel(endDate)}`;
+}
+
+function QuantityEditIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 20h4l10.5-10.5-4-4L4 16v4Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.75"
+      />
+      <path
+        d="m13.5 6.5 4 4"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.75"
+      />
+    </svg>
+  );
 }

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -44,6 +44,7 @@ vi.mock("../lib/shopping-write.server", () => {
     parseManualShoppingItemValues: vi.fn(),
     toggleShoppingItemChecked: vi.fn(),
     updateActiveShoppingDate: vi.fn(),
+    updateGeneratedShoppingItemQuantity: vi.fn(),
     updateManualShoppingItem: vi.fn(),
   };
 });
@@ -80,6 +81,7 @@ import {
   parseManualShoppingItemValues,
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
+  updateGeneratedShoppingItemQuantity,
   updateManualShoppingItem,
 } from "../lib/shopping-write.server";
 import { listIngredientCategories } from "../lib/store.server";
@@ -164,6 +166,7 @@ describe("family store mode route", () => {
                 id: "store-1",
                 name: "Meny",
               },
+              quantity: null,
               quantityLabel: "1 stk",
               section: {
                 displayName: "Frukt og gront",
@@ -595,6 +598,43 @@ describe("family store mode route", () => {
     });
     expect(result).toEqual({
       intent: "update-family-shopping-item-quantity",
+      ok: true,
+    });
+  });
+
+  it("updates generated item quantity without redirecting", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(resolveStoreModeAnchorMealPlan).mockResolvedValue({
+      id: "meal-plan-1",
+    });
+    vi.mocked(updateGeneratedShoppingItemQuantity).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-generated-shopping-item-quantity");
+    formData.set("sourceKey", "entry-1:ingredient-1");
+    formData.set("expectedUpdatedAt", "2026-05-10T00:00:00.000Z");
+    formData.set("quantity", "4 flasker");
+    formData.set("itemMealPlanId", "meal-plan-2");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(undefined, formData),
+    } as never);
+
+    expect(updateGeneratedShoppingItemQuantity).toHaveBeenCalledWith({
+      expectedUpdatedAt: "2026-05-10T00:00:00.000Z",
+      familyId: "family-1",
+      mealPlanId: "meal-plan-2",
+      quantity: "4 flasker",
+      sourceKey: "entry-1:ingredient-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      intent: "update-generated-shopping-item-quantity",
       ok: true,
     });
   });

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -62,6 +62,7 @@ import {
   parseManualShoppingItemValues,
   toggleShoppingItemChecked,
   updateActiveShoppingDate,
+  updateGeneratedShoppingItemQuantity,
   updateManualShoppingItem,
 } from "../lib/shopping-write.server";
 import { listIngredientCategories } from "../lib/store.server";
@@ -101,6 +102,7 @@ type StoreModeIntent =
   | "quick-add-family-shopping-item"
   | "update-family-shopping-item-category"
   | "update-family-shopping-item-quantity"
+  | "update-generated-shopping-item-quantity"
   | "update-manual-shopping-item-category"
   | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
@@ -364,6 +366,44 @@ export async function action({ params, request }: Route.ActionArgs) {
     } satisfies StoreModeActionData;
   }
 
+  if (intent === "update-generated-shopping-item-quantity") {
+    const sourceKey = String(formData.get("sourceKey") ?? "").trim();
+    const quantity = String(formData.get("quantity") ?? "");
+
+    if (!sourceKey) {
+      return {
+        formError: "Vi fant ikke handlelinjen som skulle oppdateres.",
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    const itemMealPlanId = resolveItemMealPlanId(formData, anchorMealPlanId);
+    const result = await updateGeneratedShoppingItemQuantity({
+      expectedUpdatedAt: String(formData.get("expectedUpdatedAt") ?? ""),
+      familyId,
+      mealPlanId: itemMealPlanId,
+      quantity,
+      sourceKey,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw buildMealPlanNotFoundResponse();
+    }
+
+    if (result.status === "CONFLICT") {
+      return {
+        formError: result.formError,
+        intent,
+      } satisfies StoreModeActionData;
+    }
+
+    return {
+      intent,
+      ok: true,
+    } satisfies StoreModeActionData;
+  }
+
   if (intent === "update-family-shopping-item-category") {
     const familyItemId = String(formData.get("sourceKey") ?? "").trim();
 
@@ -594,18 +634,32 @@ export default function FamilyMealPlanStoreModeRoute({
   const handleUpdateQuantity = useCallback(
     ({
       expectedUpdatedAt,
+      mealPlanId,
       quantity,
       sourceKey,
+      sourceType,
     }: {
       expectedUpdatedAt: string;
+      mealPlanId?: string | null;
       quantity: string;
       sourceKey: string;
+      sourceType: "FAMILY" | "GENERATED";
     }) => {
       const formData = new FormData();
-      formData.set("intent", "update-family-shopping-item-quantity");
+      formData.set(
+        "intent",
+        sourceType === "GENERATED"
+          ? "update-generated-shopping-item-quantity"
+          : "update-family-shopping-item-quantity",
+      );
       formData.set("sourceKey", sourceKey);
       formData.set("expectedUpdatedAt", expectedUpdatedAt);
       formData.set("quantity", quantity);
+
+      if (sourceType === "GENERATED" && mealPlanId) {
+        formData.set("itemMealPlanId", mealPlanId);
+      }
+
       quantityFetcher.submit(formData, { method: "post" });
     },
     [quantityFetcher],
@@ -614,7 +668,10 @@ export default function FamilyMealPlanStoreModeRoute({
   useEffect(() => {
     if (
       quantityFetcher.state !== "idle" ||
-      quantityFetcher.data?.intent !== "update-family-shopping-item-quantity" ||
+      (quantityFetcher.data?.intent !==
+        "update-family-shopping-item-quantity" &&
+        quantityFetcher.data?.intent !==
+          "update-generated-shopping-item-quantity") ||
       !quantityFetcher.data.ok
     ) {
       return;
@@ -1287,8 +1344,10 @@ function StoreModeItemGrid<
   onUpdateCategory: (request: StoreModeCategoryUpdateRequest) => void;
   onUpdateQuantity: (item: {
     expectedUpdatedAt: string;
+    mealPlanId?: string | null;
     quantity: string;
     sourceKey: string;
+    sourceType: "FAMILY" | "GENERATED";
   }) => void;
   onToggleItem: (item: TItem) => void;
   recentlyAddedSourceKey: string | null;

--- a/prisma/migrations/20260817100000_add_shopping_item_override_quantity/migration.sql
+++ b/prisma/migrations/20260817100000_add_shopping_item_override_quantity/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ShoppingItemOverride" ADD COLUMN "quantity" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -417,6 +417,7 @@ model ShoppingItemOverride {
   postponedUntilDate    DateTime?          @db.Date
   preferredStoreId      String?
   note                  String?
+  quantity              String?
   updatedByUserId       String?
   createdAt          DateTime           @default(now())
   updatedAt          DateTime           @updatedAt


### PR DESCRIPTION
## Summary
- Recipe-generated shopping lines can now have their quantity edited directly on the meal-plan list and in store mode.
- The override persists until cleared, including after later meal-plan merge-key changes, without adding a renamed manual item.

## Related issue
Closes #183

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Edit a generated quantity on the meal-plan shopping list and confirm the same name and amount in store mode
- [ ] Use Tilbakestill / empty quantity and confirm the recipe-computed amount returns
- [ ] Confirm recipe ingredient amounts are unchanged

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck