### PR TITLE
Show form mutations immediately instead of waiting for save

### DIFF
--- a/.cursor/rules/frontend-standards.mdc
+++ b/.cursor/rules/frontend-standards.mdc
@@ -16,6 +16,7 @@ alwaysApply: true
 - Reuse existing primitives and patterns before introducing new wrappers, variants, or utilities.
 - In Tailwind, prefer readable utility composition and shared patterns over long repeated class strings.
 - Match existing project conventions and keep changes minimal.
+- Client form submissions must update visible data immediately (optimistic). Pending-only `"Lagrer..."` is not enough; follow `.cursor/rules/optimistic-form-updates.mdc`.
 - Use text-base as font size for any text inputs to prevent auto-zoom in iOS devices
 
 ```tsx

--- a/.cursor/rules/optimistic-form-updates.mdc
+++ b/.cursor/rules/optimistic-form-updates.mdc
@@ -1,0 +1,37 @@
+---
+description: Client form submissions must update visible data immediately (optimistic)
+globs: app/{routes,components,features}/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# Optimistic form updates
+
+Every client **mutation** must show the intended result immediately, then reconcile with the action/loader. Pending-only UI (`"Lagrer..."`, disabled buttons) is **not** optimistic.
+
+## Do
+
+- Apply the change to display state **before or as** you submit (`useFetcher` + overlay, `navigation.formData` / `fetcher.formData`, or a queue like `useStoreModeToggleSync`).
+- Roll back on error and show the action error. On success, drop the overlay and let loader data take over.
+- For shopping lists, reuse helpers in `app/lib/shopping-list-client.ts`.
+
+```tsx
+// BAD — waits for revalidation; button spinner is not optimistic
+const isPending = navigation.state === "submitting" && pendingSourceKey === item.sourceKey;
+<button disabled={isPending}>{item.checked ? "Kjøpt" : "Ikke kjøpt"}</button>
+
+// GOOD — visible data follows the in-flight form
+const pendingChecked = navigation.formData?.get("sourceKey") === item.sourceKey
+  ? navigation.formData.get("checked") === "true"
+  : item.checked;
+```
+
+## Don't
+
+- Leave the list/card on the old value until the loader returns.
+- Insert or patch items only in an `onSuccess` handler after the action returns. That hides revalidation latency; it is **not** optimistic.
+
+## Exceptions
+
+- Auth and session flows (`login`, `register`, `logout`) that only set a session and navigate.
+- GET search forms.
+- Mutations whose only result is a redirect to a page that did not exist yet (e.g. create family) — still prefer optimistic UI when the current view can show the new entity.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,33 @@
 
 ## Current Objective
 
-Ship issue #183: editable quantity on recipe-generated shopping list items.
+Ship optimistic form updates so in-scope mutations change visible data immediately, then reconcile with the loader.
 
 ## Completed
 
-- Generated shopping lines can be quantity-edited on the meal-plan list and in store mode, without a renamed manual item.
-- Override persists until cleared, including after merge-key changes.
-- Validation passed and the branch is ready to push/PR.
+- Shopping overlays (check, quantity, category/notes, add, update/delete/exclude/restore/opt-in, GLOBAL list-mode filter) share helpers in `shopping-list-client.ts`.
+- Freezer, stock, stores, recipes, meal plans, review chips/notes/approve, and remove-member use `navigation.formData` or a local overlay until the loader matches.
+- Auto-fill only shows a filling state on empty days. COMBINED list mode still waits for the loader when switching from GLOBAL.
 
 ## Files To Read First
 
-- `app/lib/shopping-write.server.ts` - quantity update and override preservation
-- `app/lib/shopping.server.ts` - projection and overlapping override lookup
-- `app/components/shopping-quantity-edit-modal.tsx` - shared quantity modal
+- `app/lib/shopping-list-client.ts` - overlay helpers and form overlay
+- `.cursor/rules/optimistic-form-updates.mdc` - required UI pattern
+- `app/routes/family-meal-plan.tsx` - meal-plan detail overlays
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (391 tests)
+- `npm run test:run` — passed (401 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Apply migration `20260817100000_add_shopping_item_override_quantity` on deploy.
-- Manual UI check after merge: edit a generated quantity on the meal-plan list, confirm it in store mode, then Tilbakestill.
+- Manual smoke after merge: submit, confirm UI updates before network idle, confirm no duplicate after revalidate, force an error and confirm rollback.
+- Auto-fill and COMBINED←GLOBAL remain partial by data availability; that is intended.
+- Skipped by plan: login/register/logout, GET search, create-family, join-family.
 
 ## Next Step
 
-Merge the pull request for issue #183 after review.
+Review and merge the pull request for optimistic form updates.

--- a/app/components/family-recipe-editor-card.tsx
+++ b/app/components/family-recipe-editor-card.tsx
@@ -60,11 +60,11 @@ export function FamilyRecipeEditorCard({
   const pendingIntent = navigation.formData?.get("intent");
   const pendingRecipeId = String(navigation.formData?.get("recipeId") ?? "");
   const isUpdatingRecipe =
-    navigation.state === "submitting" &&
+    navigation.state !== "idle" &&
     pendingIntent === "update-recipe" &&
     pendingRecipeId === recipe.id;
   const isDeletingRecipe =
-    navigation.state === "submitting" &&
+    navigation.state !== "idle" &&
     pendingIntent === "delete-recipe" &&
     pendingRecipeId === recipe.id;
   const persistedValues = useMemo<FamilyRecipeValues>(
@@ -190,12 +190,17 @@ export function FamilyRecipeEditorCard({
 
   return (
     <article className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      {isDeletingRecipe ? (
+        <p className="text-sm font-medium text-rose-700">Sletter oppskrift...</p>
+      ) : null}
+      <div className={`flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between ${isDeletingRecipe ? "mt-3 opacity-60" : ""}`}>
         <div>
           <span className="inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
             Familieoppskrift
           </span>
-          <h2 className="mt-3 text-2xl font-semibold text-slate-950">{recipe.title}</h2>
+          <h2 className="mt-3 text-2xl font-semibold text-slate-950">
+            {isUpdatingRecipe ? draftValues.title : recipe.title}
+          </h2>
           {mealPlanEntryCount > 0 ? (
             <p className="mt-2 text-sm text-slate-600">
               Brukt i {mealPlanEntryCount}{" "}

--- a/app/components/family-store-editor-card.tsx
+++ b/app/components/family-store-editor-card.tsx
@@ -41,11 +41,11 @@ export function FamilyStoreEditorCard({
   const pendingIntent = navigation.formData?.get("intent");
   const pendingStoreId = String(navigation.formData?.get("storeId") ?? "");
   const isUpdatingStore =
-    navigation.state === "submitting" &&
+    navigation.state !== "idle" &&
     pendingIntent === "update-store" &&
     pendingStoreId === store.id;
   const isDeletingStore =
-    navigation.state === "submitting" &&
+    navigation.state !== "idle" &&
     pendingIntent === "delete-store" &&
     pendingStoreId === store.id;
   const persistedValues = useMemo<FamilyStoreValues>(
@@ -136,7 +136,7 @@ export function FamilyStoreEditorCard({
       <div className="flex items-start justify-between gap-3">
         <div>
           <h3 className="text-base font-semibold text-slate-950">
-            {store.name}
+            {isUpdatingStore ? draftName : store.name}
           </h3>
           <p className="mt-2 text-sm leading-6 text-slate-600">
             {isEditing
@@ -145,7 +145,7 @@ export function FamilyStoreEditorCard({
           </p>
         </div>
 
-        {canManageStores && !isEditing ? (
+        {canManageStores && !isEditing && !store.id.startsWith("optimistic:") ? (
           <button
             className="rounded-2xl bg-slate-950 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-slate-800"
             onClick={handleStartEditing}
@@ -232,7 +232,7 @@ export function FamilyStoreEditorCard({
         </div>
       )}
 
-      {canManageStores && !isEditing ? (
+      {canManageStores && !isEditing && !store.id.startsWith("optimistic:") ? (
         <div className="mt-4">
           <Form method="post">
             <input name="intent" type="hidden" value="delete-store" />

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -9,10 +9,12 @@ import {
 import { useFetcher } from "react-router";
 
 import type {
+  OptimisticQuickAddDraft,
   QuickAddShoppingActionData,
   QuickAddShoppingSuccess,
 } from "../lib/shopping-quick-add";
 import { isQuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import { createOptimisticSourceKey } from "../lib/shopping-list-client";
 import type { RecentManualShoppingItem } from "../lib/shopping.server";
 
 export interface IngredientSearchResult {
@@ -31,6 +33,8 @@ interface ManualShoppingQuickAddProps {
   appearance?: ManualShoppingQuickAddAppearance;
   autoFocus?: boolean;
   ingredientSearchPath: string;
+  onQuickAddError?: (sourceKey: string) => void;
+  onQuickAddSubmit?: (draft: OptimisticQuickAddDraft) => void;
   onQuickAddSuccess?: (payload: QuickAddShoppingSuccess) => void;
   quickAddIntent?: string;
   recentManualItems: RecentManualShoppingItem[];
@@ -120,6 +124,8 @@ export function ManualShoppingQuickAdd({
   appearance = "default",
   autoFocus = false,
   ingredientSearchPath,
+  onQuickAddError,
+  onQuickAddSubmit,
   onQuickAddSuccess,
   quickAddIntent = DEFAULT_QUICK_ADD_INTENT,
   recentManualItems,
@@ -155,6 +161,11 @@ export function ManualShoppingQuickAdd({
   searchFetcherRef.current = searchFetcher;
   const onQuickAddSuccessRef = useRef(onQuickAddSuccess);
   onQuickAddSuccessRef.current = onQuickAddSuccess;
+  const onQuickAddSubmitRef = useRef(onQuickAddSubmit);
+  onQuickAddSubmitRef.current = onQuickAddSubmit;
+  const onQuickAddErrorRef = useRef(onQuickAddError);
+  onQuickAddErrorRef.current = onQuickAddError;
+  const pendingOptimisticSourceKeyRef = useRef<string | null>(null);
   const isQuickAdding = quickAddFetcher.state !== "idle";
   const trimmedQuery = query.trim();
   const quickAddActionData =
@@ -194,6 +205,25 @@ export function ManualShoppingQuickAdd({
 
     if (typeof fields.quantity === "string") {
       formData.set("quantity", fields.quantity);
+    }
+
+    const draftName =
+      fields.name?.trim() ||
+      displayedResults.find((ingredient) => ingredient.id === fields.ingredientId)
+        ?.canonicalName ||
+      recentManualItems.find(
+        (item) => item.nameNormalized === fields.recentNameNormalized,
+      )?.displayName ||
+      trimmedQuery;
+    const sourceKey = createOptimisticSourceKey();
+    pendingOptimisticSourceKeyRef.current = sourceKey;
+
+    if (draftName) {
+      onQuickAddSubmitRef.current?.({
+        name: draftName,
+        quantity: fields.quantity ?? quantity,
+        sourceKey,
+      });
     }
 
     quickAddFetcher.submit(formData, { method: "post" });
@@ -246,13 +276,23 @@ export function ManualShoppingQuickAdd({
 
   useEffect(() => {
     if (
-      !isQuickAddShoppingSuccess(quickAddFetcher.data) ||
+      !quickAddFetcher.data ||
       quickAddFetcher.data === lastHandledQuickAddDataRef.current
     ) {
       return;
     }
 
     lastHandledQuickAddDataRef.current = quickAddFetcher.data;
+    const optimisticSourceKey = pendingOptimisticSourceKeyRef.current;
+    pendingOptimisticSourceKeyRef.current = null;
+
+    if (!isQuickAddShoppingSuccess(quickAddFetcher.data)) {
+      if (optimisticSourceKey) {
+        onQuickAddErrorRef.current?.(optimisticSourceKey);
+      }
+      return;
+    }
+
     setIsListOpen(false);
     setIsInputFocused(false);
     setQuery("");

--- a/app/components/meal-plan-week-entries-form.tsx
+++ b/app/components/meal-plan-week-entries-form.tsx
@@ -148,6 +148,17 @@ export function MealPlanWeekEntriesForm({
   }, [entriesSnapshot]);
 
   useEffect(() => {
+    if (!isResettingEntries) {
+      return;
+    }
+
+    setMealSelectionsByDate(
+      Object.fromEntries(visibleDates.map((date) => [date, ""])),
+    );
+    setIsReorderMode(false);
+  }, [isResettingEntries, visibleDates]);
+
+  useEffect(() => {
     if (isSavingEntries) {
       setIsReorderMode(false);
     }
@@ -187,6 +198,7 @@ export function MealPlanWeekEntriesForm({
               familyId={familyId}
               familyMembers={familyMembers}
               freezerItems={freezerItems}
+              isAutoFillingEntries={isAutoFillingEntries}
               isReorderMode={isReorderMode}
               isToday={isPlanDateToday(date)}
               mealPlanId={mealPlanId}
@@ -282,6 +294,7 @@ function MealPlanDayRow({
   familyId,
   familyMembers,
   freezerItems,
+  isAutoFillingEntries,
   isReorderMode,
   isToday,
   mealPlanId,
@@ -298,6 +311,7 @@ function MealPlanDayRow({
   familyId: string;
   familyMembers: MealPlanFamilyMemberOption[];
   freezerItems: MealPlanFreezerOption[];
+  isAutoFillingEntries: boolean;
   isReorderMode: boolean;
   isToday: boolean;
   mealPlanId: string;
@@ -333,6 +347,11 @@ function MealPlanDayRow({
     !parsedSelection.freezerItemId &&
     Boolean(entry.note.trim());
   const hasFreezerSelection = Boolean(parsedSelection.freezerItemId);
+  const isFillingEmptyDay =
+    isAutoFillingEntries &&
+    !parsedSelection.recipeId &&
+    !parsedSelection.freezerItemId &&
+    !entry.note.trim();
   const responsibleMember =
     familyMembers.find(
       (member) => member.id === selectedResponsibleUserId,
@@ -400,7 +419,7 @@ function MealPlanDayRow({
             {formatWeekdayLabel(date)}
           </p>
           <p className="truncate text-base font-semibold text-slate-950">
-            {mealLabel}
+            {isFillingEmptyDay ? "Fyller tom dag..." : mealLabel}
           </p>
           <p className="text-xs text-slate-500">{formatDateLabel(date)}</p>
         </div>

--- a/app/components/shopping-list-item-expanded.tsx
+++ b/app/components/shopping-list-item-expanded.tsx
@@ -95,6 +95,7 @@ type ShoppingListItemExpandedProps = {
   };
   categories: Array<{ displayName: string; id: string }>;
   familyValues?: FamilyShoppingItemValues | null;
+  displayChecked?: boolean;
   isPendingCheckToggle: boolean;
   isPendingFamilyDelete?: boolean;
   isPendingFamilySave?: boolean;
@@ -128,6 +129,7 @@ type ShoppingListItemExpandedProps = {
 export function ShoppingListItemExpanded({
   actionData,
   categories,
+  displayChecked,
   isPendingCheckToggle,
   isPendingGeneratedExclude,
   isPendingGeneratedSave,
@@ -143,6 +145,7 @@ export function ShoppingListItemExpanded({
   stores,
   toggleExpectedVersion,
 }: ShoppingListItemExpandedProps) {
+  const checked = displayChecked ?? item.checked;
   return (
     <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
       <div className="min-w-0 rounded-[20px] bg-white p-4 ring-1 ring-slate-200">
@@ -215,10 +218,10 @@ export function ShoppingListItemExpanded({
             type="submit"
           >
             {isPendingCheckToggle
-              ? item.checked
-                ? "Oppdaterer..."
-                : "Krysser av..."
-              : item.checked
+              ? checked
+                ? "Krysser av..."
+                : "Oppdaterer..."
+              : checked
                 ? "Fjern avkryssing"
                 : "Marker som kjøpt"}
           </button>

--- a/app/lib/shopping-list-client.test.ts
+++ b/app/lib/shopping-list-client.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  applyOptimisticShoppingListFormOverlay,
+  buildOptimisticManualShoppingItem,
+  dropResolvedOptimisticItemsFromStoreGroups,
+  filterStoreGroupsBySourceType,
+  getOptimisticChecked,
   insertProjectedItemIntoSectionGroups,
   insertProjectedItemIntoStoreGroups,
   mergeQuickAddedItemsIntoList,
+  patchProjectedItemInSectionGroups,
+  patchProjectedItemInStoreGroups,
   prependRecentManualItem,
   relocateProjectedItemInSectionGroups,
+  relocateProjectedItemInStoreGroups,
+  removeProjectedItemFromStoreGroups,
 } from "./shopping-list-client";
 import type { SerializedProjectedShoppingItem } from "./shopping-serialize";
 
@@ -190,5 +199,309 @@ describe("shopping-list-client", () => {
     const result = mergeQuickAddedItemsIntoList([loaderItem], [quickAddedItem]);
 
     expect(result.map((item) => item.sourceKey)).toEqual(["item-1", "item-2"]);
+  });
+
+  it("removes an item from store groups and drops empty groups", () => {
+    const existingItem = createFamilyItem({
+      name: "Brød",
+      sourceKey: "item-1",
+    });
+
+    const result = removeProjectedItemFromStoreGroups(
+      [
+        {
+          store: existingItem.preferredStore,
+          sections: [
+            {
+              category: existingItem.category,
+              displayName: existingItem.section.displayName,
+              items: [existingItem],
+            },
+          ],
+        },
+      ],
+      "item-1",
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("patches quantity and checked in store groups without moving the item", () => {
+    const existingItem = createFamilyItem({
+      name: "Melk",
+      quantity: "1",
+      quantityLabel: "1",
+      sourceKey: "item-1",
+    });
+
+    const result = patchProjectedItemInStoreGroups(
+      [
+        {
+          store: existingItem.preferredStore,
+          sections: [
+            {
+              category: existingItem.category,
+              displayName: existingItem.section.displayName,
+              items: [existingItem],
+            },
+          ],
+        },
+      ],
+      "item-1",
+      {
+        checked: true,
+        quantity: "2 liter",
+        quantityLabel: "2 liter",
+      },
+    );
+
+    expect(result[0]?.sections[0]?.items[0]).toMatchObject({
+      checked: true,
+      quantity: "2 liter",
+      quantityLabel: "2 liter",
+      sourceKey: "item-1",
+    });
+    expect(result[0]?.sections[0]?.displayName).toBe("Meieri");
+  });
+
+  it("patches an item in section groups", () => {
+    const existingItem = createFamilyItem({
+      name: "Melk",
+      note: null,
+      sourceKey: "item-1",
+    });
+
+    const result = patchProjectedItemInSectionGroups(
+      [
+        {
+          category: existingItem.category,
+          displayName: existingItem.section.displayName,
+          items: [existingItem],
+        },
+      ],
+      "item-1",
+      { note: "Tine" },
+    );
+
+    expect(result[0]?.items[0]?.note).toBe("Tine");
+  });
+
+  it("relocates an item into a new store group", () => {
+    const existingItem = createFamilyItem({
+      name: "Bananer",
+      preferredStore: { id: "store-1", name: "Rema" },
+      sourceKey: "item-1",
+    });
+    const updatedItem = createFamilyItem({
+      name: "Bananer",
+      preferredStore: { id: "store-2", name: "Kiwi" },
+      sourceKey: "item-1",
+    });
+
+    const result = relocateProjectedItemInStoreGroups(
+      [
+        {
+          store: existingItem.preferredStore,
+          sections: [
+            {
+              category: existingItem.category,
+              displayName: existingItem.section.displayName,
+              items: [existingItem],
+            },
+          ],
+        },
+      ],
+      "item-1",
+      updatedItem,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.store?.id).toBe("store-2");
+    expect(result[0]?.sections[0]?.items[0]?.sourceKey).toBe("item-1");
+  });
+
+  it("filters store groups down to a single source type", () => {
+    const familyItem = createFamilyItem({
+      name: "Melk",
+      sourceKey: "family-1",
+    });
+    const generatedItem = {
+      ...createFamilyItem({
+        name: "Kylling",
+        sourceKey: "generated-1",
+      }),
+      amount: null,
+      firstDate: "2026-08-17",
+      lastDate: "2026-08-17",
+      occurrenceCount: 1,
+      occurrences: [],
+      postponedUntilDate: null,
+      preferredStoreConflict: false,
+      recipeCount: 1,
+      sourceType: "GENERATED" as const,
+      unit: null,
+    };
+
+    const result = filterStoreGroupsBySourceType(
+      [
+        {
+          store: familyItem.preferredStore,
+          sections: [
+            {
+              category: familyItem.category,
+              displayName: familyItem.section.displayName,
+              items: [familyItem, generatedItem],
+            },
+          ],
+        },
+      ],
+      "FAMILY",
+    );
+
+    expect(result[0]?.sections[0]?.items.map((item) => item.sourceKey)).toEqual([
+      "family-1",
+    ]);
+  });
+
+  it("builds an optimistic family placeholder with a temp source key", () => {
+    const item = buildOptimisticManualShoppingItem({
+      category: { id: "category-1", name: "Meieri" },
+      name: "  Melk  ",
+      quantity: "1 liter",
+      sourceType: "FAMILY",
+    });
+
+    expect(item.sourceType).toBe("FAMILY");
+    expect(item.name).toBe("Melk");
+    expect(item.quantity).toBe("1 liter");
+    expect(item.checked).toBe(false);
+    expect(item.sourceKey.startsWith("optimistic:")).toBe(true);
+  });
+
+  it("drops optimistic placeholders once the loader has a matching name", () => {
+    const placeholder = buildOptimisticManualShoppingItem({
+      category: { id: "category-1", name: "Meieri" },
+      name: "Melk",
+      sourceKey: "optimistic:temp",
+      sourceType: "FAMILY",
+    });
+    const loaderItem = createFamilyItem({
+      name: "Melk",
+      sourceKey: "family-real",
+    });
+
+    const result = dropResolvedOptimisticItemsFromStoreGroups(
+      [
+        {
+          store: placeholder.preferredStore,
+          sections: [
+            {
+              category: placeholder.category,
+              displayName: placeholder.section.displayName,
+              items: [placeholder],
+            },
+          ],
+        },
+      ],
+      [loaderItem],
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("reads the pending checked value from in-flight form data", () => {
+    expect(
+      getOptimisticChecked({
+        checkedValue: "true",
+        isPending: true,
+        itemChecked: false,
+      }),
+    ).toBe(true);
+    expect(
+      getOptimisticChecked({
+        checkedValue: "false",
+        isPending: true,
+        itemChecked: true,
+      }),
+    ).toBe(false);
+    expect(
+      getOptimisticChecked({
+        checkedValue: "true",
+        isPending: false,
+        itemChecked: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("removes a deleted item from the in-flight overlay", () => {
+    const existingItem = createFamilyItem({
+      name: "Melk",
+      sourceKey: "item-1",
+    });
+    const formData = new FormData();
+
+    const result = applyOptimisticShoppingListFormOverlay({
+      categories: [{ displayName: "Meieri", id: "category-1" }],
+      formData,
+      groups: [
+        {
+          store: existingItem.preferredStore,
+          sections: [
+            {
+              category: existingItem.category,
+              displayName: existingItem.section.displayName,
+              items: [existingItem],
+            },
+          ],
+        },
+      ],
+      intent: "delete-family-shopping-item",
+      sourceKey: "item-1",
+      stores: [],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("patches and relocates an updated item from in-flight form data", () => {
+    const existingItem = createFamilyItem({
+      name: "Melk",
+      sourceKey: "item-1",
+    });
+    const formData = new FormData();
+    formData.set("name", "Lettmelk");
+    formData.set("quantity", "2");
+    formData.set("categoryId", "category-produce");
+    formData.set("note", "Tine");
+
+    const result = applyOptimisticShoppingListFormOverlay({
+      categories: [
+        { displayName: "Meieri", id: "category-1" },
+        { displayName: "Frukt og grønt", id: "category-produce" },
+      ],
+      formData,
+      groups: [
+        {
+          store: existingItem.preferredStore,
+          sections: [
+            {
+              category: existingItem.category,
+              displayName: existingItem.section.displayName,
+              items: [existingItem],
+            },
+          ],
+        },
+      ],
+      intent: "update-family-shopping-item",
+      sourceKey: "item-1",
+      stores: [],
+    });
+
+    expect(result[0]?.sections[0]?.displayName).toBe("Frukt og grønt");
+    expect(result[0]?.sections[0]?.items[0]).toMatchObject({
+      name: "Lettmelk",
+      note: "Tine",
+      quantity: "2",
+    });
   });
 });

--- a/app/lib/shopping-list-client.ts
+++ b/app/lib/shopping-list-client.ts
@@ -1,3 +1,4 @@
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import type { RecentManualShoppingItem } from "./shopping.server";
 import type { SerializedProjectedShoppingItem } from "./shopping-serialize";
 
@@ -187,4 +188,350 @@ export function mergeQuickAddedItemsIntoList<T extends { sourceKey: string }>(
   }
 
   return mergedItems;
+}
+
+export const OPTIMISTIC_SOURCE_KEY_PREFIX = "optimistic:";
+
+export type ShoppingItemDisplayPatch = {
+  checked?: boolean;
+  name?: string;
+  note?: string | null;
+  quantity?: string | null;
+  quantityLabel?: string | null;
+};
+
+export function createOptimisticSourceKey() {
+  const id =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  return `${OPTIMISTIC_SOURCE_KEY_PREFIX}${id}`;
+}
+
+export function isOptimisticSourceKey(sourceKey: string) {
+  return sourceKey.startsWith(OPTIMISTIC_SOURCE_KEY_PREFIX);
+}
+
+export function getOptimisticChecked({
+  checkedValue,
+  isPending,
+  itemChecked,
+}: {
+  checkedValue: FormDataEntryValue | null | undefined;
+  isPending: boolean;
+  itemChecked: boolean;
+}) {
+  if (!isPending || checkedValue == null) {
+    return itemChecked;
+  }
+
+  return String(checkedValue) === "true";
+}
+
+export function removeProjectedItemFromStoreGroups(
+  groups: SerializedProjectedShoppingStoreGroup[],
+  sourceKey: string,
+): SerializedProjectedShoppingStoreGroup[] {
+  return groups
+    .map((group) => ({
+      ...group,
+      sections: removeProjectedItemFromSectionGroups(group.sections, sourceKey),
+    }))
+    .filter((group) => group.sections.length > 0);
+}
+
+export function patchProjectedItemInSectionGroups(
+  sections: SerializedProjectedShoppingSectionGroup[],
+  sourceKey: string,
+  patch: ShoppingItemDisplayPatch,
+): SerializedProjectedShoppingSectionGroup[] {
+  return sections.map((section) => ({
+    ...section,
+    items: section.items.map((item) =>
+      item.sourceKey === sourceKey ? { ...item, ...patch } : item,
+    ),
+  }));
+}
+
+export function patchProjectedItemInStoreGroups(
+  groups: SerializedProjectedShoppingStoreGroup[],
+  sourceKey: string,
+  patch: ShoppingItemDisplayPatch,
+): SerializedProjectedShoppingStoreGroup[] {
+  return groups.map((group) => ({
+    ...group,
+    sections: patchProjectedItemInSectionGroups(group.sections, sourceKey, patch),
+  }));
+}
+
+export function relocateProjectedItemInStoreGroups(
+  groups: SerializedProjectedShoppingStoreGroup[],
+  sourceKey: string,
+  updatedItem: SerializedProjectedShoppingItem,
+): SerializedProjectedShoppingStoreGroup[] {
+  return insertProjectedItemIntoStoreGroups(
+    removeProjectedItemFromStoreGroups(groups, sourceKey),
+    updatedItem,
+  );
+}
+
+export function filterStoreGroupsBySourceType(
+  groups: SerializedProjectedShoppingStoreGroup[],
+  sourceType: SerializedProjectedShoppingItem["sourceType"],
+): SerializedProjectedShoppingStoreGroup[] {
+  return groups
+    .map((group) => ({
+      ...group,
+      sections: group.sections
+        .map((section) => ({
+          ...section,
+          items: section.items.filter((item) => item.sourceType === sourceType),
+        }))
+        .filter((section) => section.items.length > 0),
+    }))
+    .filter((group) => group.sections.length > 0);
+}
+
+export function dropResolvedOptimisticItemsFromSectionGroups(
+  sections: SerializedProjectedShoppingSectionGroup[],
+  loaderItems: Array<{ name: string; sourceKey: string }>,
+): SerializedProjectedShoppingSectionGroup[] {
+  const loaderSourceKeys = new Set(loaderItems.map((item) => item.sourceKey));
+  const loaderNames = new Set(
+    loaderItems.map((item) => normalizeIngredientCanonicalName(item.name)),
+  );
+
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => {
+        if (!isOptimisticSourceKey(item.sourceKey)) {
+          return true;
+        }
+
+        return (
+          !loaderSourceKeys.has(item.sourceKey) &&
+          !loaderNames.has(normalizeIngredientCanonicalName(item.name))
+        );
+      }),
+    }))
+    .filter((section) => section.items.length > 0);
+}
+
+export function dropResolvedOptimisticItemsFromStoreGroups(
+  groups: SerializedProjectedShoppingStoreGroup[],
+  loaderItems: Array<{ name: string; sourceKey: string }>,
+): SerializedProjectedShoppingStoreGroup[] {
+  return groups
+    .map((group) => ({
+      ...group,
+      sections: dropResolvedOptimisticItemsFromSectionGroups(
+        group.sections,
+        loaderItems,
+      ),
+    }))
+    .filter((group) => group.sections.length > 0);
+}
+
+export function buildOptimisticManualShoppingItem({
+  buyOnDate = null,
+  category,
+  mealPlanId = null,
+  mealPlanTitle = null,
+  name,
+  note = null,
+  preferredStore = null,
+  quantity = null,
+  section,
+  sourceKey = createOptimisticSourceKey(),
+  sourceType,
+}: {
+  buyOnDate?: string | null;
+  category: { id: string; name: string };
+  mealPlanId?: string | null;
+  mealPlanTitle?: string | null;
+  name: string;
+  note?: string | null;
+  preferredStore?: SerializedProjectedShoppingItem["preferredStore"];
+  quantity?: string | null;
+  section?: { displayName: string; sortOrder: number };
+  sourceKey?: string;
+  sourceType: "FAMILY" | "MANUAL";
+}): SerializedProjectedShoppingItem {
+  const trimmedQuantity = quantity?.trim() || null;
+  const resolvedSection = section ?? {
+    displayName: category.name,
+    sortOrder: 99,
+  };
+  const base = {
+    category,
+    checked: false,
+    collaborationVersion: "",
+    mealPlanId,
+    mealPlanTitle,
+    name: name.trim(),
+    note,
+    preferredStore,
+    quantity: trimmedQuantity,
+    quantityLabel: trimmedQuantity,
+    section: resolvedSection,
+    sourceKey,
+  };
+
+  if (sourceType === "FAMILY") {
+    return {
+      ...base,
+      sourceType: "FAMILY",
+    };
+  }
+
+  return {
+    ...base,
+    buyOnDate,
+    overrideVersion: "",
+    sourceType: "MANUAL",
+  };
+}
+
+export function findProjectedItemInStoreGroups(
+  groups: SerializedProjectedShoppingStoreGroup[],
+  sourceKey: string,
+) {
+  for (const group of groups) {
+    for (const section of group.sections) {
+      const item = section.items.find(
+        (existingItem) => existingItem.sourceKey === sourceKey,
+      );
+
+      if (item) {
+        return item;
+      }
+    }
+  }
+
+  return null;
+}
+
+function applyFormUpdateToShoppingItem({
+  categories,
+  formData,
+  item,
+  stores,
+}: {
+  categories: Array<{ displayName: string; id: string }>;
+  formData: FormData;
+  item: SerializedProjectedShoppingItem;
+  stores: Array<{ id: string; name: string }>;
+}): SerializedProjectedShoppingItem {
+  const name = String(formData.get("name") ?? item.name).trim() || item.name;
+  const quantity = String(formData.get("quantity") ?? item.quantity ?? "");
+  const trimmedQuantity = quantity.trim() || null;
+  const noteValue = formData.get("note");
+  const note =
+    noteValue == null ? item.note : String(noteValue).trim() || null;
+  const categoryId = String(formData.get("categoryId") ?? item.category.id);
+  const categoryName =
+    categories.find((entry) => entry.id === categoryId)?.displayName ??
+    item.category.name;
+  const preferredStoreId = String(
+    formData.get("preferredStoreId") ?? item.preferredStore?.id ?? "",
+  );
+  const preferredStore =
+    preferredStoreId === ""
+      ? null
+      : (stores.find((store) => store.id === preferredStoreId) ??
+        item.preferredStore);
+  const buyOnDateValue = formData.get("buyOnDate");
+  const postponedUntilDateValue = formData.get("postponedUntilDate");
+
+  const nextItem = {
+    ...item,
+    category: {
+      id: categoryId || item.category.id,
+      name: categoryName,
+    },
+    name,
+    note,
+    preferredStore,
+    quantity: trimmedQuantity,
+    quantityLabel: trimmedQuantity,
+    section: {
+      ...item.section,
+      displayName: categoryName,
+    },
+  };
+
+  if (nextItem.sourceType === "MANUAL" && buyOnDateValue != null) {
+    return {
+      ...nextItem,
+      buyOnDate: String(buyOnDateValue).trim() || null,
+    };
+  }
+
+  if (nextItem.sourceType === "GENERATED" && postponedUntilDateValue != null) {
+    return {
+      ...nextItem,
+      postponedUntilDate: String(postponedUntilDateValue).trim() || null,
+    };
+  }
+
+  return nextItem;
+}
+
+export function applyOptimisticShoppingListFormOverlay({
+  categories,
+  formData,
+  groups,
+  intent,
+  sourceKey,
+  stores,
+}: {
+  categories: Array<{ displayName: string; id: string }>;
+  formData: FormData;
+  groups: SerializedProjectedShoppingStoreGroup[];
+  intent: FormDataEntryValue | null | undefined;
+  sourceKey: string | null;
+  stores: Array<{ id: string; name: string }>;
+}) {
+  if (
+    intent === "delete-family-shopping-item" ||
+    intent === "delete-manual-shopping-item" ||
+    intent === "exclude-generated-shopping-item"
+  ) {
+    if (!sourceKey) {
+      return groups;
+    }
+
+    return removeProjectedItemFromStoreGroups(groups, sourceKey);
+  }
+
+  if (
+    intent === "update-family-shopping-item" ||
+    intent === "update-manual-shopping-item" ||
+    intent === "update-generated-shopping-item"
+  ) {
+    if (!sourceKey) {
+      return groups;
+    }
+
+    const currentItem = findProjectedItemInStoreGroups(groups, sourceKey);
+
+    if (!currentItem) {
+      return groups;
+    }
+
+    return relocateProjectedItemInStoreGroups(
+      groups,
+      sourceKey,
+      applyFormUpdateToShoppingItem({
+        categories,
+        formData,
+        item: currentItem,
+        stores,
+      }),
+    );
+  }
+
+  return groups;
 }

--- a/app/lib/shopping-quick-add.ts
+++ b/app/lib/shopping-quick-add.ts
@@ -30,3 +30,9 @@ export function isQuickAddShoppingSuccess(
 ): data is QuickAddShoppingSuccess {
   return Boolean(data && "ok" in data && data.ok === true);
 }
+
+export interface OptimisticQuickAddDraft {
+  name: string;
+  quantity: string;
+  sourceKey: string;
+}

--- a/app/routes/family-freezer.tsx
+++ b/app/routes/family-freezer.tsx
@@ -206,6 +206,59 @@ export default function FamilyFreezerRoute({
           note: "",
           quantity: "",
         };
+  const pendingFreezerItemId = String(
+    navigation.formData?.get("freezerItemId") ?? "",
+  );
+  const isPendingFreezer =
+    navigation.state !== "idle" && navigation.formData != null;
+  const displayFreezerItems = (() => {
+    if (!isPendingFreezer || !navigation.formData) {
+      return loaderData.freezerItems;
+    }
+
+    if (pendingIntent === "remove-freezer-item" && pendingFreezerItemId) {
+      return loaderData.freezerItems.filter(
+        (item) => item.id !== pendingFreezerItemId,
+      );
+    }
+
+    if (pendingIntent === "update-freezer-item" && pendingFreezerItemId) {
+      return loaderData.freezerItems.map((item) =>
+        item.id === pendingFreezerItemId
+          ? {
+              ...item,
+              label:
+                String(navigation.formData?.get("label") ?? item.label).trim() ||
+                item.label,
+              note: String(navigation.formData?.get("note") ?? "") || null,
+              quantity: Number(
+                navigation.formData?.get("quantity") ?? item.quantity,
+              ),
+            }
+          : item,
+      );
+    }
+
+    if (pendingIntent === "add-freezer-item") {
+      const label = String(navigation.formData.get("label") ?? "").trim();
+
+      if (!label) {
+        return loaderData.freezerItems;
+      }
+
+      return [
+        {
+          id: "optimistic:pending-add",
+          label,
+          note: String(navigation.formData.get("note") ?? "") || null,
+          quantity: Number(navigation.formData.get("quantity") ?? 0),
+        },
+        ...loaderData.freezerItems,
+      ];
+    }
+
+    return loaderData.freezerItems;
+  })();
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -317,12 +370,12 @@ export default function FamilyFreezerRoute({
             <button
               className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400 sm:col-span-2"
               disabled={
-                navigation.state === "submitting" &&
+                navigation.state !== "idle" &&
                 pendingIntent === "add-freezer-item"
               }
               type="submit"
             >
-              {navigation.state === "submitting" &&
+              {navigation.state !== "idle" &&
               pendingIntent === "add-freezer-item"
                 ? "Legger til..."
                 : "Legg til fryserrett"}
@@ -336,23 +389,23 @@ export default function FamilyFreezerRoute({
               Fryserbeholdning
             </h2>
             <p className="text-sm leading-6 text-slate-600">
-              {loaderData.freezerItems.length === 0
+              {displayFreezerItems.length === 0
                 ? "Ingen fryserretter er registrert ennå."
-                : `${loaderData.freezerItems.length} fryserretter er registrert.`}
+                : `${displayFreezerItems.length} fryserretter er registrert.`}
             </p>
           </div>
 
-          {loaderData.freezerItems.length > 0 ? (
+          {displayFreezerItems.length > 0 ? (
             <ul className="mt-6 grid gap-4">
-              {loaderData.freezerItems.map((item) => {
+              {displayFreezerItems.map((item) => {
                 const isUpdating =
-                  navigation.state === "submitting" &&
+                  navigation.state !== "idle" &&
                   pendingIntent === "update-freezer-item" &&
-                  navigation.formData?.get("freezerItemId") === item.id;
+                  pendingFreezerItemId === item.id;
                 const isRemoving =
-                  navigation.state === "submitting" &&
+                  navigation.state !== "idle" &&
                   pendingIntent === "remove-freezer-item" &&
-                  navigation.formData?.get("freezerItemId") === item.id;
+                  pendingFreezerItemId === item.id;
                 const updateValues =
                   actionData?.intent === "update-freezer-item" &&
                   actionData.targetFreezerItemId === item.id &&

--- a/app/routes/family-meal-plan-review.tsx
+++ b/app/routes/family-meal-plan-review.tsx
@@ -190,11 +190,13 @@ export default function FamilyMealPlanReviewRoute({
 }) {
   const navigation = useNavigation();
   const pendingIntent = navigation.formData?.get("intent");
-  const pendingDate = navigation.formData?.get("date");
+  const pendingDate = String(navigation.formData?.get("date") ?? "");
+  const isPending = navigation.state !== "idle";
   const isApprovingMealPlan =
-    navigation.state === "submitting" && pendingIntent === "approve-meal-plan";
-  const recipientLabel =
-    loaderData.mealPlan.status === "APPROVED"
+    isPending && pendingIntent === "approve-meal-plan";
+  const recipientLabel = isApprovingMealPlan
+    ? "Godkjent"
+    : loaderData.mealPlan.status === "APPROVED"
       ? "Godkjent"
       : loaderData.recipientStatus === "RESPONDED"
         ? "Du har svart"
@@ -243,7 +245,7 @@ export default function FamilyMealPlanReviewRoute({
           ) : null}
         </section>
 
-        {loaderData.notice === "meal-plan-approved" ? (
+        {loaderData.notice === "meal-plan-approved" || isApprovingMealPlan ? (
           <section className="rounded-[24px] border border-emerald-200 bg-emerald-50 px-4 py-4 text-emerald-950">
             <h2 className="text-base font-semibold">Ukeplan godkjent</h2>
             <p className="mt-1 text-sm leading-6 text-emerald-900">
@@ -252,7 +254,7 @@ export default function FamilyMealPlanReviewRoute({
           </section>
         ) : null}
 
-        {loaderData.canApprove ? (
+        {loaderData.canApprove && !isApprovingMealPlan ? (
           <section className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm mt-15">
             <h2 className="text-base font-semibold text-slate-950">
               Godkjenn ukeplanen
@@ -287,11 +289,18 @@ export default function FamilyMealPlanReviewRoute({
 
         <div className="flex flex-col gap-3 pb-8">
           {loaderData.days.map((day) => {
-            const isSubmittingDay =
-              navigation.state === "submitting" && pendingDate === day.date;
+            const isSubmittingDay = isPending && pendingDate === day.date;
             const dayError =
               actionData?.date === day.date ? actionData.formError : undefined;
-            const selectedQuickResponse = day.comment?.quickResponse ?? null;
+            const selectedQuickResponse =
+              isSubmittingDay && pendingIntent === "save-day-feedback"
+                ? String(navigation.formData?.get("quickResponse") ?? "")
+                : (day.comment?.quickResponse ?? null);
+            const pendingNoteBody =
+              isSubmittingDay && pendingIntent === "save-day-note"
+                ? String(navigation.formData?.get("body") ?? "").trim()
+                : "";
+            const displayNoteBody = pendingNoteBody || day.comment?.body || "";
 
             return (
               <article
@@ -341,11 +350,6 @@ export default function FamilyMealPlanReviewRoute({
                   <div className="mt-4 flex flex-col gap-2">
                     {loaderData.quickResponseOptions.map((option) => {
                       const isSelected = selectedQuickResponse === option.value;
-                      const isSubmittingChip =
-                        isSubmittingDay &&
-                        pendingIntent === "save-day-feedback" &&
-                        navigation.formData?.get("quickResponse") ===
-                          option.value;
 
                       return (
                         <Form
@@ -379,7 +383,7 @@ export default function FamilyMealPlanReviewRoute({
                             disabled={isSubmittingDay}
                             type="submit"
                           >
-                            {isSubmittingChip ? "Lagrer..." : option.label}
+                            {option.label}
                           </button>
                         </Form>
                       );
@@ -432,9 +436,13 @@ export default function FamilyMealPlanReviewRoute({
 
                 {day.comment &&
                 !day.comment.quickResponse &&
-                day.comment.body ? (
+                displayNoteBody ? (
                   <p className="mt-2 text-xs text-slate-500">
-                    Lagret: {day.comment.feedbackLabel}
+                    Lagret: {pendingNoteBody || day.comment.feedbackLabel}
+                  </p>
+                ) : pendingNoteBody ? (
+                  <p className="mt-2 text-xs text-slate-500">
+                    Lagret: {pendingNoteBody}
                   </p>
                 ) : null}
 

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1,5 +1,5 @@
 import { ShoppingItemSource } from "@prisma/client";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Form,
   Link,
@@ -24,10 +24,19 @@ import {
 import { ShoppingQuantityEditModal } from "../components/shopping-quantity-edit-modal";
 import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
+  applyOptimisticShoppingListFormOverlay,
+  buildOptimisticManualShoppingItem,
+  dropResolvedOptimisticItemsFromStoreGroups,
+  getOptimisticChecked,
   insertProjectedItemIntoStoreGroups,
+  patchProjectedItemInStoreGroups,
   prependRecentManualItem,
+  removeProjectedItemFromStoreGroups,
 } from "../lib/shopping-list-client";
-import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import type {
+  OptimisticQuickAddDraft,
+  QuickAddShoppingSuccess,
+} from "../lib/shopping-quick-add";
 import { serializeProjectedShoppingItem } from "../lib/shopping-serialize";
 import {
   getMealPlanShoppingData,
@@ -664,6 +673,7 @@ export default function FamilyMealPlanShoppingRoute({
   } | null>(null);
   const [quantityDraft, setQuantityDraft] = useState("");
   const quantityInputRef = useRef<HTMLInputElement>(null);
+  const quantityRollbackRef = useRef(loaderData.storeGroups);
   const addManualValues =
     actionData?.intent === "add-manual-shopping-item" && actionData.manualValues
       ? actionData.manualValues
@@ -672,16 +682,72 @@ export default function FamilyMealPlanShoppingRoute({
   const noticeContent = loaderData.notice
     ? getShoppingNoticeContent(loaderData.notice)
     : null;
+  const listFormError =
+    quantityFetcher.data?.formError &&
+    quantityFetcher.data.intent === "update-generated-shopping-item-quantity"
+      ? quantityFetcher.data.formError
+      : actionData?.formError;
 
   useEffect(() => {
-    setStoreGroups(loaderData.storeGroups);
+    setStoreGroups(
+      dropResolvedOptimisticItemsFromStoreGroups(
+        loaderData.storeGroups,
+        loaderData.storeGroups.flatMap((group) =>
+          group.sections.flatMap((section) => section.items),
+        ),
+      ),
+    );
     setRecentManualItems(loaderData.recentManualItems);
   }, [loaderData.recentManualItems, loaderData.storeGroups]);
+
+  const fallbackCategory = useMemo(
+    () =>
+      loaderData.categories[0] ?? {
+        displayName: "Annet",
+        id: "uncategorized",
+      },
+    [loaderData.categories],
+  );
+
+  const handleQuickAddSubmit = useCallback(
+    (draft: OptimisticQuickAddDraft) => {
+      setStoreGroups((currentGroups) =>
+        insertProjectedItemIntoStoreGroups(
+          currentGroups,
+          buildOptimisticManualShoppingItem({
+            buyOnDate: loaderData.mealPlan.startDate,
+            category: {
+              id: fallbackCategory.id,
+              name: fallbackCategory.displayName,
+            },
+            mealPlanId: loaderData.mealPlan.id,
+            mealPlanTitle: loaderData.mealPlan.title,
+            name: draft.name,
+            quantity: draft.quantity,
+            sourceKey: draft.sourceKey,
+            sourceType: "MANUAL",
+          }),
+        ),
+      );
+    },
+    [
+      fallbackCategory.displayName,
+      fallbackCategory.id,
+      loaderData.mealPlan.id,
+      loaderData.mealPlan.startDate,
+      loaderData.mealPlan.title,
+    ],
+  );
 
   const handleQuickAddSuccess = useCallback(
     (payload: QuickAddShoppingSuccess) => {
       setStoreGroups((currentGroups) =>
-        insertProjectedItemIntoStoreGroups(currentGroups, payload.item),
+        insertProjectedItemIntoStoreGroups(
+          dropResolvedOptimisticItemsFromStoreGroups(currentGroups, [
+            payload.item,
+          ]),
+          payload.item,
+        ),
       );
       setRecentManualItems((currentRecents) =>
         prependRecentManualItem(currentRecents, payload.recentManualItem),
@@ -690,6 +756,12 @@ export default function FamilyMealPlanShoppingRoute({
     },
     [scheduleRevalidate],
   );
+
+  const handleQuickAddError = useCallback((sourceKey: string) => {
+    setStoreGroups((currentGroups) =>
+      removeProjectedItemFromStoreGroups(currentGroups, sourceKey),
+    );
+  }, []);
 
   const closeQuantityEdit = useCallback(() => {
     setQuantityEditItem(null);
@@ -702,6 +774,14 @@ export default function FamilyMealPlanShoppingRoute({
       formData.set("sourceKey", item.sourceKey);
       formData.set("expectedUpdatedAt", item.collaborationVersion);
       formData.set("quantity", quantity);
+      const trimmedQuantity = quantity.trim() || null;
+      setStoreGroups((currentGroups) => {
+        quantityRollbackRef.current = currentGroups;
+        return patchProjectedItemInStoreGroups(currentGroups, item.sourceKey, {
+          quantity: trimmedQuantity,
+          quantityLabel: trimmedQuantity,
+        });
+      });
       quantityFetcher.submit(formData, { method: "post" });
       closeQuantityEdit();
     },
@@ -721,14 +801,176 @@ export default function FamilyMealPlanShoppingRoute({
     if (
       quantityFetcher.state !== "idle" ||
       quantityFetcher.data?.intent !==
-        "update-generated-shopping-item-quantity" ||
-      !quantityFetcher.data.ok
+        "update-generated-shopping-item-quantity"
     ) {
+      return;
+    }
+
+    if (!quantityFetcher.data.ok) {
+      setStoreGroups(quantityRollbackRef.current);
       return;
     }
 
     scheduleRevalidate();
   }, [quantityFetcher.data, quantityFetcher.state, scheduleRevalidate]);
+
+  const displayStoreGroups = useMemo(() => {
+    if (navigation.state === "idle" || !navigation.formData) {
+      return storeGroups;
+    }
+
+    let overlayGroups = applyOptimisticShoppingListFormOverlay({
+      categories: loaderData.categories,
+      formData: navigation.formData,
+      groups: storeGroups,
+      intent: pendingIntent,
+      sourceKey: pendingSourceKey,
+      stores: loaderData.stores,
+    });
+
+    if (pendingIntent === "restore-generated-shopping-item" && pendingSourceKey) {
+      const restoredItem = loaderData.excludedGeneratedItems.find(
+        (item) => item.sourceKey === pendingSourceKey,
+      );
+
+      if (restoredItem) {
+        overlayGroups = insertProjectedItemIntoStoreGroups(
+          overlayGroups,
+          restoredItem,
+        );
+      }
+    }
+
+    if (
+      pendingIntent === "opt-in-stock-shopping-item" ||
+      pendingIntent === "opt-in-stock-shopping-items"
+    ) {
+      const optedInKeys = new Set(
+        navigation.formData.getAll("sourceKey").map((value) => String(value)),
+      );
+
+      for (const ingredient of loaderData.stockIngredientsForPlan) {
+        if (!optedInKeys.has(ingredient.sourceKey)) {
+          continue;
+        }
+
+        overlayGroups = insertProjectedItemIntoStoreGroups(
+          overlayGroups,
+          {
+            amount: null,
+            category: ingredient.category,
+            checked: false,
+            collaborationVersion: "",
+            firstDate:
+              ingredient.occurrences[0]?.date ?? loaderData.mealPlan.startDate,
+            lastDate:
+              ingredient.occurrences.at(-1)?.date ??
+              loaderData.mealPlan.endDate,
+            mealPlanId: loaderData.mealPlan.id,
+            mealPlanTitle: loaderData.mealPlan.title,
+            name: ingredient.name,
+            note: null,
+            occurrenceCount: ingredient.occurrenceCount,
+            occurrences: ingredient.occurrences,
+            postponedUntilDate: null,
+            preferredStore: null,
+            preferredStoreConflict: false,
+            quantity: ingredient.quantityLabel,
+            quantityLabel: ingredient.quantityLabel,
+            recipeCount: 1,
+            section: {
+              displayName: ingredient.category.name,
+              sortOrder: 99,
+            },
+            sourceKey: ingredient.sourceKey,
+            sourceType: "GENERATED",
+            unit: null,
+          },
+        );
+      }
+    }
+
+    if (pendingIntent !== "add-manual-shopping-item") {
+      return overlayGroups;
+    }
+
+    const name = String(navigation.formData.get("name") ?? "").trim();
+
+    if (!name) {
+      return overlayGroups;
+    }
+
+    const categoryId = String(navigation.formData.get("categoryId") ?? "");
+    const category =
+      loaderData.categories.find((entry) => entry.id === categoryId) ??
+      fallbackCategory;
+    const preferredStoreId = String(
+      navigation.formData.get("preferredStoreId") ?? "",
+    );
+    const preferredStore =
+      loaderData.stores.find((store) => store.id === preferredStoreId) ?? null;
+
+    return insertProjectedItemIntoStoreGroups(
+      overlayGroups,
+      buildOptimisticManualShoppingItem({
+        buyOnDate: String(navigation.formData.get("buyOnDate") ?? "") || null,
+        category: {
+          id: category.id,
+          name: category.displayName,
+        },
+        mealPlanId: loaderData.mealPlan.id,
+        mealPlanTitle: loaderData.mealPlan.title,
+        name,
+        note: String(navigation.formData.get("note") ?? "") || null,
+        preferredStore,
+        quantity: String(navigation.formData.get("quantity") ?? ""),
+        sourceKey: "optimistic:pending-add-manual",
+        sourceType: "MANUAL",
+      }),
+    );
+  }, [
+    fallbackCategory,
+    loaderData.categories,
+    loaderData.excludedGeneratedItems,
+    loaderData.mealPlan.endDate,
+    loaderData.mealPlan.id,
+    loaderData.mealPlan.startDate,
+    loaderData.mealPlan.title,
+    loaderData.stockIngredientsForPlan,
+    loaderData.stores,
+    navigation.formData,
+    navigation.state,
+    pendingIntent,
+    pendingSourceKey,
+    storeGroups,
+  ]);
+
+  const pendingOptInSourceKeys = useMemo(() => {
+    if (
+      navigation.state === "idle" ||
+      !navigation.formData ||
+      (pendingIntent !== "opt-in-stock-shopping-item" &&
+        pendingIntent !== "opt-in-stock-shopping-items")
+    ) {
+      return new Set<string>();
+    }
+
+    return new Set(
+      navigation.formData.getAll("sourceKey").map((value) => String(value)),
+    );
+  }, [navigation.formData, navigation.state, pendingIntent]);
+
+  const displayStockIngredients = loaderData.stockIngredientsForPlan.filter(
+    (ingredient) => !pendingOptInSourceKeys.has(ingredient.sourceKey),
+  );
+  const displayExcludedGeneratedItems =
+    navigation.state !== "idle" &&
+    pendingIntent === "restore-generated-shopping-item" &&
+    pendingSourceKey
+      ? loaderData.excludedGeneratedItems.filter(
+          (item) => item.sourceKey !== pendingSourceKey,
+        )
+      : loaderData.excludedGeneratedItems;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -781,20 +1023,20 @@ export default function FamilyMealPlanShoppingRoute({
           </section>
         ) : null}
 
-        {actionData?.formError ? (
+        {listFormError ? (
           <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
             <h2 className="text-base font-semibold">
               Kunne ikke oppdatere handlelisten
             </h2>
-            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+            <p className="mt-2 text-sm leading-6">{listFormError}</p>
           </section>
         ) : null}
 
-        {loaderData.stockIngredientCount > 0 ? (
+        {displayStockIngredients.length > 0 ? (
           <section className="rounded-[28px] border border-amber-200 bg-amber-50 px-6 py-5 text-amber-950 shadow-sm">
             <details>
               <summary className="cursor-pointer text-base font-semibold">
-                {loaderData.stockIngredientCount} basisvarer brukt denne uken
+                {displayStockIngredients.length} basisvarer brukt denne uken
               </summary>
               <div className="mt-4 space-y-4">
                 <p className="text-sm leading-6 text-amber-900">
@@ -807,7 +1049,7 @@ export default function FamilyMealPlanShoppingRoute({
                     type="hidden"
                     value="opt-in-stock-shopping-items"
                   />
-                  {loaderData.stockIngredientsForPlan.map((ingredient) => (
+                  {displayStockIngredients.map((ingredient) => (
                     <input
                       key={ingredient.sourceKey}
                       name="sourceKey"
@@ -818,7 +1060,7 @@ export default function FamilyMealPlanShoppingRoute({
                   <button
                     className="rounded-2xl bg-amber-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-950 disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={
-                      navigation.state === "submitting" &&
+                      navigation.state !== "idle" &&
                       pendingIntent === "opt-in-stock-shopping-items"
                     }
                     type="submit"
@@ -827,7 +1069,7 @@ export default function FamilyMealPlanShoppingRoute({
                   </button>
                 </Form>
                 <ul className="grid gap-3">
-                  {loaderData.stockIngredientsForPlan.map((ingredient) => (
+                  {displayStockIngredients.map((ingredient) => (
                     <li
                       key={ingredient.sourceKey}
                       className="rounded-[20px] border border-amber-200 bg-white px-4 py-4"
@@ -879,7 +1121,7 @@ export default function FamilyMealPlanShoppingRoute({
                           <button
                             className="rounded-xl bg-slate-950 px-4 py-2 text-xs font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
                             disabled={
-                              navigation.state === "submitting" &&
+                              navigation.state !== "idle" &&
                               pendingIntent === "opt-in-stock-shopping-item" &&
                               navigation.formData?.get("sourceKey") ===
                                 ingredient.sourceKey
@@ -898,11 +1140,11 @@ export default function FamilyMealPlanShoppingRoute({
           </section>
         ) : null}
 
-        {loaderData.excludedGeneratedCount > 0 ? (
+        {displayExcludedGeneratedItems.length > 0 ? (
           <section className="rounded-[28px] border border-slate-200 bg-slate-50 px-6 py-5 text-slate-950 shadow-sm">
             <details open>
               <summary className="cursor-pointer text-base font-semibold">
-                {loaderData.excludedGeneratedCount} varelinjer fjernet fra
+                {displayExcludedGeneratedItems.length} varelinjer fjernet fra
                 listen
               </summary>
               <div className="mt-4 space-y-4">
@@ -911,9 +1153,9 @@ export default function FamilyMealPlanShoppingRoute({
                   ukeplanen. Du kan legge dem tilbake når du trenger dem.
                 </p>
                 <ul className="grid gap-3">
-                  {loaderData.excludedGeneratedItems.map((item) => {
+                  {displayExcludedGeneratedItems.map((item) => {
                     const isPendingRestore =
-                      navigation.state === "submitting" &&
+                      navigation.state !== "idle" &&
                       pendingIntent === "restore-generated-shopping-item" &&
                       pendingSourceKey === item.sourceKey;
 
@@ -1042,6 +1284,8 @@ export default function FamilyMealPlanShoppingRoute({
             <div className="mt-6">
               <ManualShoppingQuickAdd
                 ingredientSearchPath={ingredientSearchPath}
+                onQuickAddError={handleQuickAddError}
+                onQuickAddSubmit={handleQuickAddSubmit}
                 onQuickAddSuccess={handleQuickAddSuccess}
                 recentManualItems={recentManualItems}
               />
@@ -1208,10 +1452,15 @@ export default function FamilyMealPlanShoppingRoute({
                     {group.sections.flatMap((section) =>
                       section.items.map((item) => {
                         const isPendingCheckToggle =
-                          navigation.state === "submitting" &&
+                          navigation.state !== "idle" &&
                           pendingIntent ===
                             "toggle-family-shopping-item-checked" &&
                           pendingSourceKey === item.sourceKey;
+                        const displayChecked = getOptimisticChecked({
+                          checkedValue: navigation.formData?.get("checked"),
+                          isPending: isPendingCheckToggle,
+                          itemChecked: item.checked,
+                        });
 
                         return (
                           <article
@@ -1220,7 +1469,13 @@ export default function FamilyMealPlanShoppingRoute({
                           >
                             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                               <div>
-                                <p className="text-sm font-semibold text-slate-950">
+                                <p
+                                  className={`text-sm font-semibold ${
+                                    displayChecked
+                                      ? "text-slate-500 line-through"
+                                      : "text-slate-950"
+                                  }`}
+                                >
                                   {item.name}
                                   {item.quantityLabel
                                     ? ` · ${item.quantityLabel}`
@@ -1257,8 +1512,10 @@ export default function FamilyMealPlanShoppingRoute({
                                   type="submit"
                                 >
                                   {isPendingCheckToggle
-                                    ? "Oppdaterer..."
-                                    : item.checked
+                                    ? displayChecked
+                                      ? "Krysser av..."
+                                      : "Oppdaterer..."
+                                    : displayChecked
                                       ? "Fjern avkryssing"
                                       : "Marker som kjøpt"}
                                 </button>
@@ -1275,9 +1532,9 @@ export default function FamilyMealPlanShoppingRoute({
           </section>
         ) : null}
 
-        {storeGroups.length ? (
+        {displayStoreGroups.length ? (
           <section className="grid gap-6">
-            {storeGroups.map((group) => (
+            {displayStoreGroups.map((group) => (
               <article
                 key={group.store?.id ?? "no-store"}
                 className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200"
@@ -1305,9 +1562,14 @@ export default function FamilyMealPlanShoppingRoute({
                       <div className="mt-3 grid gap-2 xl:gap-3">
                         {section.items.map((item) => {
                           const isPendingCheckToggle =
-                            navigation.state === "submitting" &&
+                            navigation.state !== "idle" &&
                             pendingIntent === "toggle-shopping-item-checked" &&
                             pendingSourceKey === item.sourceKey;
+                          const displayChecked = getOptimisticChecked({
+                            checkedValue: navigation.formData?.get("checked"),
+                            isPending: isPendingCheckToggle,
+                            itemChecked: item.checked,
+                          });
                           const isPendingManualSave =
                             navigation.state === "submitting" &&
                             pendingIntent === "update-manual-shopping-item" &&
@@ -1373,6 +1635,7 @@ export default function FamilyMealPlanShoppingRoute({
                           const expandedProps = {
                             actionData,
                             categories: loaderData.categories,
+                            displayChecked,
                             isPendingCheckToggle,
                             isPendingGeneratedExclude,
                             isPendingGeneratedSave,
@@ -1394,7 +1657,13 @@ export default function FamilyMealPlanShoppingRoute({
                               className="min-w-0 max-w-full overflow-hidden rounded-[24px] border border-slate-200 bg-slate-50 p-3 xl:p-5"
                             >
                               <div className="flex flex-wrap items-center gap-2">
-                                <h4 className="text-base font-semibold text-slate-950">
+                                <h4
+                                  className={`text-base font-semibold ${
+                                    displayChecked
+                                      ? "text-slate-500 line-through"
+                                      : "text-slate-950"
+                                  }`}
+                                >
                                   {item.name}
                                 </h4>
                                 {item.sourceType === "GENERATED" ? (
@@ -1451,7 +1720,7 @@ export default function FamilyMealPlanShoppingRoute({
                                     Manuell
                                   </span>
                                 ) : null}
-                                {item.checked ? (
+                                {displayChecked ? (
                                   <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700">
                                     Avkrysset
                                   </span>

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1,6 +1,6 @@
 import { ShoppingItemSource } from "@prisma/client";
 import type { ChangeEvent, ComponentProps } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Form,
   Link,
@@ -42,11 +42,18 @@ import {
   writeStoreModeShoppingView,
 } from "../lib/shopping-store-mode-client";
 import {
+  buildOptimisticManualShoppingItem,
+  dropResolvedOptimisticItemsFromSectionGroups,
   insertProjectedItemIntoSectionGroups,
+  patchProjectedItemInSectionGroups,
   prependRecentManualItem,
   relocateProjectedItemInSectionGroups,
+  removeProjectedItemFromSectionGroups,
 } from "../lib/shopping-list-client";
-import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import type {
+  OptimisticQuickAddDraft,
+  QuickAddShoppingSuccess,
+} from "../lib/shopping-quick-add";
 import { scrollToShoppingItem } from "../lib/shopping-quick-add-feedback.client";
 import { serializeProjectedShoppingItem } from "../lib/shopping-serialize";
 import { resolveStoreModeAnchorMealPlan } from "../lib/meal-plan-for-date.server";
@@ -593,6 +600,8 @@ export default function FamilyMealPlanStoreModeRoute({
   const [recentlyAddedSourceKey, setRecentlyAddedSourceKey] = useState<
     string | null
   >(null);
+  const quantityRollbackRef = useRef(loaderData.dueSectionGroups);
+  const categoryRollbackRef = useRef(loaderData.dueSectionGroups);
   const isSavingStore =
     navigation.state === "submitting" &&
     pendingIntent === "update-selected-store";
@@ -601,14 +610,51 @@ export default function FamilyMealPlanStoreModeRoute({
     pendingIntent === "update-active-shopping-date";
 
   useEffect(() => {
-    setDueSectionGroups(loaderData.dueSectionGroups);
+    setDueSectionGroups(
+      dropResolvedOptimisticItemsFromSectionGroups(
+        loaderData.dueSectionGroups,
+        loaderData.dueSectionGroups.flatMap((section) => section.items),
+      ),
+    );
     setRecentManualItems(loaderData.recentManualItems);
   }, [loaderData.dueSectionGroups, loaderData.recentManualItems]);
+
+  const fallbackCategory = loaderData.categories[0] ?? {
+    displayName: "Annet",
+    id: "uncategorized",
+  };
+
+  const handleQuickAddSubmit = useCallback(
+    (draft: OptimisticQuickAddDraft) => {
+      setDueSectionGroups((currentSections) =>
+        insertProjectedItemIntoSectionGroups(
+          currentSections,
+          buildOptimisticManualShoppingItem({
+            category: {
+              id: fallbackCategory.id,
+              name: fallbackCategory.displayName,
+            },
+            name: draft.name,
+            quantity: draft.quantity,
+            sourceKey: draft.sourceKey,
+            sourceType: "FAMILY",
+          }),
+        ),
+      );
+      setRecentlyAddedSourceKey(draft.sourceKey);
+    },
+    [fallbackCategory.displayName, fallbackCategory.id],
+  );
 
   const handleQuickAddSuccess = useCallback(
     (payload: QuickAddShoppingSuccess) => {
       setDueSectionGroups((currentSections) =>
-        insertProjectedItemIntoSectionGroups(currentSections, payload.item),
+        insertProjectedItemIntoSectionGroups(
+          dropResolvedOptimisticItemsFromSectionGroups(currentSections, [
+            payload.item,
+          ]),
+          payload.item,
+        ),
       );
       setRecentManualItems((currentRecents) =>
         prependRecentManualItem(currentRecents, payload.recentManualItem),
@@ -619,6 +665,12 @@ export default function FamilyMealPlanStoreModeRoute({
     },
     [scheduleRevalidate],
   );
+
+  const handleQuickAddError = useCallback((sourceKey: string) => {
+    setDueSectionGroups((currentSections) =>
+      removeProjectedItemFromSectionGroups(currentSections, sourceKey),
+    );
+  }, []);
 
   const handleQuickAddFromCard = useCallback(
     (item: { name: string; quantityLabel: string | null }) => {
@@ -660,20 +712,35 @@ export default function FamilyMealPlanStoreModeRoute({
         formData.set("itemMealPlanId", mealPlanId);
       }
 
+      const trimmedQuantity = quantity.trim() || null;
+      setDueSectionGroups((currentSections) => {
+        quantityRollbackRef.current = currentSections;
+        return patchProjectedItemInSectionGroups(currentSections, sourceKey, {
+          quantity: trimmedQuantity,
+          quantityLabel: trimmedQuantity,
+        });
+      });
       quantityFetcher.submit(formData, { method: "post" });
     },
     [quantityFetcher],
   );
 
   useEffect(() => {
+    if (quantityFetcher.state !== "idle") {
+      return;
+    }
+
+    const data = quantityFetcher.data;
+
     if (
-      quantityFetcher.state !== "idle" ||
-      (quantityFetcher.data?.intent !==
-        "update-family-shopping-item-quantity" &&
-        quantityFetcher.data?.intent !==
-          "update-generated-shopping-item-quantity") ||
-      !quantityFetcher.data.ok
+      data?.intent !== "update-family-shopping-item-quantity" &&
+      data?.intent !== "update-generated-shopping-item-quantity"
     ) {
+      return;
+    }
+
+    if (!data.ok) {
+      setDueSectionGroups(quantityRollbackRef.current);
       return;
     }
 
@@ -702,9 +769,42 @@ export default function FamilyMealPlanStoreModeRoute({
         formData.set("itemMealPlanId", request.mealPlanId);
       }
 
+      const nextCategory = loaderData.categories.find(
+        (category) => category.id === request.categoryId,
+      );
+      const trimmedNote = request.note.trim() || null;
+
+      setDueSectionGroups((currentSections) => {
+        categoryRollbackRef.current = currentSections;
+        const currentItem = currentSections
+          .flatMap((section) => section.items)
+          .find((item) => item.sourceKey === request.sourceKey);
+
+        if (!currentItem || !nextCategory) {
+          return currentSections;
+        }
+
+        return relocateProjectedItemInSectionGroups(
+          currentSections,
+          request.sourceKey,
+          {
+            ...currentItem,
+            category: {
+              id: nextCategory.id,
+              name: nextCategory.displayName,
+            },
+            note: trimmedNote,
+            section: {
+              ...currentItem.section,
+              displayName: nextCategory.displayName,
+            },
+          },
+        );
+      });
+      setRecentlyAddedSourceKey(request.sourceKey);
       categoryFetcher.submit(formData, { method: "post" });
     },
-    [categoryFetcher],
+    [categoryFetcher, loaderData.categories],
   );
 
   useEffect(() => {
@@ -722,23 +822,23 @@ export default function FamilyMealPlanStoreModeRoute({
     }
 
     if (!data.ok) {
+      setDueSectionGroups(categoryRollbackRef.current);
       return;
     }
 
     const updatedItem = data.item;
 
-    if (!updatedItem) {
-      return;
+    if (updatedItem) {
+      setDueSectionGroups((currentSections) =>
+        relocateProjectedItemInSectionGroups(
+          currentSections,
+          updatedItem.sourceKey,
+          updatedItem,
+        ),
+      );
+      setRecentlyAddedSourceKey(updatedItem.sourceKey);
     }
 
-    setDueSectionGroups((currentSections) =>
-      relocateProjectedItemInSectionGroups(
-        currentSections,
-        updatedItem.sourceKey,
-        updatedItem,
-      ),
-    );
-    setRecentlyAddedSourceKey(updatedItem.sourceKey);
     scheduleRevalidate();
   }, [categoryFetcher.data, categoryFetcher.state, scheduleRevalidate]);
 
@@ -870,8 +970,16 @@ export default function FamilyMealPlanStoreModeRoute({
       ? actionData.activeShoppingDateValue
       : loaderData.activeShoppingDate;
   const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
+  const quantityFetcherError =
+    quantityFetcher.data?.formError &&
+    (quantityFetcher.data.intent === "update-family-shopping-item-quantity" ||
+      quantityFetcher.data.intent ===
+        "update-generated-shopping-item-quantity")
+      ? quantityFetcher.data.formError
+      : null;
   const generalFormError =
     categoryFetcherError ??
+    quantityFetcherError ??
     (actionData?.formError &&
     actionData.intent !== "quick-add-family-shopping-item"
       ? actionData.formError
@@ -1196,6 +1304,8 @@ export default function FamilyMealPlanStoreModeRoute({
             <ManualShoppingQuickAdd
               appearance="store-mode"
               ingredientSearchPath={ingredientSearchPath}
+              onQuickAddError={handleQuickAddError}
+              onQuickAddSubmit={handleQuickAddSubmit}
               onQuickAddSuccess={handleQuickAddSuccess}
               prefillRequest={quickAddPrefillRequest}
               quickAddIntent="quick-add-family-shopping-item"

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -515,31 +515,33 @@ export default function FamilyMealPlanRoute({
 }: MealPlanRouteProps) {
   const navigation = useNavigation();
   const pendingIntent = navigation.formData?.get("intent");
+  const isPending = navigation.state !== "idle";
   const isApprovingMealPlan =
-    navigation.state === "submitting" && pendingIntent === "approve-meal-plan";
+    isPending && pendingIntent === "approve-meal-plan";
   const isReopeningMealPlan =
-    navigation.state === "submitting" && pendingIntent === "reopen-meal-plan";
+    isPending && pendingIntent === "reopen-meal-plan";
   const isAutoFillingEntries =
-    navigation.state === "submitting" &&
-    pendingIntent === "auto-fill-meal-plan-entries";
+    isPending && pendingIntent === "auto-fill-meal-plan-entries";
   const isSavingEntries =
-    navigation.state === "submitting" &&
-    pendingIntent === "save-meal-plan-entries";
+    isPending && pendingIntent === "save-meal-plan-entries";
   const isResettingEntries =
-    navigation.state === "submitting" &&
-    pendingIntent === "reset-meal-plan-entries";
+    isPending && pendingIntent === "reset-meal-plan-entries";
   const isUpdatingMetadata =
-    navigation.state === "submitting" && pendingIntent === "update-meal-plan";
+    isPending && pendingIntent === "update-meal-plan";
   const isSharingMealPlan =
-    navigation.state === "submitting" && pendingIntent === "share-meal-plan";
+    isPending && pendingIntent === "share-meal-plan";
   const isMarkingCommentAddressed =
-    navigation.state === "submitting" &&
-    pendingIntent === "mark-comment-addressed";
+    isPending && pendingIntent === "mark-comment-addressed";
+  const pendingCommentId = isMarkingCommentAddressed
+    ? String(navigation.formData?.get("commentId") ?? "")
+    : "";
   const openFeedbackShares = loaderData.feedbackShares.filter(
     (share) => share.status === "OPEN",
   );
   const unresolvedComments = openFeedbackShares.flatMap((share) =>
-    share.comments.filter((comment) => !comment.addressedAt),
+    share.comments.filter(
+      (comment) => !comment.addressedAt && comment.id !== pendingCommentId,
+    ),
   );
   const noticeContent = loaderData.notice
     ? getMealPlanNoticeContent(loaderData.notice, loaderData.noticeMeta)
@@ -557,6 +559,27 @@ export default function FamilyMealPlanRoute({
     actionData?.values?.startDate ?? loaderData.mealPlan.startDate;
   const endDateValue =
     actionData?.values?.endDate ?? loaderData.mealPlan.endDate;
+  const displayTitle = isUpdatingMetadata
+    ? String(navigation.formData?.get("title") ?? loaderData.mealPlan.title)
+    : loaderData.mealPlan.title;
+  const displayStartDate = isUpdatingMetadata
+    ? String(
+        navigation.formData?.get("startDate") ?? loaderData.mealPlan.startDate,
+      )
+    : loaderData.mealPlan.startDate;
+  const displayEndDate = isUpdatingMetadata
+    ? String(navigation.formData?.get("endDate") ?? loaderData.mealPlan.endDate)
+    : loaderData.mealPlan.endDate;
+  const displayMealPlanStatus = isApprovingMealPlan
+    ? "APPROVED"
+    : isReopeningMealPlan
+      ? "DRAFT"
+      : loaderData.mealPlan.status;
+  const displayApprovedAt = isApprovingMealPlan
+    ? new Date().toISOString()
+    : isReopeningMealPlan
+      ? null
+      : loaderData.mealPlan.approvedAt;
   const approvalIntent =
     loaderData.mealPlan.status === "APPROVED"
       ? "reopen-meal-plan"
@@ -575,8 +598,26 @@ export default function FamilyMealPlanRoute({
     actionData.entryValues
       ? actionData.entryValues
       : loaderData.entriesByDate;
+  const displayEntryValues = isResettingEntries
+    ? Object.fromEntries(
+        loaderData.visibleDates.map((date) => {
+          const current = entryValues[date];
+
+          return [
+            date,
+            {
+              freezerItemId: "",
+              note: "",
+              recipeId: "",
+              responsibleUserId: "",
+              updatedAt: current?.updatedAt ?? "",
+            } satisfies MealPlanEntryFormState,
+          ];
+        }),
+      )
+    : entryValues;
   const selectedRecipeIds = new Set(
-    Object.values(entryValues)
+    Object.values(displayEntryValues)
       .map((entry) => entry.recipeId)
       .filter(Boolean),
   );
@@ -601,13 +642,10 @@ export default function FamilyMealPlanRoute({
                   Middagsplanlegging
                 </span>
                 <h1 className="mt-4 text-3xl font-semibold tracking-tight sm:text-4xl">
-                  {loaderData.mealPlan.title}
+                  {displayTitle}
                 </h1>
                 <p className="mt-2 text-sm font-medium text-emerald-200/90">
-                  {formatMealPlanWindow(
-                    loaderData.mealPlan.startDate,
-                    loaderData.mealPlan.endDate,
-                  )}
+                  {formatMealPlanWindow(displayStartDate, displayEndDate)}
                 </p>
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base sm:leading-7">
                   Se hele uken med ett blikk. Trykk på en dag for å planlegge
@@ -654,11 +692,11 @@ export default function FamilyMealPlanRoute({
               actionData={actionData}
               approvalButtonLabel={approvalButtonLabel}
               approvalIntent={approvalIntent}
-              approvedAt={loaderData.mealPlan.approvedAt}
+              approvedAt={displayApprovedAt}
               entriesSnapshot={loaderData.entriesSnapshot}
               isApprovingMealPlan={isApprovingMealPlan}
               isReopeningMealPlan={isReopeningMealPlan}
-              mealPlanStatus={loaderData.mealPlan.status}
+              mealPlanStatus={displayMealPlanStatus}
               mealPlanUpdatedAt={loaderData.mealPlan.updatedAt}
               variant="hero"
             />
@@ -674,7 +712,7 @@ export default function FamilyMealPlanRoute({
           </section>
         ) : null}
 
-        {loaderData.mealPlan.status === "DRAFT" ? (
+        {displayMealPlanStatus === "DRAFT" ? (
           <section className="grid min-w-0 gap-6 lg:grid-cols-2">
             <MealPlanShareSection
               actionData={actionData}
@@ -682,10 +720,27 @@ export default function FamilyMealPlanRoute({
               familyId={loaderData.family.id}
               isSharingMealPlan={isSharingMealPlan}
               members={loaderData.shareMembers}
+              pendingShare={
+                isSharingMealPlan
+                  ? {
+                      message: String(
+                        navigation.formData?.get("message") ?? "",
+                      ).trim(),
+                      recipientIds: navigation.formData
+                        ? navigation.formData
+                            .getAll("recipientUserIds")
+                            .map((value) => String(value))
+                        : [],
+                      wholeFamily: Boolean(
+                        navigation.formData?.get("wholeFamily"),
+                      ),
+                    }
+                  : null
+              }
             />
             <MealPlanFeedbackSection
-              actionData={actionData}
               isMarkingCommentAddressed={isMarkingCommentAddressed}
+              pendingCommentId={pendingCommentId}
               unresolvedCount={unresolvedComments.length}
               visibleDates={loaderData.visibleDates}
               shares={openFeedbackShares}
@@ -773,7 +828,7 @@ export default function FamilyMealPlanRoute({
                   : undefined
               }
               entriesSnapshot={loaderData.entriesSnapshot}
-              entryValues={entryValues}
+              entryValues={displayEntryValues}
               familyId={loaderData.family.id}
               familyMembers={loaderData.familyMembers}
               freezerItems={loaderData.freezerItems}
@@ -1201,17 +1256,34 @@ function MealPlanShareSection({
   familyId,
   isSharingMealPlan,
   members,
+  pendingShare,
 }: {
   actionData?: MealPlanActionData;
   activeOpenShare: FeedbackShare | null;
   familyId: string;
   isSharingMealPlan: boolean;
   members: ShareMemberOption[];
+  pendingShare: {
+    message: string;
+    recipientIds: string[];
+    wholeFamily: boolean;
+  } | null;
 }) {
-  if (activeOpenShare) {
-    const recipientNames = activeOpenShare.recipients
-      .map((recipient) => recipient.displayName)
-      .join(", ");
+  if (activeOpenShare || pendingShare) {
+    const recipientNames = pendingShare
+      ? members
+          .filter((member) => pendingShare.recipientIds.includes(member.id))
+          .map((member) => member.displayName)
+          .join(", ")
+      : activeOpenShare?.recipients
+          .map((recipient) => recipient.displayName)
+          .join(", ") ?? "";
+    const wholeFamily = pendingShare
+      ? pendingShare.wholeFamily
+      : Boolean(activeOpenShare?.wholeFamily);
+    const message = pendingShare
+      ? pendingShare.message
+      : activeOpenShare?.message ?? "";
 
     return (
       <article className="rounded-[28px] bg-white p-5 shadow-sm ring-1 ring-slate-200">
@@ -1220,15 +1292,17 @@ function MealPlanShareSection({
         </h2>
         <p className="mt-2 text-sm leading-6 text-slate-600">
           Ukeplanen venter allerede på tilbakemelding fra{" "}
-          {activeOpenShare.wholeFamily
-            ? "familien"
-            : recipientNames || "mottakerne"}
-          .{activeOpenShare.message ? ` «${activeOpenShare.message}»` : ""}
+          {wholeFamily ? "familien" : recipientNames || "mottakerne"}
+          .{message ? ` «${message}»` : ""}
         </p>
-        <p className="mt-3 text-sm text-slate-500">
-          Du kan ikke sende en ny gjennomgang før denne er avsluttet (for
-          eksempel når planen godkjennes).
-        </p>
+        {pendingShare ? (
+          <p className="mt-3 text-sm text-slate-500">Sender deling...</p>
+        ) : (
+          <p className="mt-3 text-sm text-slate-500">
+            Du kan ikke sende en ny gjennomgang før denne er avsluttet (for
+            eksempel når planen godkjennes).
+          </p>
+        )}
         <Link
           className="mt-4 inline-flex text-sm font-medium text-emerald-700 hover:text-emerald-800"
           to={`/families/${familyId}/meal-plans/reviews`}
@@ -1325,14 +1399,14 @@ function MealPlanShareSection({
 }
 
 function MealPlanFeedbackSection({
-  actionData,
   isMarkingCommentAddressed,
+  pendingCommentId,
   shares,
   unresolvedCount,
   visibleDates,
 }: {
-  actionData?: MealPlanActionData;
   isMarkingCommentAddressed: boolean;
+  pendingCommentId: string;
   shares: FeedbackShare[];
   unresolvedCount: number;
   visibleDates: string[];
@@ -1410,7 +1484,7 @@ function MealPlanFeedbackSection({
                     <p className="mt-1 text-sm text-slate-700">
                       {comment.feedbackLabel}
                     </p>
-                    {comment.addressedAt ? (
+                    {comment.addressedAt || comment.id === pendingCommentId ? (
                       <p className="mt-2 text-xs text-emerald-700">Behandlet</p>
                     ) : (
                       <Form className="mt-2" method="post">
@@ -1429,10 +1503,7 @@ function MealPlanFeedbackSection({
                           disabled={isMarkingCommentAddressed}
                           type="submit"
                         >
-                          {isMarkingCommentAddressed &&
-                          actionData?.commentId === comment.id
-                            ? "Lagrer..."
-                            : "Merk som behandlet"}
+                          Merk som behandlet
                         </button>
                       </Form>
                     )}

--- a/app/routes/family-meal-plans.tsx
+++ b/app/routes/family-meal-plans.tsx
@@ -211,11 +211,21 @@ export default function FamilyMealPlansRoute({
     navigation.formData?.get("mealPlanId") ?? "",
   );
   const isCreatingMealPlan =
-    navigation.state === "submitting" && pendingIntent === "create-meal-plan";
+    navigation.state !== "idle" && pendingIntent === "create-meal-plan";
   const isDeletingMealPlan =
-    navigation.state === "submitting" && pendingIntent === "delete-meal-plan";
+    navigation.state !== "idle" && pendingIntent === "delete-meal-plan";
+  const pendingCreateMealPlan = isCreatingMealPlan
+    ? buildOptimisticMealPlanListItem(navigation.formData)
+    : null;
+  const mealPlansForDisplay = [
+    ...(pendingCreateMealPlan ? [pendingCreateMealPlan] : []),
+    ...loaderData.mealPlans.filter(
+      (mealPlan) =>
+        !(isDeletingMealPlan && mealPlan.id === pendingMealPlanId),
+    ),
+  ];
   const partitionedMealPlans = partitionMealPlansByTimeStatus(
-    loaderData.mealPlans,
+    mealPlansForDisplay,
   );
   const visiblePastMealPlans = showAllPastMealPlans
     ? partitionedMealPlans.past
@@ -313,7 +323,7 @@ export default function FamilyMealPlansRoute({
               </p>
             </div>
 
-            {loaderData.mealPlans.length > 0 ? (
+            {mealPlansForDisplay.length > 0 ? (
               <div className="mt-6 grid gap-6">
                 {partitionedMealPlans.upcoming.length > 0 ? (
                   <div className="grid gap-3">
@@ -432,6 +442,35 @@ export default function FamilyMealPlansRoute({
 }
 
 type MealPlanListItem = MealPlanListRouteProps["loaderData"]["mealPlans"][number];
+
+function buildOptimisticMealPlanListItem(
+  formData: FormData | undefined,
+): MealPlanListItem | null {
+  if (!formData) {
+    return null;
+  }
+
+  const startDate = String(formData.get("startDate") ?? "");
+  const endDate = String(formData.get("endDate") ?? "");
+
+  if (!startDate || !endDate) {
+    return null;
+  }
+
+  const title = String(formData.get("title") ?? "").trim();
+  const now = new Date();
+
+  return {
+    activeShoppingDate: null,
+    createdAt: now,
+    endDate,
+    id: "optimistic:pending-add",
+    startDate,
+    status: "DRAFT",
+    title: title || "Ny ukeplan",
+    updatedAt: now,
+  };
+}
 
 function getCreateMealPlanInitialState(actionData?: MealPlanActionData) {
   if (actionData?.intent === "create-meal-plan") {
@@ -633,6 +672,7 @@ function MealPlanListCard({
       : timeStatus === "past"
         ? "inline-flex items-center justify-center rounded-2xl bg-slate-700 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
         : "inline-flex items-center justify-center rounded-2xl bg-slate-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-slate-800";
+  const isPlaceholder = mealPlan.id.startsWith("optimistic:");
   const timeStatusBadge =
     timeStatus === "active"
       ? {
@@ -675,24 +715,32 @@ function MealPlanListCard({
         </div>
 
         <div className="flex flex-wrap gap-3">
-          <Link
-            className={openLinkClassName}
-            to={`/families/${familyId}/meal-plans/${mealPlan.id}`}
-          >
-            Åpne ukeplan
-          </Link>
+          {isPlaceholder ? (
+            <span className="inline-flex items-center justify-center rounded-2xl bg-slate-200 px-4 py-3 text-sm font-medium text-slate-600">
+              Oppretter...
+            </span>
+          ) : (
+            <>
+              <Link
+                className={openLinkClassName}
+                to={`/families/${familyId}/meal-plans/${mealPlan.id}`}
+              >
+                Åpne ukeplan
+              </Link>
 
-          <Form method="post">
-            <input name="intent" type="hidden" value="delete-meal-plan" />
-            <input name="mealPlanId" type="hidden" value={mealPlan.id} />
-            <button
-              className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
-              disabled={isDeletingMealPlan}
-              type="submit"
-            >
-              {isPendingDelete ? "Sletter..." : "Slett"}
-            </button>
-          </Form>
+              <Form method="post">
+                <input name="intent" type="hidden" value="delete-meal-plan" />
+                <input name="mealPlanId" type="hidden" value={mealPlan.id} />
+                <button
+                  className="inline-flex items-center justify-center rounded-2xl bg-rose-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-rose-700 disabled:cursor-not-allowed disabled:bg-rose-300"
+                  disabled={isDeletingMealPlan}
+                  type="submit"
+                >
+                  {isPendingDelete ? "Sletter..." : "Slett"}
+                </button>
+              </Form>
+            </>
+          )}
         </div>
       </div>
 

--- a/app/routes/family-recipes.tsx
+++ b/app/routes/family-recipes.tsx
@@ -143,6 +143,27 @@ export default function FamilyRecipesRoute({
     () => filterRecipeList(loaderData.globalRecipes, searchQuery),
     [loaderData.globalRecipes, searchQuery],
   );
+  const pendingCreateTitle =
+    navigation.state !== "idle" && pendingIntent === "create-recipe"
+      ? String(navigation.formData?.get("title") ?? "").trim()
+      : "";
+  const displayFamilyRecipes = pendingCreateTitle
+    ? [
+        {
+          _count: {
+            ingredients: 1,
+            mealPlanEntries: 0,
+          },
+          defaultServings: null,
+          description: null,
+          id: "optimistic:pending-add",
+          prepMinutes: null,
+          tags: [] as string[],
+          title: pendingCreateTitle,
+        },
+        ...filteredFamilyRecipes,
+      ]
+    : filteredFamilyRecipes;
   const createValues =
     actionData?.intent === "create-recipe" && actionData.createValues
       ? actionData.createValues
@@ -322,12 +343,12 @@ export default function FamilyRecipesRoute({
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
                 disabled={
-                  navigation.state === "submitting" &&
+                  navigation.state !== "idle" &&
                   pendingIntent === "create-recipe"
                 }
                 type="submit"
               >
-                {navigation.state === "submitting" &&
+                {navigation.state !== "idle" &&
                 pendingIntent === "create-recipe"
                   ? "Oppretter..."
                   : "Opprett oppskrift"}
@@ -375,25 +396,29 @@ export default function FamilyRecipesRoute({
             </h2>
           </div>
 
-          {loaderData.familyRecipes.length === 0 ? (
+          {loaderData.familyRecipes.length === 0 && !pendingCreateTitle ? (
             <p className="mt-6 rounded-[24px] border border-dashed border-emerald-200 bg-emerald-50/50 px-5 py-8 text-center text-sm leading-6 text-slate-600">
               {canManageRecipes
                 ? "Ingen familieoppskrifter ennå. Opprett den første oppskriften over."
                 : "Familien har ingen egne oppskrifter ennå."}
             </p>
-          ) : filteredFamilyRecipes.length === 0 && isSearchActive ? (
+          ) : displayFamilyRecipes.length === 0 && isSearchActive ? (
             <p className="mt-6 rounded-[24px] border border-dashed border-emerald-200 bg-emerald-50/50 px-5 py-8 text-center text-sm leading-6 text-slate-600">
               Ingen familieoppskrifter matcher søket.
             </p>
           ) : (
             <div className="mt-6 grid gap-3">
-              {filteredFamilyRecipes.map((recipe) => (
+              {displayFamilyRecipes.map((recipe) => (
                 <RecipeListCard
                   key={recipe.id}
                   recipe={recipe}
                   scopeLabel="Familie"
                   scopeTone="family"
-                  to={`/families/${loaderData.family.id}/recipes/${recipe.id}`}
+                  to={
+                    recipe.id.startsWith("optimistic:")
+                      ? undefined
+                      : `/families/${loaderData.family.id}/recipes/${recipe.id}`
+                  }
                 />
               ))}
             </div>

--- a/app/routes/family-shopping.tsx
+++ b/app/routes/family-shopping.tsx
@@ -1,5 +1,5 @@
 import { ShoppingItemSource } from "@prisma/client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Form,
   Link,
@@ -36,10 +36,19 @@ import {
 } from "../lib/shopping-preference-write.server";
 import { getToggleExpectedVersion } from "../lib/shopping-store-mode-client";
 import {
+  applyOptimisticShoppingListFormOverlay,
+  buildOptimisticManualShoppingItem,
+  dropResolvedOptimisticItemsFromStoreGroups,
+  filterStoreGroupsBySourceType,
+  getOptimisticChecked,
   insertProjectedItemIntoStoreGroups,
   prependRecentManualItem,
+  removeProjectedItemFromStoreGroups,
 } from "../lib/shopping-list-client";
-import type { QuickAddShoppingSuccess } from "../lib/shopping-quick-add";
+import type {
+  OptimisticQuickAddDraft,
+  QuickAddShoppingSuccess,
+} from "../lib/shopping-quick-add";
 import { scrollToShoppingItem } from "../lib/shopping-quick-add-feedback.client";
 import {
   serializeProjectedShoppingItem,
@@ -443,6 +452,13 @@ export default function FamilyShoppingRoute({
       : null;
   const pendingIntent = navigation.formData?.get("intent");
   const pendingSourceKey = getPendingSourceKey(navigation.formData);
+  const displayListMode =
+    navigation.state !== "idle" &&
+    pendingIntent === "set-family-shopping-list-mode"
+      ? String(
+          navigation.formData?.get("listMode") ?? loaderData.activeListMode,
+        )
+      : loaderData.activeListMode;
   const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
   const generalFormError =
     actionData?.formError &&
@@ -451,14 +467,55 @@ export default function FamilyShoppingRoute({
       : undefined;
 
   useEffect(() => {
-    setStoreGroups(loaderData.storeGroups);
+    setStoreGroups(
+      dropResolvedOptimisticItemsFromStoreGroups(
+        loaderData.storeGroups,
+        loaderData.storeGroups.flatMap((group) =>
+          group.sections.flatMap((section) => section.items),
+        ),
+      ),
+    );
     setRecentManualItems(loaderData.recentManualItems);
   }, [loaderData.recentManualItems, loaderData.storeGroups]);
+
+  const fallbackCategory = useMemo(
+    () =>
+      loaderData.categories[0] ?? {
+        displayName: "Annet",
+        id: "uncategorized",
+      },
+    [loaderData.categories],
+  );
+
+  const handleQuickAddSubmit = useCallback(
+    (draft: OptimisticQuickAddDraft) => {
+      const placeholder = buildOptimisticManualShoppingItem({
+        category: {
+          id: fallbackCategory.id,
+          name: fallbackCategory.displayName,
+        },
+        name: draft.name,
+        quantity: draft.quantity,
+        sourceKey: draft.sourceKey,
+        sourceType: "FAMILY",
+      });
+      setStoreGroups((currentGroups) =>
+        insertProjectedItemIntoStoreGroups(currentGroups, placeholder),
+      );
+      setRecentlyAddedSourceKey(draft.sourceKey);
+    },
+    [fallbackCategory.displayName, fallbackCategory.id],
+  );
 
   const handleQuickAddSuccess = useCallback(
     (payload: QuickAddShoppingSuccess) => {
       setStoreGroups((currentGroups) =>
-        insertProjectedItemIntoStoreGroups(currentGroups, payload.item),
+        insertProjectedItemIntoStoreGroups(
+          dropResolvedOptimisticItemsFromStoreGroups(currentGroups, [
+            payload.item,
+          ]),
+          payload.item,
+        ),
       );
       setRecentManualItems((currentRecents) =>
         prependRecentManualItem(currentRecents, payload.recentManualItem),
@@ -468,6 +525,12 @@ export default function FamilyShoppingRoute({
     },
     [scheduleRevalidate],
   );
+
+  const handleQuickAddError = useCallback((sourceKey: string) => {
+    setStoreGroups((currentGroups) =>
+      removeProjectedItemFromStoreGroups(currentGroups, sourceKey),
+    );
+  }, []);
 
   useEffect(() => {
     if (!recentlyAddedSourceKey) {
@@ -489,6 +552,8 @@ export default function FamilyShoppingRoute({
 
   const quickAddProps = {
     ingredientSearchPath,
+    onQuickAddError: handleQuickAddError,
+    onQuickAddSubmit: handleQuickAddSubmit,
     onQuickAddSuccess: handleQuickAddSuccess,
     quickAddIntent: "quick-add-family-shopping-item" as const,
     recentManualItems,
@@ -497,6 +562,62 @@ export default function FamilyShoppingRoute({
     actionData?.intent === "add-family-shopping-item" && actionData.familyValues
       ? actionData.familyValues
       : defaultFamilyShoppingItemValues;
+  const displayStoreGroups = useMemo(() => {
+    if (navigation.state === "idle" || !navigation.formData) {
+      return storeGroups;
+    }
+
+    const overlayGroups = applyOptimisticShoppingListFormOverlay({
+      categories: loaderData.categories,
+      formData: navigation.formData,
+      groups: storeGroups,
+      intent: pendingIntent,
+      sourceKey: pendingSourceKey,
+      stores: loaderData.stores,
+    });
+
+    if (pendingIntent !== "add-family-shopping-item") {
+      return overlayGroups;
+    }
+
+    const name = String(navigation.formData.get("name") ?? "").trim();
+
+    if (!name) {
+      return overlayGroups;
+    }
+
+    const categoryId = String(navigation.formData.get("categoryId") ?? "");
+    const category =
+      loaderData.categories.find((entry) => entry.id === categoryId) ??
+      fallbackCategory;
+
+    return insertProjectedItemIntoStoreGroups(
+      overlayGroups,
+      buildOptimisticManualShoppingItem({
+        category: {
+          id: category.id,
+          name: category.displayName,
+        },
+        name,
+        quantity: String(navigation.formData.get("quantity") ?? ""),
+        sourceKey: "optimistic:pending-add-family",
+        sourceType: "FAMILY",
+      }),
+    );
+  }, [
+    fallbackCategory,
+    loaderData.categories,
+    loaderData.stores,
+    navigation.formData,
+    navigation.state,
+    pendingIntent,
+    pendingSourceKey,
+    storeGroups,
+  ]);
+  const visibleStoreGroups =
+    displayListMode === "GLOBAL"
+      ? filterStoreGroupsBySourceType(displayStoreGroups, "FAMILY")
+      : displayStoreGroups;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 pb-44 pt-8 text-slate-900 lg:pb-12 lg:py-12">
@@ -574,12 +695,12 @@ export default function FamilyShoppingRoute({
                   <input name="listMode" type="hidden" value="GLOBAL" />
                   <button
                     className={`rounded-2xl px-5 py-3 text-sm font-medium transition ${
-                      loaderData.activeListMode === "GLOBAL"
+                      displayListMode === "GLOBAL"
                         ? "bg-slate-950 text-white"
                         : "bg-white text-slate-900 ring-1 ring-sky-200 hover:bg-sky-100"
                     }`}
                     disabled={
-                      navigation.state === "submitting" &&
+                      navigation.state !== "idle" &&
                       pendingIntent === "set-family-shopping-list-mode"
                     }
                     type="submit"
@@ -596,12 +717,12 @@ export default function FamilyShoppingRoute({
                   <input name="listMode" type="hidden" value="COMBINED" />
                   <button
                     className={`rounded-2xl px-5 py-3 text-sm font-medium transition ${
-                      loaderData.activeListMode === "COMBINED"
+                      displayListMode === "COMBINED"
                         ? "bg-emerald-600 text-white"
                         : "bg-white text-slate-900 ring-1 ring-sky-200 hover:bg-sky-100"
                     }`}
                     disabled={
-                      navigation.state === "submitting" &&
+                      navigation.state !== "idle" &&
                       pendingIntent === "set-family-shopping-list-mode"
                     }
                     type="submit"
@@ -721,9 +842,9 @@ export default function FamilyShoppingRoute({
           </article>
         </section>
 
-        {storeGroups.length ? (
+        {visibleStoreGroups.length ? (
           <section className="grid gap-6">
-            {storeGroups.map((group) => (
+            {visibleStoreGroups.map((group) => (
               <article
                 key={group.store?.id ?? "no-store"}
                 className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200"
@@ -1005,18 +1126,23 @@ function renderFamilyShoppingListItem({
 }) {
   const sourceBadge = getFamilyShoppingSourceBadge(item);
   const isPendingCheckToggle =
-    navigation.state === "submitting" &&
+    navigation.state !== "idle" &&
     ((pendingIntent === "toggle-family-shopping-item-checked" &&
       item.sourceType === "FAMILY") ||
       (pendingIntent === "toggle-meal-plan-shopping-item-checked" &&
         item.sourceType !== "FAMILY")) &&
     pendingSourceKey === item.sourceKey;
+  const displayChecked = getOptimisticChecked({
+    checkedValue: navigation.formData?.get("checked"),
+    isPending: isPendingCheckToggle,
+    itemChecked: item.checked,
+  });
   const isPendingFamilySave =
-    navigation.state === "submitting" &&
+    navigation.state !== "idle" &&
     pendingIntent === "update-family-shopping-item" &&
     pendingSourceKey === item.sourceKey;
   const isPendingFamilyDelete =
-    navigation.state === "submitting" &&
+    navigation.state !== "idle" &&
     pendingIntent === "delete-family-shopping-item" &&
     pendingSourceKey === item.sourceKey;
   const familyValues =
@@ -1036,7 +1162,7 @@ function renderFamilyShoppingListItem({
   const rowStateClass =
     recentlyAddedSourceKey === item.sourceKey
       ? "border-emerald-300 bg-emerald-100"
-      : item.checked
+      : displayChecked
         ? "border-slate-200 bg-slate-100 opacity-80"
         : "border-slate-200 bg-slate-50";
 
@@ -1049,7 +1175,7 @@ function renderFamilyShoppingListItem({
       <div className="flex flex-wrap items-center gap-2">
         <h4
           className={`text-base font-semibold ${
-            item.checked ? "text-slate-500 line-through" : "text-slate-950"
+            displayChecked ? "text-slate-500 line-through" : "text-slate-950"
           }`}
         >
           {item.name}
@@ -1098,6 +1224,7 @@ function renderFamilyShoppingListItem({
             <ShoppingListItemExpanded
               actionData={actionData}
               categories={categories}
+              displayChecked={displayChecked}
               familyValues={familyValues}
               isPendingCheckToggle={isPendingCheckToggle}
               isPendingFamilyDelete={isPendingFamilyDelete}
@@ -1140,8 +1267,10 @@ function renderFamilyShoppingListItem({
             type="submit"
           >
             {isPendingCheckToggle
-              ? "Oppdaterer..."
-              : item.checked
+              ? displayChecked
+                ? "Krysser av..."
+                : "Oppdaterer..."
+              : displayChecked
                 ? "Fjern avkryssing"
                 : "Marker som kjøpt"}
           </button>

--- a/app/routes/family-stock-ingredients.tsx
+++ b/app/routes/family-stock-ingredients.tsx
@@ -171,6 +171,50 @@ export default function FamilyStockIngredientsRoute({
           note: "",
         };
   const canManageStock = loaderData.userRole === "ADMIN";
+  const pendingStockId = String(
+    navigation.formData?.get("stockIngredientId") ?? "",
+  );
+  const isPendingStock =
+    navigation.state !== "idle" && navigation.formData != null;
+  const displayStockIngredients = (() => {
+    if (!isPendingStock || !navigation.formData) {
+      return loaderData.stockIngredients;
+    }
+
+    if (pendingIntent === "remove-stock-ingredient" && pendingStockId) {
+      return loaderData.stockIngredients.filter(
+        (ingredient) => ingredient.id !== pendingStockId,
+      );
+    }
+
+    if (pendingIntent === "add-stock-ingredient") {
+      const ingredientId = String(navigation.formData.get("ingredientId") ?? "");
+      const displayName = String(
+        navigation.formData.get("displayName") ?? "",
+      ).trim();
+      const searchName = loaderData.searchResults.find(
+        (ingredient) => ingredient.id === ingredientId,
+      )?.canonicalName;
+      const label = displayName || searchName || "";
+
+      if (!label) {
+        return loaderData.stockIngredients;
+      }
+
+      return [
+        {
+          displayLabel: label,
+          displayNameNormalized: label.toLowerCase(),
+          id: "optimistic:pending-add",
+          ingredientId: ingredientId || null,
+          note: String(navigation.formData.get("note") ?? "") || null,
+        },
+        ...loaderData.stockIngredients,
+      ];
+    }
+
+    return loaderData.stockIngredients;
+  })();
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -315,12 +359,12 @@ export default function FamilyStockIngredientsRoute({
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
                 disabled={
-                  navigation.state === "submitting" &&
+                  navigation.state !== "idle" &&
                   pendingIntent === "add-stock-ingredient"
                 }
                 type="submit"
               >
-                {navigation.state === "submitting" &&
+                {navigation.state !== "idle" &&
                 pendingIntent === "add-stock-ingredient"
                   ? "Legger til..."
                   : "Legg til basisvare"}
@@ -340,15 +384,15 @@ export default function FamilyStockIngredientsRoute({
               Familiens basisvarer
             </h2>
             <p className="text-sm leading-6 text-slate-600">
-              {loaderData.stockIngredients.length === 0
+              {displayStockIngredients.length === 0
                 ? "Ingen basisvarer er konfigurert ennå."
-                : `${loaderData.stockIngredients.length} basisvarer er registrert.`}
+                : `${displayStockIngredients.length} basisvarer er registrert.`}
             </p>
           </div>
 
-          {loaderData.stockIngredients.length > 0 ? (
+          {displayStockIngredients.length > 0 ? (
             <ul className="mt-6 grid gap-3">
-              {loaderData.stockIngredients.map((ingredient) => (
+              {displayStockIngredients.map((ingredient) => (
                 <li
                   key={ingredient.id}
                   className="flex flex-col gap-3 rounded-[24px] border border-slate-200 bg-slate-50 p-5 sm:flex-row sm:items-center sm:justify-between"
@@ -363,7 +407,8 @@ export default function FamilyStockIngredientsRoute({
                       </p>
                     ) : null}
                   </div>
-                  {canManageStock ? (
+                  {canManageStock &&
+                  ingredient.id !== "optimistic:pending-add" ? (
                     <Form method="post">
                       <input
                         name="intent"
@@ -378,10 +423,9 @@ export default function FamilyStockIngredientsRoute({
                       <button
                         className="rounded-xl border border-rose-200 px-4 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
                         disabled={
-                          navigation.state === "submitting" &&
+                          navigation.state !== "idle" &&
                           pendingIntent === "remove-stock-ingredient" &&
-                          navigation.formData?.get("stockIngredientId") ===
-                            ingredient.id
+                          pendingStockId === ingredient.id
                         }
                         type="submit"
                       >

--- a/app/routes/family-stores.tsx
+++ b/app/routes/family-stores.tsx
@@ -208,6 +208,50 @@ export default function FamilyStoresRoute({
       ? actionData.createValues
       : { name: "" };
   const canManageStores = loaderData.userRole === "ADMIN";
+  const pendingStoreId = String(navigation.formData?.get("storeId") ?? "");
+  const isPendingStore =
+    navigation.state !== "idle" && navigation.formData != null;
+  const displayFamilyStores = (() => {
+    if (!isPendingStore || !navigation.formData) {
+      return loaderData.familyStores;
+    }
+
+    if (pendingIntent === "delete-store" && pendingStoreId) {
+      return loaderData.familyStores.filter((store) => store.id !== pendingStoreId);
+    }
+
+    if (pendingIntent === "update-store" && pendingStoreId) {
+      return loaderData.familyStores.map((store) =>
+        store.id === pendingStoreId
+          ? {
+              ...store,
+              name:
+                String(navigation.formData?.get("name") ?? store.name).trim() ||
+                store.name,
+            }
+          : store,
+      );
+    }
+
+    if (pendingIntent === "create-store") {
+      const name = String(navigation.formData.get("name") ?? "").trim();
+
+      if (!name) {
+        return loaderData.familyStores;
+      }
+
+      return [
+        {
+          id: "optimistic:pending-add",
+          name,
+          sections: [],
+        },
+        ...loaderData.familyStores,
+      ];
+    }
+
+    return loaderData.familyStores;
+  })();
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -295,13 +339,11 @@ export default function FamilyStoresRoute({
               <button
                 className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
                 disabled={
-                  navigation.state === "submitting" &&
-                  pendingIntent === "create-store"
+                  navigation.state !== "idle" && pendingIntent === "create-store"
                 }
                 type="submit"
               >
-                {navigation.state === "submitting" &&
-                pendingIntent === "create-store"
+                {navigation.state !== "idle" && pendingIntent === "create-store"
                   ? "Oppretter..."
                   : "Opprett butikk"}
               </button>
@@ -321,10 +363,10 @@ export default function FamilyStoresRoute({
               </p>
             </div>
 
-            {loaderData.familyStores.length > 0 ? (
+            {displayFamilyStores.length > 0 ? (
               <DndProvider backend={HTML5Backend}>
                 <div className="mt-6 grid gap-5">
-                  {loaderData.familyStores.map((store) => (
+                  {displayFamilyStores.map((store) => (
                     <FamilyStoreEditorCard
                       canManageStores={canManageStores}
                       key={store.id}

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -355,9 +355,14 @@ export default function FamilyRoute({
     navigation.formData?.get("targetUserId") ?? "",
   );
   const isRemovingMember =
-    navigation.state === "submitting" && pendingIntent === "remove-member";
+    navigation.state !== "idle" && pendingIntent === "remove-member";
   const isAdmin = loaderData.userRole === "ADMIN";
   const familyId = loaderData.family.id;
+  const displayMembers = isRemovingMember
+    ? loaderData.members.filter(
+        (member) => member.user.id !== pendingTargetUserId,
+      )
+    : loaderData.members;
 
   return (
     <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
@@ -448,7 +453,7 @@ export default function FamilyRoute({
                   </div>
 
                   <div className="mt-6 grid gap-4">
-                    {loaderData.members.map(
+                    {displayMembers.map(
                       (member: (typeof loaderData.members)[number]) => {
                         const canRemove = member.role === "MEMBER";
                         const isPendingRemoval =


### PR DESCRIPTION
## Summary
- In-scope form mutations now update the visible list, card, badge, or field on submit, then reconcile with the loader.
- Shopping overlays share helpers in `shopping-list-client.ts`; freezer, stock, stores, recipes, meal plans, review, and remove-member follow the same two patterns (document Form + fetcher overlay).
- Auto-fill only shows a filling state on empty days (no invented recipe titles). Switching GLOBAL → COMBINED still waits for the loader.

## Related issue
Closes #185

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] Toggle a shopping item checked and confirm strikethrough before the request finishes
- [ ] Change quantity in store mode and confirm the badge does not snap back
- [ ] Quick-add an item and confirm a placeholder appears immediately, with no duplicate after revalidate
- [ ] Create and delete a meal plan from the list; confirm the card appears/hides immediately
- [ ] On review, tap a feedback chip and confirm it stays selected; approve and confirm the Godkjent label
- [ ] Remove a family member and confirm the row hides immediately; if the action errors, the row returns

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck