### PR TITLE
Default store-mode shopping to grid view

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,19 +2,18 @@
 
 ## Current Objective
 
-Ship optimistic form updates so in-scope mutations change visible data immediately, then reconcile with the loader.
+Ship store-mode shopping defaulting to grid view, with Rutenett first in the view toggle.
 
 ## Completed
 
-- Shopping overlays (check, quantity, category/notes, add, update/delete/exclude/restore/opt-in, GLOBAL list-mode filter) share helpers in `shopping-list-client.ts`.
-- Freezer, stock, stores, recipes, meal plans, review chips/notes/approve, and remove-member use `navigation.formData` or a local overlay until the loader matches.
-- Auto-fill only shows a filling state on empty days. COMBINED list mode still waits for the loader when switching from GLOBAL.
+- `readStoreModeShoppingView` defaults to `grid` when nothing (or an invalid value) is stored.
+- Store-mode toggle UI order is Rutenett, then Liste.
+- Unit tests cover the new default, persistence of `list`, and invalid-storage fallback.
 
 ## Files To Read First
 
-- `app/lib/shopping-list-client.ts` - overlay helpers and form overlay
-- `.cursor/rules/optimistic-form-updates.mdc` - required UI pattern
-- `app/routes/family-meal-plan.tsx` - meal-plan detail overlays
+- `app/lib/shopping-store-mode-client.ts` - default view constant and storage read
+- `app/components/store-mode-shopping-view-toggle.tsx` - toggle button order
 
 ## Validation
 
@@ -25,10 +24,9 @@ Ship optimistic form updates so in-scope mutations change visible data immediate
 
 ## Open Items
 
-- Manual smoke after merge: submit, confirm UI updates before network idle, confirm no duplicate after revalidate, force an error and confirm rollback.
-- Auto-fill and COMBINED←GLOBAL remain partial by data availability; that is intended.
-- Skipped by plan: login/register/logout, GET search, create-family, join-family.
+- Existing localStorage values of `list` still win over the new default; that is intended.
+- No related GitHub issue was found for this change.
 
 ## Next Step
 
-Review and merge the pull request for optimistic form updates.
+Review and merge the pull request.

--- a/app/components/store-mode-shopping-view-toggle.tsx
+++ b/app/components/store-mode-shopping-view-toggle.tsx
@@ -16,19 +16,6 @@ export function StoreModeShoppingViewToggle({
       role="radiogroup"
     >
       <button
-        aria-checked={view === "list"}
-        className={
-          view === "list"
-            ? "rounded-xl bg-white px-4 py-2.5 text-sm font-medium text-stone-950 shadow-sm ring-1 ring-stone-200"
-            : "rounded-xl px-4 py-2.5 text-sm font-medium text-stone-600 transition hover:text-stone-950"
-        }
-        onClick={() => onChange("list")}
-        role="radio"
-        type="button"
-      >
-        Liste
-      </button>
-      <button
         aria-checked={view === "grid"}
         className={
           view === "grid"
@@ -40,6 +27,19 @@ export function StoreModeShoppingViewToggle({
         type="button"
       >
         Rutenett
+      </button>
+      <button
+        aria-checked={view === "list"}
+        className={
+          view === "list"
+            ? "rounded-xl bg-white px-4 py-2.5 text-sm font-medium text-stone-950 shadow-sm ring-1 ring-stone-200"
+            : "rounded-xl px-4 py-2.5 text-sm font-medium text-stone-600 transition hover:text-stone-950"
+        }
+        onClick={() => onChange("list")}
+        role="radio"
+        type="button"
+      >
+        Liste
       </button>
     </div>
   );

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -266,12 +266,12 @@ describe("shopping-store-mode-client", () => {
     );
   });
 
-  it("defaults shopping view to list", () => {
+  it("defaults shopping view to grid", () => {
     const viewStorageKey = buildStoreModeViewStorageKey({
       familyId: "family-1",
     });
 
-    expect(readStoreModeShoppingView(viewStorageKey)).toBe("list");
+    expect(readStoreModeShoppingView(viewStorageKey)).toBe("grid");
   });
 
   it("persists and reads shopping view preference", () => {
@@ -279,19 +279,19 @@ describe("shopping-store-mode-client", () => {
       familyId: "family-1",
     });
 
-    writeStoreModeShoppingView(viewStorageKey, "grid");
+    writeStoreModeShoppingView(viewStorageKey, "list");
 
-    expect(readStoreModeShoppingView(viewStorageKey)).toBe("grid");
+    expect(readStoreModeShoppingView(viewStorageKey)).toBe("list");
   });
 
-  it("falls back to list for invalid stored shopping views", () => {
+  it("falls back to grid for invalid stored shopping views", () => {
     const viewStorageKey = buildStoreModeViewStorageKey({
       familyId: "family-1",
     });
 
     window.localStorage.setItem(viewStorageKey, "table");
 
-    expect(readStoreModeShoppingView(viewStorageKey)).toBe("list");
+    expect(readStoreModeShoppingView(viewStorageKey)).toBe("grid");
   });
 
   it("builds isolated deprioritize-bought storage keys per family", () => {

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -26,6 +26,8 @@ export interface StoreModeProgress {
 
 export type StoreModeShoppingView = "list" | "grid";
 
+export const DEFAULT_STORE_MODE_SHOPPING_VIEW: StoreModeShoppingView = "grid";
+
 const STORE_MODE_QUEUE_KEY_PREFIX = "mealplanner:store-mode-queue:v1";
 const STORE_MODE_VIEW_KEY_PREFIX = "mealplanner:store-mode-view:v1";
 const STORE_MODE_DEPRIORITIZE_BOUGHT_KEY_PREFIX =
@@ -43,7 +45,7 @@ export function readStoreModeShoppingView(
   storageKey: string,
 ): StoreModeShoppingView {
   if (typeof window === "undefined") {
-    return "list";
+    return DEFAULT_STORE_MODE_SHOPPING_VIEW;
   }
 
   try {
@@ -53,9 +55,9 @@ export function readStoreModeShoppingView(
       return raw;
     }
 
-    return "list";
+    return DEFAULT_STORE_MODE_SHOPPING_VIEW;
   } catch {
-    return "list";
+    return DEFAULT_STORE_MODE_SHOPPING_VIEW;
   }
 }
 


### PR DESCRIPTION
## Summary
- Store-mode shopping now defaults to grid (`Rutenett`) for first-time visitors and when no valid preference is stored.
- The view toggle shows Rutenett first, then Liste, matching the new default.

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Open store mode with no saved view preference and confirm grid is selected
- [ ] Confirm the toggle order is Rutenett, then Liste
- [ ] Switch to Liste, reload, and confirm the list preference is still saved

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck