### PR TITLE
Sort store-mode shopping items alphabetically

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,29 +2,28 @@
 
 ## Current Objective
 
-Ship store-mode shopping defaulting to grid view, with Rutenett first in the view toggle.
+Ship alphabetical A–Z sorting for items in store-mode `StoreModeItemGrid`.
 
 ## Completed
 
-- `readStoreModeShoppingView` defaults to `grid` when nothing (or an invalid value) is stored.
-- Store-mode toggle UI order is Rutenett, then Liste.
-- Unit tests cover the new default, persistence of `list`, and invalid-storage fallback.
+- `StoreModeItemGrid` sorts items by name (`nb` locale) before render, including the bought-items grid.
+- `sortStoreModeItemsByName` lives in `shopping-store-mode-client.ts` with unit tests for name order and `sourceKey` tie-breaking.
 
 ## Files To Read First
 
-- `app/lib/shopping-store-mode-client.ts` - default view constant and storage read
-- `app/components/store-mode-shopping-view-toggle.tsx` - toggle button order
+- `app/routes/family-meal-plan-store-mode.tsx` - `StoreModeItemGrid` sorts its `items` prop
+- `app/lib/shopping-store-mode-client.ts` - `sortStoreModeItemsByName` / `compareStoreModeItemsByName`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (401 tests)
+- `npm run test:run` — passed (403 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Existing localStorage values of `list` still win over the new default; that is intended.
+- Loader data (`compareProjectedItemsForStoreMode`) still orders within a section by relevant date, then name. The grid re-sorts for display; aisle/section order is unchanged.
 - No related GitHub issue was found for this change.
 
 ## Next Step

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -17,6 +17,7 @@ import {
   readStoreModeToggleQueue,
   reconcileToggleQueue,
   removeToggleOp,
+  sortStoreModeItemsByName,
   upsertToggleOp,
   writeStoreModeDeprioritizeBought,
   writeStoreModeShoppingView,
@@ -342,6 +343,25 @@ describe("shopping-store-mode-client", () => {
     window.localStorage.setItem(storageKey, "yes");
 
     expect(readStoreModeDeprioritizeBought(storageKey)).toBe(true);
+  });
+
+  it("sorts store-mode items alphabetically by name", () => {
+    expect(
+      sortStoreModeItemsByName([
+        { name: "Yoghurt", sourceKey: "item-3" },
+        { name: "Eple", sourceKey: "item-1" },
+        { name: "Melk", sourceKey: "item-2" },
+      ]).map((item) => item.name),
+    ).toEqual(["Eple", "Melk", "Yoghurt"]);
+  });
+
+  it("uses sourceKey as a stable tiebreaker when names match", () => {
+    expect(
+      sortStoreModeItemsByName([
+        { name: "Melk", sourceKey: "family:2" },
+        { name: "Melk", sourceKey: "family:1" },
+      ]).map((item) => item.sourceKey),
+    ).toEqual(["family:1", "family:2"]);
   });
 
   it("returns sections unchanged when deprioritize-bought is off", () => {

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -121,6 +121,25 @@ export function writeStoreModeDeprioritizeBought(
   }
 }
 
+export function compareStoreModeItemsByName(
+  left: { name: string; sourceKey: string },
+  right: { name: string; sourceKey: string },
+) {
+  const nameComparison = left.name.localeCompare(right.name, "nb");
+
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  return left.sourceKey.localeCompare(right.sourceKey, "nb");
+}
+
+export function sortStoreModeItemsByName<
+  TItem extends { name: string; sourceKey: string },
+>(items: TItem[]): TItem[] {
+  return [...items].sort(compareStoreModeItemsByName);
+}
+
 export function partitionStoreModeSections<
   TItem extends { checked: boolean },
   TSection extends { items: TItem[] },

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -37,6 +37,7 @@ import {
   partitionStoreModeSections,
   readStoreModeDeprioritizeBought,
   readStoreModeShoppingView,
+  sortStoreModeItemsByName,
   type StoreModeShoppingView,
   writeStoreModeDeprioritizeBought,
   writeStoreModeShoppingView,
@@ -1463,6 +1464,11 @@ function StoreModeItemGrid<
   recentlyAddedSourceKey: string | null;
   selectedStoreId?: string;
 }) {
+  const sortedItems = useMemo(
+    () => sortStoreModeItemsByName(items),
+    [items],
+  );
+
   return (
     <div
       className={
@@ -1471,7 +1477,7 @@ function StoreModeItemGrid<
           : "mt-4 flex flex-col gap-2"
       }
     >
-      {items.map((item) => (
+      {sortedItems.map((item) => (
         <StoreModeShoppingItemCard
           key={item.sourceKey}
           categories={categories}


### PR DESCRIPTION
## Summary
- Store-mode items in each aisle (and in Kjøpt) now sort A–Z by name, so the grid is easier to scan while shopping.
- Section/aisle order is unchanged; duplicate names stay stable via `sourceKey`.

## Related issue
No related GitHub issue.

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] Open store mode and confirm items within a category are A–Z
- [ ] Confirm the Kjøpt section is also A–Z when deprioritize-bought is on
- [ ] Confirm switching between Rutenett and Liste keeps the same name order

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck