### PR TITLE
Persist family shopping catalog for reusable quick-add names

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,29 +2,34 @@
 
 ## Current Objective
 
-Ship alphabetical A–Z sorting for items in store-mode `StoreModeItemGrid`.
+Open and merge the pull request for the family shopping catalog (issue #189).
 
 ## Completed
 
-- `StoreModeItemGrid` sorts items by name (`nb` locale) before render, including the bought-items grid.
-- `sortStoreModeItemsByName` lives in `shopping-store-mode-client.ts` with unit tests for name order and `sourceKey` tie-breaking.
+- Custom quick-add names persist in a family-scoped catalog and show up in typeahead on later lists.
+- Handlevarer admin supports rename, default quantity/category, add, and delete.
+- Migration backfills historical custom shopping names that are not canonical ingredients.
+- Search loaders require family membership and merge catalog + register suggestions.
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx` - `StoreModeItemGrid` sorts its `items` prop
-- `app/lib/shopping-store-mode-client.ts` - `sortStoreModeItemsByName` / `compareStoreModeItemsByName`
+- `app/lib/shopping-catalog.server.ts` - list/search/merge suggestions
+- `app/lib/shopping-catalog-write.server.ts` - upsert and admin CRUD
+- `app/routes/family-shopping-catalog.tsx` - Handlevarer UI
+- `app/components/manual-shopping-quick-add.tsx` - typeahead sources
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — passed (403 tests)
+- `npm run test:run` — passed (421 tests)
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Loader data (`compareProjectedItemsForStoreMode`) still orders within a section by relevant date, then name. The grid re-sorts for display; aisle/section order is unchanged.
-- No related GitHub issue was found for this change.
+- Apply Prisma migration on each environment before using the feature.
+- Manual check: add a custom name, start a new week, type it, confirm default quantity, then rename in Handlevarer.
+- Issue #189 closes when the PR merges (`Closes #189`).
 
 ## Next Step
 

--- a/app/components/app-top-nav.test.tsx
+++ b/app/components/app-top-nav.test.tsx
@@ -36,6 +36,10 @@ describe("AppTopNav", () => {
       "href",
       "/families/family-1/stock-ingredients",
     );
+    expect(screen.getByRole("link", { name: "Handlevarer" })).toHaveAttribute(
+      "href",
+      "/families/family-1/shopping-catalog",
+    );
     expect(screen.getByRole("link", { name: "Fryser" })).toHaveAttribute(
       "href",
       "/families/family-1/freezer",

--- a/app/components/app-top-nav.tsx
+++ b/app/components/app-top-nav.tsx
@@ -43,6 +43,11 @@ function buildFamilyNavItems(
     },
     {
       end: true,
+      label: "Handlevarer",
+      to: `/families/${familyId}/shopping-catalog`,
+    },
+    {
+      end: true,
       label: "Fryser",
       to: `/families/${familyId}/freezer`,
     },

--- a/app/components/manual-shopping-quick-add.tsx
+++ b/app/components/manual-shopping-quick-add.tsx
@@ -20,7 +20,9 @@ import type { RecentManualShoppingItem } from "../lib/shopping.server";
 export interface IngredientSearchResult {
   canonicalName: string;
   defaultCategoryId: string | null;
+  defaultQuantity?: string | null;
   id: string;
+  source?: "catalog" | "register";
 }
 
 interface ManualShoppingQuickAddLoaderSlice {
@@ -183,6 +185,7 @@ export function ManualShoppingQuickAdd({
       : undefined;
 
   function submitQuickAdd(fields: {
+    catalogItemId?: string;
     ingredientId?: string;
     name?: string;
     quantity?: string;
@@ -190,6 +193,10 @@ export function ManualShoppingQuickAdd({
   }) {
     const formData = new FormData();
     formData.set("intent", quickAddIntent);
+
+    if (fields.catalogItemId) {
+      formData.set("catalogItemId", fields.catalogItemId);
+    }
 
     if (fields.ingredientId) {
       formData.set("ingredientId", fields.ingredientId);
@@ -209,8 +216,11 @@ export function ManualShoppingQuickAdd({
 
     const draftName =
       fields.name?.trim() ||
-      displayedResults.find((ingredient) => ingredient.id === fields.ingredientId)
-        ?.canonicalName ||
+      displayedResults.find(
+        (ingredient) =>
+          ingredient.id === fields.ingredientId ||
+          ingredient.id === fields.catalogItemId,
+      )?.canonicalName ||
       recentManualItems.find(
         (item) => item.nameNormalized === fields.recentNameNormalized,
       )?.displayName ||
@@ -529,11 +539,19 @@ export function ManualShoppingQuickAdd({
                 </li>
               ) : null}
               {displayedResults.map((ingredient) => (
-                <li key={ingredient.id} role="option">
+                <li key={`${ingredient.source ?? "register"}:${ingredient.id}`} role="option">
                   <button
                     className={styles.option}
                     disabled={isQuickAdding}
                     onClick={() => {
+                      if (ingredient.source === "catalog") {
+                        submitQuickAdd({
+                          catalogItemId: ingredient.id,
+                          quantity,
+                        });
+                        return;
+                      }
+
                       submitQuickAdd({
                         ingredientId: ingredient.id,
                         quantity,
@@ -544,7 +562,9 @@ export function ManualShoppingQuickAdd({
                     <span className="font-medium">
                       {ingredient.canonicalName}
                     </span>
-                    <span className={styles.optionMeta}>Fra register</span>
+                    <span className={styles.optionMeta}>
+                      {formatSuggestionMeta(ingredient)}
+                    </span>
                   </button>
                 </li>
               ))}
@@ -570,4 +590,16 @@ export function ManualShoppingQuickAdd({
       {!revealOnFocus && recentsBlock ? recentsBlock : null}
     </div>
   );
+}
+
+function formatSuggestionMeta(ingredient: IngredientSearchResult) {
+  if (ingredient.source === "catalog") {
+    const defaultQuantity = ingredient.defaultQuantity?.trim();
+
+    return defaultQuantity
+      ? `Familievare · ${defaultQuantity}`
+      : "Familievare";
+  }
+
+  return "Fra register";
 }

--- a/app/lib/family-shopping-write.server.test.ts
+++ b/app/lib/family-shopping-write.server.test.ts
@@ -45,6 +45,10 @@ vi.mock("./shopping-write.server", () => ({
   resolveQuickAddManualShoppingItemValues: vi.fn(),
 }));
 
+vi.mock("./shopping-catalog-write.server", () => ({
+  upsertFamilyShoppingCatalogItemFromQuickAdd: vi.fn(),
+}));
+
 import { resolveQuickAddManualShoppingItemValues } from "./shopping-write.server";
 import {
   createFamilyShoppingItem,
@@ -278,6 +282,16 @@ describe("family-shopping-write.server", () => {
       },
       status: "CREATED",
     });
+    const { upsertFamilyShoppingCatalogItemFromQuickAdd } = await import(
+      "./shopping-catalog-write.server"
+    );
+    expect(upsertFamilyShoppingCatalogItemFromQuickAdd).toHaveBeenCalledWith({
+      familyId: "family-1",
+      ingredientId: undefined,
+      item: expect.objectContaining({
+        name: "Batterier",
+      }),
+    });
   });
 
   it("parses quick-add input quantity from form data", () => {
@@ -286,6 +300,7 @@ describe("family-shopping-write.server", () => {
     formData.set("quantity", "4 flasker");
 
     expect(parseQuickAddFamilyShoppingItemInput(formData)).toEqual({
+      catalogItemId: "",
       ingredientId: "",
       name: "Melk",
       quantity: "4 flasker",

--- a/app/lib/family-shopping-write.server.ts
+++ b/app/lib/family-shopping-write.server.ts
@@ -11,6 +11,7 @@ import {
   buildRecentManualItemFromProjectedItem,
   projectCreatedFamilyShoppingItem,
 } from "./shopping.server";
+import { upsertFamilyShoppingCatalogItemFromQuickAdd } from "./shopping-catalog-write.server";
 import {
   resolveQuickAddManualShoppingItemValues,
   type QuickAddManualShoppingItemInput,
@@ -47,6 +48,7 @@ export function parseFamilyShoppingItemValues(
 
 export function parseQuickAddFamilyShoppingItemInput(formData: FormData) {
   return {
+    catalogItemId: String(formData.get("catalogItemId") ?? ""),
     ingredientId: String(formData.get("ingredientId") ?? ""),
     name: String(formData.get("name") ?? ""),
     quantity: String(formData.get("quantity") ?? ""),
@@ -95,6 +97,12 @@ export async function createQuickFamilyShoppingItem({
   if (!item) {
     throw new Error("Fant ikke den nylig opprettede familiens handlelinje.");
   }
+
+  await upsertFamilyShoppingCatalogItemFromQuickAdd({
+    familyId,
+    ingredientId: input.ingredientId,
+    item,
+  });
 
   return {
     item,

--- a/app/lib/shopping-catalog-write.server.test.ts
+++ b/app/lib/shopping-catalog-write.server.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => {
+  return {
+    dbMock: {
+      familyShoppingCatalogItem: {
+        create: vi.fn(),
+        deleteMany: vi.fn(),
+        findFirst: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+        updateMany: vi.fn(),
+      },
+      ingredient: {
+        findFirst: vi.fn(),
+      },
+      ingredientCategory: {
+        findUnique: vi.fn(),
+      },
+    },
+    requireFamilyMembershipMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+import {
+  addFamilyShoppingCatalogItem,
+  deleteFamilyShoppingCatalogItem,
+  updateFamilyShoppingCatalogItem,
+  upsertFamilyShoppingCatalogItem,
+  upsertFamilyShoppingCatalogItemFromQuickAdd,
+} from "./shopping-catalog-write.server";
+
+describe("shopping-catalog-write.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "MEMBER",
+      userId: "user-1",
+    });
+    dbMock.ingredient.findFirst.mockResolvedValue(null);
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.familyShoppingCatalogItem.findFirst.mockResolvedValue(null);
+    dbMock.familyShoppingCatalogItem.findUnique.mockResolvedValue(null);
+  });
+
+  it("creates a catalog item on first custom upsert", async () => {
+    dbMock.familyShoppingCatalogItem.create.mockResolvedValue({
+      id: "catalog-1",
+    });
+
+    const result = await upsertFamilyShoppingCatalogItem({
+      categoryId: "category-other",
+      displayName: "  Tørkerull  ",
+      familyId: "family-1",
+      quantity: "1 pk",
+    });
+
+    expect(result).toEqual({
+      catalogItemId: "catalog-1",
+      status: "CREATED",
+    });
+    expect(dbMock.familyShoppingCatalogItem.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        defaultCategoryId: "category-other",
+        defaultQuantity: "1 pk",
+        displayName: "Tørkerull",
+        familyId: "family-1",
+        nameNormalized: "tørkerull",
+      }),
+      select: { id: true },
+    });
+  });
+
+  it("only updates lastUsedAt on a later upsert of the same name", async () => {
+    dbMock.familyShoppingCatalogItem.findUnique.mockResolvedValue({
+      id: "catalog-1",
+    });
+    dbMock.familyShoppingCatalogItem.update.mockResolvedValue({
+      id: "catalog-1",
+    });
+
+    const result = await upsertFamilyShoppingCatalogItem({
+      categoryId: "category-household",
+      displayName: "Tørkerull",
+      familyId: "family-1",
+      quantity: "2 pk",
+    });
+
+    expect(result).toEqual({
+      catalogItemId: "catalog-1",
+      status: "UPDATED",
+    });
+    expect(dbMock.familyShoppingCatalogItem.update).toHaveBeenCalledWith({
+      data: {
+        lastUsedAt: expect.any(Date),
+      },
+      where: { id: "catalog-1" },
+    });
+    expect(dbMock.familyShoppingCatalogItem.create).not.toHaveBeenCalled();
+  });
+
+  it("skips upsert for canonical ingredient names", async () => {
+    dbMock.ingredient.findFirst.mockResolvedValue({
+      canonicalName: "Melk",
+      id: "ingredient-milk",
+    });
+
+    const result = await upsertFamilyShoppingCatalogItem({
+      categoryId: "category-dairy",
+      displayName: "Melk",
+      familyId: "family-1",
+      quantity: "1",
+    });
+
+    expect(result).toEqual({ status: "SKIPPED" });
+    expect(dbMock.familyShoppingCatalogItem.create).not.toHaveBeenCalled();
+  });
+
+  it("skips quick-add upsert when an ingredientId was used", async () => {
+    const result = await upsertFamilyShoppingCatalogItemFromQuickAdd({
+      familyId: "family-1",
+      ingredientId: "ingredient-milk",
+      item: {
+        category: { id: "category-dairy" },
+        name: "Melk",
+        quantity: "1",
+      },
+    });
+
+    expect(result).toEqual({ status: "SKIPPED" });
+    expect(dbMock.familyShoppingCatalogItem.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects admin add of a duplicate catalog name", async () => {
+    dbMock.familyShoppingCatalogItem.findFirst.mockResolvedValue({
+      id: "catalog-existing",
+    });
+
+    const result = await addFamilyShoppingCatalogItem({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-other",
+        name: "Tørkerull",
+        quantity: "1 pk",
+      },
+    });
+
+    expect(result.status).toBe("VALIDATION_ERROR");
+    if (result.status === "VALIDATION_ERROR") {
+      expect(result.fieldErrors.name).toBe(
+        "Det finnes allerede en handlevare med dette navnet.",
+      );
+    }
+    expect(dbMock.familyShoppingCatalogItem.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects renaming onto another catalog name", async () => {
+    dbMock.familyShoppingCatalogItem.findFirst.mockResolvedValue({
+      id: "catalog-other",
+    });
+
+    const result = await updateFamilyShoppingCatalogItem({
+      catalogItemId: "catalog-1",
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-other",
+        name: "Tannkrem",
+        quantity: "1",
+      },
+    });
+
+    expect(result.status).toBe("VALIDATION_ERROR");
+    if (result.status === "VALIDATION_ERROR") {
+      expect(result.fieldErrors.name).toBe(
+        "Det finnes allerede en handlevare med dette navnet.",
+      );
+    }
+  });
+
+  it("updates a catalog item", async () => {
+    dbMock.familyShoppingCatalogItem.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await updateFamilyShoppingCatalogItem({
+      catalogItemId: "catalog-1",
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-other",
+        name: "Tørkerull XL",
+        quantity: "2 pk",
+      },
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(dbMock.familyShoppingCatalogItem.updateMany).toHaveBeenCalledWith({
+      data: {
+        defaultCategoryId: "category-other",
+        defaultQuantity: "2 pk",
+        displayName: "Tørkerull XL",
+        nameNormalized: "tørkerull xl",
+      },
+      where: {
+        familyId: "family-1",
+        id: "catalog-1",
+      },
+    });
+  });
+
+  it("deletes a catalog item", async () => {
+    dbMock.familyShoppingCatalogItem.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await deleteFamilyShoppingCatalogItem({
+      catalogItemId: "catalog-1",
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "DELETED" });
+  });
+});

--- a/app/lib/shopping-catalog-write.server.ts
+++ b/app/lib/shopping-catalog-write.server.ts
@@ -1,0 +1,345 @@
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
+import { findCanonicalIngredientByNormalizedName } from "./shopping-catalog.server";
+
+export interface FamilyShoppingCatalogItemValues {
+  categoryId: string;
+  name: string;
+  quantity: string;
+}
+
+export interface FamilyShoppingCatalogItemFieldErrors {
+  categoryId?: string;
+  name?: string;
+}
+
+export async function upsertFamilyShoppingCatalogItem({
+  categoryId,
+  displayName,
+  familyId,
+  quantity,
+}: {
+  categoryId: string;
+  displayName: string;
+  familyId: string;
+  quantity?: string | null;
+}) {
+  const trimmedName = displayName.trim();
+  const nameNormalized = normalizeIngredientCanonicalName(trimmedName);
+
+  if (!nameNormalized || !categoryId) {
+    return {
+      status: "SKIPPED" as const,
+    };
+  }
+
+  const canonicalIngredient =
+    await findCanonicalIngredientByNormalizedName(nameNormalized);
+
+  if (canonicalIngredient) {
+    return {
+      status: "SKIPPED" as const,
+    };
+  }
+
+  const existing = await db.familyShoppingCatalogItem.findUnique({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId_nameNormalized: {
+        familyId,
+        nameNormalized,
+      },
+    },
+  });
+
+  if (existing) {
+    await db.familyShoppingCatalogItem.update({
+      data: {
+        lastUsedAt: new Date(),
+      },
+      where: {
+        id: existing.id,
+      },
+    });
+
+    return {
+      catalogItemId: existing.id,
+      status: "UPDATED" as const,
+    };
+  }
+
+  const created = await db.familyShoppingCatalogItem.create({
+    data: {
+      defaultCategoryId: categoryId,
+      defaultQuantity: quantity?.trim() || null,
+      displayName: trimmedName,
+      familyId,
+      lastUsedAt: new Date(),
+      nameNormalized,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return {
+    catalogItemId: created.id,
+    status: "CREATED" as const,
+  };
+}
+
+export async function upsertFamilyShoppingCatalogItemFromQuickAdd({
+  familyId,
+  ingredientId,
+  item,
+}: {
+  familyId: string;
+  ingredientId?: string;
+  item: {
+    category: { id: string };
+    name: string;
+    quantity?: string | null;
+  };
+}) {
+  if (ingredientId?.trim()) {
+    return {
+      status: "SKIPPED" as const,
+    };
+  }
+
+  return upsertFamilyShoppingCatalogItem({
+    categoryId: item.category.id,
+    displayName: item.name,
+    familyId,
+    quantity: item.quantity,
+  });
+}
+
+export async function addFamilyShoppingCatalogItem({
+  familyId,
+  userId,
+  values,
+}: {
+  familyId: string;
+  userId: string;
+  values: FamilyShoppingCatalogItemValues;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const validation = await validateFamilyShoppingCatalogItemValues({
+    familyId,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  const created = await db.familyShoppingCatalogItem.create({
+    data: {
+      defaultCategoryId: validation.categoryId,
+      defaultQuantity: validation.quantity,
+      displayName: validation.name,
+      familyId,
+      lastUsedAt: new Date(),
+      nameNormalized: validation.nameNormalized,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return {
+    catalogItemId: created.id,
+    status: "CREATED" as const,
+  };
+}
+
+export async function updateFamilyShoppingCatalogItem({
+  catalogItemId,
+  familyId,
+  userId,
+  values,
+}: {
+  catalogItemId: string;
+  familyId: string;
+  userId: string;
+  values: FamilyShoppingCatalogItemValues;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const validation = await validateFamilyShoppingCatalogItemValues({
+    excludeCatalogItemId: catalogItemId,
+    familyId,
+    values,
+  });
+
+  if (!validation.ok) {
+    return {
+      fieldErrors: validation.fieldErrors,
+      status: "VALIDATION_ERROR" as const,
+      values: validation.values,
+    };
+  }
+
+  const updated = await db.familyShoppingCatalogItem.updateMany({
+    data: {
+      defaultCategoryId: validation.categoryId,
+      defaultQuantity: validation.quantity,
+      displayName: validation.name,
+      nameNormalized: validation.nameNormalized,
+    },
+    where: {
+      familyId,
+      id: catalogItemId,
+    },
+  });
+
+  if (updated.count === 0) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  return {
+    status: "UPDATED" as const,
+  };
+}
+
+export async function deleteFamilyShoppingCatalogItem({
+  catalogItemId,
+  familyId,
+  userId,
+}: {
+  catalogItemId: string;
+  familyId: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const deleted = await db.familyShoppingCatalogItem.deleteMany({
+    where: {
+      familyId,
+      id: catalogItemId,
+    },
+  });
+
+  if (deleted.count === 0) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  return {
+    status: "DELETED" as const,
+  };
+}
+
+async function validateFamilyShoppingCatalogItemValues({
+  excludeCatalogItemId,
+  familyId,
+  values,
+}: {
+  excludeCatalogItemId?: string;
+  familyId: string;
+  values: FamilyShoppingCatalogItemValues;
+}) {
+  const name = values.name.trim();
+  const quantity = values.quantity.trim() || null;
+  const categoryId = values.categoryId.trim();
+  const fieldErrors: FamilyShoppingCatalogItemFieldErrors = {};
+
+  if (!name) {
+    fieldErrors.name = "Skriv inn et varenavn.";
+  }
+
+  if (!categoryId) {
+    fieldErrors.categoryId = "Velg en kategori.";
+  }
+
+  const nameNormalized = normalizeIngredientCanonicalName(name);
+
+  if (name && !fieldErrors.name) {
+    const canonicalIngredient =
+      await findCanonicalIngredientByNormalizedName(nameNormalized);
+
+    if (canonicalIngredient) {
+      fieldErrors.name =
+        "Dette navnet finnes allerede i ingrediensregisteret.";
+    }
+  }
+
+  if (name && categoryId && !fieldErrors.name) {
+    const collision = await db.familyShoppingCatalogItem.findFirst({
+      select: {
+        id: true,
+      },
+      where: {
+        familyId,
+        nameNormalized,
+        ...(excludeCatalogItemId
+          ? {
+              NOT: {
+                id: excludeCatalogItemId,
+              },
+            }
+          : {}),
+      },
+    });
+
+    if (collision) {
+      fieldErrors.name = "Det finnes allerede en handlevare med dette navnet.";
+    }
+  }
+
+  if (categoryId && !fieldErrors.categoryId) {
+    const category = await db.ingredientCategory.findUnique({
+      select: {
+        id: true,
+      },
+      where: {
+        id: categoryId,
+      },
+    });
+
+    if (!category) {
+      fieldErrors.categoryId = "Velg en gyldig kategori.";
+    }
+  }
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      fieldErrors,
+      ok: false as const,
+      values: {
+        categoryId,
+        name,
+        quantity: values.quantity,
+      },
+    };
+  }
+
+  return {
+    categoryId,
+    name,
+    nameNormalized,
+    ok: true as const,
+    quantity,
+  };
+}

--- a/app/lib/shopping-catalog.server.test.ts
+++ b/app/lib/shopping-catalog.server.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock, searchCanonicalIngredientsMock } =
+  vi.hoisted(() => {
+    return {
+      dbMock: {
+        familyShoppingCatalogItem: {
+          findFirst: vi.fn(),
+          findMany: vi.fn(),
+          findUnique: vi.fn(),
+        },
+        ingredient: {
+          findFirst: vi.fn(),
+        },
+      },
+      requireFamilyMembershipMock: vi.fn(),
+      searchCanonicalIngredientsMock: vi.fn(),
+    };
+  });
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+vi.mock("./stock.server", () => ({
+  searchCanonicalIngredients: searchCanonicalIngredientsMock,
+}));
+
+import {
+  listFamilyShoppingCatalogItems,
+  searchShoppingQuickAddSuggestions,
+} from "./shopping-catalog.server";
+
+const catalogPaperTowels = {
+  defaultCategory: {
+    displayName: "Annet",
+    id: "category-other",
+  },
+  defaultCategoryId: "category-other",
+  defaultQuantity: "1 pk",
+  displayName: "Tørkerull",
+  id: "catalog-1",
+  lastUsedAt: new Date("2026-08-18T00:00:00.000Z"),
+  nameNormalized: "tørkerull",
+};
+
+describe("shopping-catalog.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireFamilyMembershipMock.mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      role: "MEMBER",
+      userId: "user-1",
+    });
+  });
+
+  it("lists family catalog items", async () => {
+    dbMock.familyShoppingCatalogItem.findMany.mockResolvedValue([
+      catalogPaperTowels,
+    ]);
+
+    const result = await listFamilyShoppingCatalogItems({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(result.catalogItems).toEqual([catalogPaperTowels]);
+    expect(result.family).toEqual({
+      id: "family-1",
+      name: "Solberg",
+    });
+    expect(dbMock.familyShoppingCatalogItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { familyId: "family-1" },
+      }),
+    );
+  });
+
+  it("merges catalog and register suggestions and prefers catalog duplicates", async () => {
+    dbMock.familyShoppingCatalogItem.findMany.mockResolvedValue([
+      catalogPaperTowels,
+      {
+        ...catalogPaperTowels,
+        defaultQuantity: "2 l",
+        displayName: "Melk",
+        id: "catalog-milk",
+        nameNormalized: "melk",
+      },
+    ]);
+    searchCanonicalIngredientsMock.mockResolvedValue([
+      {
+        canonicalName: "Melk",
+        defaultCategoryId: "category-dairy",
+        id: "ingredient-milk",
+      },
+      {
+        canonicalName: "Melkesjokolade",
+        defaultCategoryId: "category-sweets",
+        id: "ingredient-chocolate",
+      },
+    ]);
+
+    const result = await searchShoppingQuickAddSuggestions({
+      familyId: "family-1",
+      query: "mel",
+    });
+
+    expect(result).toEqual([
+      {
+        canonicalName: "Tørkerull",
+        defaultCategoryId: "category-other",
+        defaultQuantity: "1 pk",
+        id: "catalog-1",
+        source: "catalog",
+      },
+      {
+        canonicalName: "Melk",
+        defaultCategoryId: "category-other",
+        defaultQuantity: "2 l",
+        id: "catalog-milk",
+        source: "catalog",
+      },
+      {
+        canonicalName: "Melkesjokolade",
+        defaultCategoryId: "category-sweets",
+        defaultQuantity: null,
+        id: "ingredient-chocolate",
+        source: "register",
+      },
+    ]);
+  });
+});

--- a/app/lib/shopping-catalog.server.ts
+++ b/app/lib/shopping-catalog.server.ts
@@ -1,0 +1,206 @@
+import { Prisma } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
+import { searchCanonicalIngredients } from "./stock.server";
+
+const CATALOG_SEARCH_LIMIT = 20;
+
+const familyShoppingCatalogItemSelect =
+  Prisma.validator<Prisma.FamilyShoppingCatalogItemSelect>()({
+    defaultCategory: {
+      select: {
+        displayName: true,
+        id: true,
+      },
+    },
+    defaultCategoryId: true,
+    defaultQuantity: true,
+    displayName: true,
+    id: true,
+    lastUsedAt: true,
+    nameNormalized: true,
+  });
+
+export type FamilyShoppingCatalogItemRow = Prisma.FamilyShoppingCatalogItemGetPayload<{
+  select: typeof familyShoppingCatalogItemSelect;
+}>;
+
+export type ShoppingQuickAddSuggestionSource = "catalog" | "register";
+
+export interface ShoppingQuickAddSuggestion {
+  canonicalName: string;
+  defaultCategoryId: string | null;
+  defaultQuantity: string | null;
+  id: string;
+  source: ShoppingQuickAddSuggestionSource;
+}
+
+export async function listFamilyShoppingCatalogItems({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const catalogItems = await db.familyShoppingCatalogItem.findMany({
+    orderBy: [{ displayName: "asc" }, { id: "asc" }],
+    select: familyShoppingCatalogItemSelect,
+    where: {
+      familyId,
+    },
+  });
+
+  return {
+    catalogItems,
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    userRole: membership.role,
+  };
+}
+
+export async function searchFamilyShoppingCatalogItems({
+  familyId,
+  query,
+}: {
+  familyId: string;
+  query: string;
+}) {
+  const normalizedQuery = query.trim();
+
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  return db.familyShoppingCatalogItem.findMany({
+    orderBy: [{ displayName: "asc" }, { id: "asc" }],
+    select: familyShoppingCatalogItemSelect,
+    take: CATALOG_SEARCH_LIMIT,
+    where: {
+      familyId,
+      displayName: {
+        contains: normalizedQuery,
+        mode: "insensitive",
+      },
+    },
+  });
+}
+
+export async function getFamilyShoppingCatalogItemForFamily({
+  catalogItemId,
+  familyId,
+}: {
+  catalogItemId: string;
+  familyId: string;
+}) {
+  return db.familyShoppingCatalogItem.findFirst({
+    select: familyShoppingCatalogItemSelect,
+    where: {
+      familyId,
+      id: catalogItemId,
+    },
+  });
+}
+
+export async function getFamilyShoppingCatalogItemByNormalizedName({
+  familyId,
+  nameNormalized,
+}: {
+  familyId: string;
+  nameNormalized: string;
+}) {
+  if (!nameNormalized) {
+    return null;
+  }
+
+  return db.familyShoppingCatalogItem.findUnique({
+    select: familyShoppingCatalogItemSelect,
+    where: {
+      familyId_nameNormalized: {
+        familyId,
+        nameNormalized,
+      },
+    },
+  });
+}
+
+export async function findCanonicalIngredientByNormalizedName(
+  nameNormalized: string,
+) {
+  if (!nameNormalized) {
+    return null;
+  }
+
+  return db.ingredient.findFirst({
+    select: {
+      canonicalName: true,
+      id: true,
+    },
+    where: {
+      canonicalName: {
+        equals: nameNormalized,
+        mode: "insensitive",
+      },
+    },
+  });
+}
+
+export async function searchShoppingQuickAddSuggestions({
+  familyId,
+  query,
+}: {
+  familyId: string;
+  query: string;
+}): Promise<ShoppingQuickAddSuggestion[]> {
+  const [catalogItems, registerItems] = await Promise.all([
+    searchFamilyShoppingCatalogItems({
+      familyId,
+      query,
+    }),
+    searchCanonicalIngredients(query),
+  ]);
+
+  const suggestions: ShoppingQuickAddSuggestion[] = catalogItems.map(
+    (item) => ({
+      canonicalName: item.displayName,
+      defaultCategoryId: item.defaultCategoryId,
+      defaultQuantity: item.defaultQuantity,
+      id: item.id,
+      source: "catalog" as const,
+    }),
+  );
+  const seen = new Set(
+    suggestions.map((item) =>
+      normalizeIngredientCanonicalName(item.canonicalName),
+    ),
+  );
+
+  for (const ingredient of registerItems) {
+    const nameNormalized = normalizeIngredientCanonicalName(
+      ingredient.canonicalName,
+    );
+
+    if (seen.has(nameNormalized)) {
+      continue;
+    }
+
+    seen.add(nameNormalized);
+    suggestions.push({
+      canonicalName: ingredient.canonicalName,
+      defaultCategoryId: ingredient.defaultCategoryId,
+      defaultQuantity: null,
+      id: ingredient.id,
+      source: "register",
+    });
+  }
+
+  return suggestions;
+}

--- a/app/lib/shopping-write.server.test.ts
+++ b/app/lib/shopping-write.server.test.ts
@@ -64,6 +64,10 @@ const {
       store: {
         findFirst: vi.fn(),
       },
+      familyShoppingCatalogItem: {
+        findFirst: vi.fn(),
+        findUnique: vi.fn(),
+      },
     },
     getFamilyStockMatchSetMock: vi.fn(),
     getStockIngredientsForMealPlanMock: vi.fn(),
@@ -117,6 +121,12 @@ vi.mock("./stock.server", () => {
   };
 });
 
+vi.mock("./shopping-catalog-write.server", () => {
+  return {
+    upsertFamilyShoppingCatalogItemFromQuickAdd: vi.fn(),
+  };
+});
+
 import {
   createManualShoppingItem,
   createQuickManualShoppingItem,
@@ -160,6 +170,8 @@ describe("shopping-write.server", () => {
     dbMock.shoppingItemOverride.updateMany.mockResolvedValue({ count: 1 });
     dbMock.shoppingItemOverride.deleteMany.mockResolvedValue({ count: 1 });
     dbMock.shoppingItemOverride.findMany.mockResolvedValue([]);
+    dbMock.familyShoppingCatalogItem.findFirst.mockResolvedValue(null);
+    dbMock.familyShoppingCatalogItem.findUnique.mockResolvedValue(null);
     dbMock.$transaction.mockImplementation(async (callback: (tx: typeof transactionMock) => unknown) =>
       callback(transactionMock),
     );
@@ -430,6 +442,100 @@ describe("shopping-write.server", () => {
     });
   });
 
+  it("resolves quick-add values from a family catalog item id", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.familyShoppingCatalogItem.findFirst.mockResolvedValue({
+      defaultCategoryId: "category-household",
+      defaultQuantity: "1 pk",
+      displayName: "Tørkerull",
+      id: "catalog-1",
+    });
+
+    const result = await resolveQuickAddManualShoppingItemValues({
+      familyId: "family-1",
+      input: {
+        catalogItemId: "catalog-1",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-household",
+        name: "Tørkerull",
+        note: "",
+        preferredStoreId: "",
+        quantity: "1 pk",
+      },
+    });
+  });
+
+  it("uses catalog defaults when typing a matching custom name", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.familyShoppingCatalogItem.findUnique.mockResolvedValue({
+      defaultCategoryId: "category-household",
+      defaultQuantity: "2 pk",
+      displayName: "Tørkerull",
+      id: "catalog-1",
+    });
+
+    const result = await resolveQuickAddManualShoppingItemValues({
+      familyId: "family-1",
+      input: {
+        name: "tørkerull",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-household",
+        name: "Tørkerull",
+        note: "",
+        preferredStoreId: "",
+        quantity: "2 pk",
+      },
+    });
+  });
+
+  it("prefers an explicit quantity over catalog default quantity", async () => {
+    dbMock.ingredientCategory.findUnique.mockResolvedValue({
+      id: "category-other",
+    });
+    dbMock.familyShoppingCatalogItem.findFirst.mockResolvedValue({
+      defaultCategoryId: "category-household",
+      defaultQuantity: "1 pk",
+      displayName: "Tørkerull",
+      id: "catalog-1",
+    });
+
+    const result = await resolveQuickAddManualShoppingItemValues({
+      familyId: "family-1",
+      input: {
+        catalogItemId: "catalog-1",
+        quantity: "3 pk",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        buyOnDate: "",
+        categoryId: "category-household",
+        name: "Tørkerull",
+        note: "",
+        preferredStoreId: "",
+        quantity: "3 pk",
+      },
+    });
+  });
+
   it("creates a quick-add manual item with Annet defaults for new names", async () => {
     dbMock.ingredientCategory.findUnique.mockResolvedValue({
       id: "category-other",
@@ -497,6 +603,16 @@ describe("shopping-write.server", () => {
         quantity: "1",
         updatedByUserId: "user-1",
       },
+    });
+    const { upsertFamilyShoppingCatalogItemFromQuickAdd } = await import(
+      "./shopping-catalog-write.server"
+    );
+    expect(upsertFamilyShoppingCatalogItemFromQuickAdd).toHaveBeenCalledWith({
+      familyId: "family-1",
+      ingredientId: undefined,
+      item: expect.objectContaining({
+        name: "Tannkrem",
+      }),
     });
   });
 

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -18,6 +18,11 @@ import {
   loadShoppingMealPlan,
   projectCreatedManualShoppingItem,
 } from "./shopping.server";
+import {
+  getFamilyShoppingCatalogItemByNormalizedName,
+  getFamilyShoppingCatalogItemForFamily,
+} from "./shopping-catalog.server";
+import { upsertFamilyShoppingCatalogItemFromQuickAdd } from "./shopping-catalog-write.server";
 import { getFamilyStockMatchSet } from "./stock.server";
 import { logCollaborationFailure, logCollaborationWrite } from "./write-observability.server";
 
@@ -38,6 +43,7 @@ export interface ManualShoppingItemFieldErrors {
 }
 
 export interface QuickAddManualShoppingItemInput {
+  catalogItemId?: string;
   ingredientId?: string;
   name?: string;
   quantity?: string;
@@ -123,6 +129,12 @@ export async function createQuickManualShoppingItem({
       status: "NOT_FOUND" as const,
     };
   }
+
+  await upsertFamilyShoppingCatalogItemFromQuickAdd({
+    familyId,
+    ingredientId: input.ingredientId,
+    item,
+  });
 
   return {
     item,
@@ -1891,6 +1903,7 @@ export async function resolveQuickAddManualShoppingItemValues({
   }
 
   const ingredientId = input.ingredientId?.trim();
+  const catalogItemId = input.catalogItemId?.trim();
   const requestedQuantity = input.quantity?.trim();
   const quantity = requestedQuantity || QUICK_ADD_DEFAULT_QUANTITY;
 
@@ -1912,6 +1925,27 @@ export async function resolveQuickAddManualShoppingItemValues({
           categoryId: ingredient.defaultCategoryId ?? otherCategoryId,
           name: ingredient.canonicalName,
           quantity,
+        }),
+      };
+    }
+  }
+
+  if (catalogItemId) {
+    const catalogItem = await getFamilyShoppingCatalogItemForFamily({
+      catalogItemId,
+      familyId,
+    });
+
+    if (catalogItem) {
+      return {
+        ok: true as const,
+        values: buildQuickAddManualShoppingItemValues({
+          categoryId: catalogItem.defaultCategoryId,
+          name: catalogItem.displayName,
+          quantity:
+            requestedQuantity ||
+            catalogItem.defaultQuantity?.trim() ||
+            QUICK_ADD_DEFAULT_QUANTITY,
         }),
       };
     }
@@ -1952,6 +1986,25 @@ export async function resolveQuickAddManualShoppingItemValues({
         categoryId: otherCategoryId,
         name,
         quantity,
+      }),
+    };
+  }
+
+  const catalogItem = await getFamilyShoppingCatalogItemByNormalizedName({
+    familyId,
+    nameNormalized: normalizeIngredientCanonicalName(name),
+  });
+
+  if (catalogItem) {
+    return {
+      ok: true as const,
+      values: buildQuickAddManualShoppingItemValues({
+        categoryId: catalogItem.defaultCategoryId,
+        name: catalogItem.displayName,
+        quantity:
+          requestedQuantity ||
+          catalogItem.defaultQuantity?.trim() ||
+          QUICK_ADD_DEFAULT_QUANTITY,
       }),
     };
   }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -44,6 +44,7 @@ export default [
     ),
     route("families/:familyId/stores", "routes/family-stores.tsx"),
     route("families/:familyId/stock-ingredients", "routes/family-stock-ingredients.tsx"),
+    route("families/:familyId/shopping-catalog", "routes/family-shopping-catalog.tsx"),
     route("families/:familyId/freezer", "routes/family-freezer.tsx"),
     route("families/:familyId/recipes", "routes/family-recipes.tsx"),
     route("families/:familyId/recipes/:recipeId", "routes/family-recipe.tsx"),

--- a/app/routes/family-meal-plan-shopping-ingredient-search.test.ts
+++ b/app/routes/family-meal-plan-shopping-ingredient-search.test.ts
@@ -9,14 +9,21 @@ vi.mock("../lib/auth.server", async () => {
   };
 });
 
-vi.mock("../lib/stock.server", () => {
+vi.mock("../lib/family.server", () => {
   return {
-    searchCanonicalIngredients: vi.fn(),
+    requireFamilyMembership: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping-catalog.server", () => {
+  return {
+    searchShoppingQuickAddSuggestions: vi.fn(),
   };
 });
 
 import { requireUser } from "../lib/auth.server";
-import { searchCanonicalIngredients } from "../lib/stock.server";
+import { requireFamilyMembership } from "../lib/family.server";
+import { searchShoppingQuickAddSuggestions } from "../lib/shopping-catalog.server";
 import { loader } from "./family-meal-plan-shopping-ingredient-search";
 
 const mockUser = {
@@ -33,42 +40,83 @@ describe("family meal plan shopping ingredient search route", () => {
 
   it("returns an empty list for short queries", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "MEMBER",
+      userId: "user-1",
+    } as never);
 
     const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
       request: new Request(
         "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping/ingredient-search?q=m",
       ),
     });
 
-    expect(searchCanonicalIngredients).not.toHaveBeenCalled();
+    expect(searchShoppingQuickAddSuggestions).not.toHaveBeenCalled();
     expect(result).toEqual({
       ingredientSearchResults: [],
     });
   });
 
-  it("returns canonical ingredient matches for longer queries", async () => {
+  it("returns merged catalog and register matches for longer queries", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
-    vi.mocked(searchCanonicalIngredients).mockResolvedValue([
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "MEMBER",
+      userId: "user-1",
+    } as never);
+    vi.mocked(searchShoppingQuickAddSuggestions).mockResolvedValue([
+      {
+        canonicalName: "Tørkerull",
+        defaultCategoryId: "category-other",
+        defaultQuantity: "1 pk",
+        id: "catalog-1",
+        source: "catalog",
+      },
       {
         canonicalName: "Melk",
         defaultCategoryId: "category-dairy",
+        defaultQuantity: null,
         id: "ingredient-milk",
+        source: "register",
       },
     ]);
 
     const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
       request: new Request(
         "http://localhost/families/family-1/meal-plans/meal-plan-1/shopping/ingredient-search?q=melk",
       ),
     });
 
-    expect(searchCanonicalIngredients).toHaveBeenCalledWith("melk");
+    expect(requireFamilyMembership).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(searchShoppingQuickAddSuggestions).toHaveBeenCalledWith({
+      familyId: "family-1",
+      query: "melk",
+    });
     expect(result).toEqual({
       ingredientSearchResults: [
         {
+          canonicalName: "Tørkerull",
+          defaultCategoryId: "category-other",
+          defaultQuantity: "1 pk",
+          id: "catalog-1",
+          source: "catalog",
+        },
+        {
           canonicalName: "Melk",
           defaultCategoryId: "category-dairy",
+          defaultQuantity: null,
           id: "ingredient-milk",
+          source: "register",
         },
       ],
     });

--- a/app/routes/family-meal-plan-shopping-ingredient-search.ts
+++ b/app/routes/family-meal-plan-shopping-ingredient-search.ts
@@ -1,10 +1,25 @@
 import { requireUser } from "../lib/auth.server";
-import { searchCanonicalIngredients } from "../lib/stock.server";
+import { requireFamilyMembership } from "../lib/family.server";
+import { searchShoppingQuickAddSuggestions } from "../lib/shopping-catalog.server";
 
 const MIN_SEARCH_LENGTH = 2;
 
-export async function loader({ request }: { request: Request }) {
-  await requireUser(request);
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+
+  await requireFamilyMembership({
+    familyId,
+    userId: user.id,
+  });
 
   const searchQuery = new URL(request.url).searchParams.get("q")?.trim() ?? "";
 
@@ -15,6 +30,20 @@ export async function loader({ request }: { request: Request }) {
   }
 
   return {
-    ingredientSearchResults: await searchCanonicalIngredients(searchQuery),
+    ingredientSearchResults: await searchShoppingQuickAddSuggestions({
+      familyId,
+      query: searchQuery,
+    }),
   };
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
 }

--- a/app/routes/family-meal-plan-shopping.test.ts
+++ b/app/routes/family-meal-plan-shopping.test.ts
@@ -611,6 +611,7 @@ describe("family meal plan shopping route", () => {
     expect(createQuickManualShoppingItem).toHaveBeenCalledWith({
       familyId: "family-1",
       input: {
+        catalogItemId: "",
         ingredientId: "",
         name: "Tannkrem",
         quantity: "",

--- a/app/routes/family-meal-plan-shopping.tsx
+++ b/app/routes/family-meal-plan-shopping.tsx
@@ -1920,6 +1920,7 @@ function shouldAutoOpenShoppingItemDetails(
 
 function parseQuickAddManualShoppingItemInput(formData: FormData) {
   return {
+    catalogItemId: String(formData.get("catalogItemId") ?? ""),
     ingredientId: String(formData.get("ingredientId") ?? ""),
     name: String(formData.get("name") ?? ""),
     quantity: String(formData.get("quantity") ?? ""),

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -447,6 +447,7 @@ describe("family store mode route", () => {
       id: "meal-plan-1",
     });
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      catalogItemId: "",
       ingredientId: "ingredient-1",
       name: "Melk",
       quantity: "",
@@ -491,6 +492,7 @@ describe("family store mode route", () => {
     expect(createQuickFamilyShoppingItem).toHaveBeenCalledWith({
       familyId: "family-1",
       input: {
+        catalogItemId: "",
         ingredientId: "ingredient-1",
         name: "Melk",
         quantity: "",
@@ -531,6 +533,7 @@ describe("family store mode route", () => {
       id: "meal-plan-1",
     });
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      catalogItemId: "",
       ingredientId: "",
       name: "",
       quantity: "",

--- a/app/routes/family-shopping-catalog.test.ts
+++ b/app/routes/family-shopping-catalog.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping-catalog.server", () => {
+  return {
+    listFamilyShoppingCatalogItems: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping-catalog-write.server", () => {
+  return {
+    addFamilyShoppingCatalogItem: vi.fn(),
+    deleteFamilyShoppingCatalogItem: vi.fn(),
+    updateFamilyShoppingCatalogItem: vi.fn(),
+  };
+});
+
+vi.mock("../lib/store.server", () => {
+  return {
+    listIngredientCategories: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { listFamilyShoppingCatalogItems } from "../lib/shopping-catalog.server";
+import {
+  addFamilyShoppingCatalogItem,
+  deleteFamilyShoppingCatalogItem,
+  updateFamilyShoppingCatalogItem,
+} from "../lib/shopping-catalog-write.server";
+import { listIngredientCategories } from "../lib/store.server";
+import { action, loader } from "./family-shopping-catalog";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildRequest(
+  url = "http://localhost/families/family-1/shopping-catalog",
+  formData?: FormData,
+) {
+  return new Request(url, {
+    body: formData,
+    method: formData ? "POST" : "GET",
+  });
+}
+
+describe("family shopping catalog route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads family catalog items and categories", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(listFamilyShoppingCatalogItems).mockResolvedValue({
+      catalogItems: [
+        {
+          defaultCategory: {
+            displayName: "Annet",
+            id: "category-other",
+          },
+          defaultCategoryId: "category-other",
+          defaultQuantity: "1 pk",
+          displayName: "Tørkerull",
+          id: "catalog-1",
+          lastUsedAt: new Date("2026-08-18T00:00:00.000Z"),
+          nameNormalized: "tørkerull",
+        },
+      ],
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      userRole: "MEMBER",
+    });
+    vi.mocked(listIngredientCategories).mockResolvedValue([
+      { displayName: "Annet", id: "category-other" },
+    ]);
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(),
+    });
+
+    expect(result.catalogItems).toHaveLength(1);
+    expect(result.categories).toHaveLength(1);
+    expect(result.userRole).toBe("MEMBER");
+  });
+
+  it("adds a catalog item", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(addFamilyShoppingCatalogItem).mockResolvedValue({
+      catalogItemId: "catalog-1",
+      status: "CREATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "add-catalog-item");
+    formData.set("name", "Tørkerull");
+    formData.set("quantity", "1 pk");
+    formData.set("categoryId", "category-other");
+
+    const response = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/shopping-catalog",
+        formData,
+      ),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+    expect(addFamilyShoppingCatalogItem).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-other",
+        name: "Tørkerull",
+        quantity: "1 pk",
+      },
+    });
+  });
+
+  it("updates a catalog item", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(updateFamilyShoppingCatalogItem).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-catalog-item");
+    formData.set("catalogItemId", "catalog-1");
+    formData.set("name", "Tørkerull XL");
+    formData.set("quantity", "2 pk");
+    formData.set("categoryId", "category-other");
+
+    const response = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/shopping-catalog",
+        formData,
+      ),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect(updateFamilyShoppingCatalogItem).toHaveBeenCalledWith({
+      catalogItemId: "catalog-1",
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        categoryId: "category-other",
+        name: "Tørkerull XL",
+        quantity: "2 pk",
+      },
+    });
+  });
+
+  it("removes a catalog item", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(deleteFamilyShoppingCatalogItem).mockResolvedValue({
+      status: "DELETED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "remove-catalog-item");
+    formData.set("catalogItemId", "catalog-1");
+
+    const response = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(
+        "http://localhost/families/family-1/shopping-catalog",
+        formData,
+      ),
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+    expect(deleteFamilyShoppingCatalogItem).toHaveBeenCalledWith({
+      catalogItemId: "catalog-1",
+      familyId: "family-1",
+      userId: "user-1",
+    });
+  });
+});

--- a/app/routes/family-shopping-catalog.tsx
+++ b/app/routes/family-shopping-catalog.tsx
@@ -1,0 +1,653 @@
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import { listFamilyShoppingCatalogItems } from "../lib/shopping-catalog.server";
+import {
+  addFamilyShoppingCatalogItem,
+  deleteFamilyShoppingCatalogItem,
+  updateFamilyShoppingCatalogItem,
+  type FamilyShoppingCatalogItemFieldErrors,
+  type FamilyShoppingCatalogItemValues,
+} from "../lib/shopping-catalog-write.server";
+import { listIngredientCategories } from "../lib/store.server";
+
+type CatalogNotice =
+  | "catalog-item-added"
+  | "catalog-item-removed"
+  | "catalog-item-updated";
+
+type CatalogIntent =
+  | "add-catalog-item"
+  | "remove-catalog-item"
+  | "update-catalog-item";
+
+interface CatalogActionData {
+  addFieldErrors?: FamilyShoppingCatalogItemFieldErrors;
+  addValues?: FamilyShoppingCatalogItemValues;
+  formError?: string;
+  intent?: CatalogIntent;
+  targetCatalogItemId?: string;
+  updateFieldErrors?: FamilyShoppingCatalogItemFieldErrors;
+  updateValues?: FamilyShoppingCatalogItemValues;
+}
+
+interface FamilyShoppingCatalogRouteProps {
+  actionData?: CatalogActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Handlevarer | Mealplanner" },
+    {
+      name: "description",
+      content:
+        "Administrer familiens gjenbrukbare varenavn for hurtig utfylling i handlelisten.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const [result, categories] = await Promise.all([
+    listFamilyShoppingCatalogItems({
+      familyId,
+      userId: user.id,
+    }),
+    listIngredientCategories(),
+  ]);
+
+  return {
+    catalogItems: result.catalogItems,
+    categories,
+    family: result.family,
+    notice: getCatalogNotice(request),
+    userRole: result.userRole,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "");
+
+  if (intent === "add-catalog-item") {
+    const result = await addFamilyShoppingCatalogItem({
+      familyId,
+      userId: user.id,
+      values: parseCatalogItemValues(formData),
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        addFieldErrors: result.fieldErrors,
+        addValues: result.values,
+        intent,
+      } satisfies CatalogActionData;
+    }
+
+    return buildCatalogRedirect({
+      familyId,
+      notice: "catalog-item-added",
+      request,
+    });
+  }
+
+  if (intent === "update-catalog-item") {
+    const catalogItemId = String(formData.get("catalogItemId") ?? "").trim();
+
+    if (!catalogItemId) {
+      return {
+        formError: "Fant ikke varen som skulle oppdateres.",
+        intent,
+      } satisfies CatalogActionData;
+    }
+
+    const result = await updateFamilyShoppingCatalogItem({
+      catalogItemId,
+      familyId,
+      userId: user.id,
+      values: parseCatalogItemValues(formData),
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke varen som skulle oppdateres.",
+        intent,
+        targetCatalogItemId: catalogItemId,
+      } satisfies CatalogActionData;
+    }
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        intent,
+        targetCatalogItemId: catalogItemId,
+        updateFieldErrors: result.fieldErrors,
+        updateValues: result.values,
+      } satisfies CatalogActionData;
+    }
+
+    return buildCatalogRedirect({
+      familyId,
+      notice: "catalog-item-updated",
+      request,
+    });
+  }
+
+  if (intent === "remove-catalog-item") {
+    const catalogItemId = String(formData.get("catalogItemId") ?? "").trim();
+
+    if (!catalogItemId) {
+      return {
+        formError: "Fant ikke varen som skulle fjernes.",
+        intent,
+      } satisfies CatalogActionData;
+    }
+
+    const result = await deleteFamilyShoppingCatalogItem({
+      catalogItemId,
+      familyId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      return {
+        formError: "Fant ikke varen som skulle fjernes.",
+        intent,
+        targetCatalogItemId: catalogItemId,
+      } satisfies CatalogActionData;
+    }
+
+    return buildCatalogRedirect({
+      familyId,
+      notice: "catalog-item-removed",
+      request,
+    });
+  }
+
+  return {
+    formError: "Ukjent handling.",
+  } satisfies CatalogActionData;
+}
+
+export default function FamilyShoppingCatalogRoute({
+  actionData,
+  loaderData,
+}: FamilyShoppingCatalogRouteProps) {
+  const navigation = useNavigation();
+  const noticeContent = loaderData.notice
+    ? getCatalogNoticeContent(loaderData.notice)
+    : null;
+  const pendingIntent = navigation.formData?.get("intent");
+  const addValues =
+    actionData?.intent === "add-catalog-item" && actionData.addValues
+      ? actionData.addValues
+      : {
+          categoryId: "",
+          name: "",
+          quantity: "",
+        };
+  const pendingCatalogItemId = String(
+    navigation.formData?.get("catalogItemId") ?? "",
+  );
+  const isPendingCatalog =
+    navigation.state !== "idle" && navigation.formData != null;
+  const displayCatalogItems = (() => {
+    if (!isPendingCatalog || !navigation.formData) {
+      return loaderData.catalogItems;
+    }
+
+    if (pendingIntent === "remove-catalog-item" && pendingCatalogItemId) {
+      return loaderData.catalogItems.filter(
+        (item) => item.id !== pendingCatalogItemId,
+      );
+    }
+
+    if (pendingIntent === "update-catalog-item" && pendingCatalogItemId) {
+      const name = String(navigation.formData.get("name") ?? "").trim();
+      const categoryId = String(
+        navigation.formData.get("categoryId") ?? "",
+      ).trim();
+      const quantity = String(navigation.formData.get("quantity") ?? "").trim();
+      const category =
+        loaderData.categories.find((entry) => entry.id === categoryId) ?? null;
+
+      return loaderData.catalogItems.map((item) =>
+        item.id === pendingCatalogItemId
+          ? {
+              ...item,
+              defaultCategory: category ?? item.defaultCategory,
+              defaultCategoryId: categoryId || item.defaultCategoryId,
+              defaultQuantity: quantity || null,
+              displayName: name || item.displayName,
+            }
+          : item,
+      );
+    }
+
+    if (pendingIntent === "add-catalog-item") {
+      const name = String(navigation.formData.get("name") ?? "").trim();
+
+      if (!name) {
+        return loaderData.catalogItems;
+      }
+
+      const categoryId = String(
+        navigation.formData.get("categoryId") ?? "",
+      ).trim();
+      const quantity = String(navigation.formData.get("quantity") ?? "").trim();
+      const category =
+        loaderData.categories.find((entry) => entry.id === categoryId) ?? {
+          displayName: "",
+          id: categoryId,
+        };
+
+      return [
+        {
+          defaultCategory: category,
+          defaultCategoryId: categoryId,
+          defaultQuantity: quantity || null,
+          displayName: name,
+          id: "optimistic:pending-add",
+          lastUsedAt: new Date(),
+          nameNormalized: name.toLowerCase(),
+        },
+        ...loaderData.catalogItems,
+      ];
+    }
+
+    return loaderData.catalogItems;
+  })();
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <section className="rounded-[32px] bg-slate-950 px-6 py-8 text-white shadow-xl sm:px-8">
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div>
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-emerald-200">
+                Handlevarer
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight">
+                {loaderData.family.name}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+                Gjenbrukbare varenavn som ikke kommer fra oppskrifter, for
+                eksempel husholdningsvarer. Når dere legger til et nytt navn i
+                handlelisten, lagres det her så det kan søkes opp neste uke.
+                Dette er ikke det samme som basisvarer, som holdes utenfor
+                handlelisten fordi dere vanligvis har dem hjemme.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                className="rounded-2xl bg-emerald-500 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-600"
+                to={`/families/${loaderData.family.id}/store-mode`}
+              >
+                Åpne handleliste
+              </Link>
+              <Link
+                className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                to={`/families/${loaderData.family.id}/stock-ingredients`}
+              >
+                Basisvarer
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {noticeContent ? (
+          <section className="rounded-[28px] border border-emerald-200 bg-emerald-50 px-6 py-5 text-emerald-950 shadow-sm">
+            <h2 className="text-base font-semibold">{noticeContent.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {noticeContent.description}
+            </p>
+          </section>
+        ) : null}
+
+        {actionData?.formError ? (
+          <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-5 text-rose-900 shadow-sm">
+            <h2 className="text-base font-semibold">
+              Kunne ikke oppdatere handlevarene
+            </h2>
+            <p className="mt-2 text-sm leading-6">{actionData.formError}</p>
+          </section>
+        ) : null}
+
+        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <div className="flex flex-col gap-2">
+            <h2 className="text-lg font-semibold text-slate-950">
+              Legg til handlevare
+            </h2>
+            <p className="text-sm leading-6 text-slate-600">
+              Gi varen et navn, en standardmengde og en kategori. Den dukker opp
+              når dere skriver i hurtigfeltet på handlelisten.
+            </p>
+          </div>
+
+          <Form className="mt-6 grid gap-4 sm:grid-cols-2" method="post">
+            <input name="intent" type="hidden" value="add-catalog-item" />
+            <label className="block text-sm font-medium text-slate-700 sm:col-span-2">
+              Navn
+              <input
+                className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={addValues.name}
+                name="name"
+                placeholder="For eksempel tørkerull"
+                type="text"
+              />
+            </label>
+            {actionData?.addFieldErrors?.name ? (
+              <p className="text-sm text-rose-600 sm:col-span-2">
+                {actionData.addFieldErrors.name}
+              </p>
+            ) : null}
+            <label className="block text-sm font-medium text-slate-700">
+              Standardmengde
+              <input
+                className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={addValues.quantity}
+                name="quantity"
+                placeholder="For eksempel 1 pk"
+                type="text"
+              />
+            </label>
+            <label className="block text-sm font-medium text-slate-700">
+              Kategori
+              <select
+                className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                defaultValue={addValues.categoryId}
+                name="categoryId"
+              >
+                <option value="">Velg kategori</option>
+                {loaderData.categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.displayName}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {actionData?.addFieldErrors?.categoryId ? (
+              <p className="text-sm text-rose-600 sm:col-span-2">
+                {actionData.addFieldErrors.categoryId}
+              </p>
+            ) : null}
+            <button
+              className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400 sm:col-span-2"
+              disabled={
+                navigation.state !== "idle" &&
+                pendingIntent === "add-catalog-item"
+              }
+              type="submit"
+            >
+              {navigation.state !== "idle" &&
+              pendingIntent === "add-catalog-item"
+                ? "Legger til..."
+                : "Legg til handlevare"}
+            </button>
+          </Form>
+        </section>
+
+        <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <div className="flex flex-col gap-2">
+            <h2 className="text-lg font-semibold text-slate-950">
+              Familiens handlevarer
+            </h2>
+            <p className="text-sm leading-6 text-slate-600">
+              {displayCatalogItems.length === 0
+                ? "Ingen handlevarer er registrert ennå. De opprettes også automatisk når dere skriver inn et nytt navn i handlelisten."
+                : `${displayCatalogItems.length} handlevarer er registrert.`}
+            </p>
+          </div>
+
+          {displayCatalogItems.length > 0 ? (
+            <ul className="mt-6 grid gap-4">
+              {displayCatalogItems.map((item) => {
+                const isUpdating =
+                  navigation.state !== "idle" &&
+                  pendingIntent === "update-catalog-item" &&
+                  pendingCatalogItemId === item.id;
+                const isRemoving =
+                  navigation.state !== "idle" &&
+                  pendingIntent === "remove-catalog-item" &&
+                  pendingCatalogItemId === item.id;
+                const updateValues =
+                  actionData?.intent === "update-catalog-item" &&
+                  actionData.targetCatalogItemId === item.id &&
+                  actionData.updateValues
+                    ? actionData.updateValues
+                    : {
+                        categoryId: item.defaultCategoryId,
+                        name: item.displayName,
+                        quantity: item.defaultQuantity ?? "",
+                      };
+                const updateFieldErrors =
+                  actionData?.intent === "update-catalog-item" &&
+                  actionData.targetCatalogItemId === item.id
+                    ? actionData.updateFieldErrors
+                    : undefined;
+
+                return (
+                  <li
+                    key={item.id}
+                    className="rounded-[24px] border border-slate-200 bg-slate-50 p-5"
+                  >
+                    <Form className="grid gap-4" method="post">
+                      <input
+                        name="intent"
+                        type="hidden"
+                        value="update-catalog-item"
+                      />
+                      <input
+                        name="catalogItemId"
+                        type="hidden"
+                        value={item.id}
+                      />
+                      <label className="block text-sm font-medium text-slate-700">
+                        Navn
+                        <input
+                          className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                          defaultValue={updateValues.name}
+                          name="name"
+                          type="text"
+                        />
+                      </label>
+                      {updateFieldErrors?.name ? (
+                        <p className="text-sm text-rose-600">
+                          {updateFieldErrors.name}
+                        </p>
+                      ) : null}
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <label className="block text-sm font-medium text-slate-700">
+                          Standardmengde
+                          <input
+                            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                            defaultValue={updateValues.quantity}
+                            name="quantity"
+                            type="text"
+                          />
+                        </label>
+                        <label className="block text-sm font-medium text-slate-700">
+                          Kategori
+                          <select
+                            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+                            defaultValue={updateValues.categoryId}
+                            name="categoryId"
+                          >
+                            <option value="">Velg kategori</option>
+                            {loaderData.categories.map((category) => (
+                              <option key={category.id} value={category.id}>
+                                {category.displayName}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      </div>
+                      {updateFieldErrors?.categoryId ? (
+                        <p className="text-sm text-rose-600">
+                          {updateFieldErrors.categoryId}
+                        </p>
+                      ) : null}
+                      <div className="flex flex-wrap gap-3">
+                        <button
+                          className="rounded-2xl bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                          disabled={isUpdating || isRemoving}
+                          type="submit"
+                        >
+                          {isUpdating ? "Lagrer..." : "Lagre endringer"}
+                        </button>
+                      </div>
+                    </Form>
+                    <Form className="mt-3" method="post">
+                      <input
+                        name="intent"
+                        type="hidden"
+                        value="remove-catalog-item"
+                      />
+                      <input
+                        name="catalogItemId"
+                        type="hidden"
+                        value={item.id}
+                      />
+                      <button
+                        className="rounded-xl border border-rose-200 px-4 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={isUpdating || isRemoving}
+                        type="submit"
+                      >
+                        {isRemoving ? "Fjerner..." : "Fjern"}
+                      </button>
+                    </Form>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  if (isRouteErrorResponse(error)) {
+    return (
+      <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+        <div className="mx-auto max-w-3xl rounded-[28px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+          <h1 className="text-2xl font-semibold text-slate-950">
+            {error.status} {error.statusText}
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            {typeof error.data === "string"
+              ? error.data
+              : "Noe gikk galt under lasting av handlevarene."}
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-100 px-4 py-12 text-slate-900">
+      <div className="mx-auto max-w-3xl rounded-[28px] bg-white p-8 shadow-sm ring-1 ring-slate-200">
+        <h1 className="text-2xl font-semibold text-slate-950">Uventet feil</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          Noe gikk galt under lasting av handlevarene.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
+}
+
+function parseCatalogItemValues(
+  formData: FormData,
+): FamilyShoppingCatalogItemValues {
+  return {
+    categoryId: String(formData.get("categoryId") ?? ""),
+    name: String(formData.get("name") ?? ""),
+    quantity: String(formData.get("quantity") ?? ""),
+  };
+}
+
+function getCatalogNotice(request: Request): CatalogNotice | null {
+  const notice = new URL(request.url).searchParams.get("notice");
+
+  if (
+    notice === "catalog-item-added" ||
+    notice === "catalog-item-updated" ||
+    notice === "catalog-item-removed"
+  ) {
+    return notice;
+  }
+
+  return null;
+}
+
+function getCatalogNoticeContent(notice: CatalogNotice) {
+  switch (notice) {
+    case "catalog-item-added":
+      return {
+        description: "Handlevaren ble lagt til.",
+        title: "Lagret",
+      };
+    case "catalog-item-updated":
+      return {
+        description: "Handlevaren ble oppdatert.",
+        title: "Oppdatert",
+      };
+    case "catalog-item-removed":
+      return {
+        description: "Handlevaren ble fjernet.",
+        title: "Fjernet",
+      };
+  }
+}
+
+function buildCatalogRedirect({
+  familyId,
+  notice,
+  request,
+}: {
+  familyId: string;
+  notice: CatalogNotice;
+  request: Request;
+}) {
+  const url = new URL(`/families/${familyId}/shopping-catalog`, request.url);
+  url.searchParams.set("notice", notice);
+
+  return Response.redirect(url, 302);
+}

--- a/app/routes/family-shopping-ingredient-search.test.ts
+++ b/app/routes/family-shopping-ingredient-search.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/family.server", () => {
+  return {
+    requireFamilyMembership: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping-catalog.server", () => {
+  return {
+    searchShoppingQuickAddSuggestions: vi.fn(),
+  };
+});
+
+import { requireUser } from "../lib/auth.server";
+import { requireFamilyMembership } from "../lib/family.server";
+import { searchShoppingQuickAddSuggestions } from "../lib/shopping-catalog.server";
+import { loader } from "./family-shopping-ingredient-search";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+describe("family shopping ingredient search route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires family membership and returns merged suggestions", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(requireFamilyMembership).mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "MEMBER",
+      userId: "user-1",
+    } as never);
+    vi.mocked(searchShoppingQuickAddSuggestions).mockResolvedValue([
+      {
+        canonicalName: "Tørkerull",
+        defaultCategoryId: "category-other",
+        defaultQuantity: "1 pk",
+        id: "catalog-1",
+        source: "catalog",
+      },
+    ]);
+
+    const result = await loader({
+      params: {
+        familyId: "family-1",
+      },
+      request: new Request(
+        "http://localhost/families/family-1/shopping/ingredient-search?q=tørk",
+      ),
+    });
+
+    expect(requireFamilyMembership).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(searchShoppingQuickAddSuggestions).toHaveBeenCalledWith({
+      familyId: "family-1",
+      query: "tørk",
+    });
+    expect(result.ingredientSearchResults).toHaveLength(1);
+  });
+});

--- a/app/routes/family-shopping-ingredient-search.ts
+++ b/app/routes/family-shopping-ingredient-search.ts
@@ -1,10 +1,25 @@
 import { requireUser } from "../lib/auth.server";
-import { searchCanonicalIngredients } from "../lib/stock.server";
+import { requireFamilyMembership } from "../lib/family.server";
+import { searchShoppingQuickAddSuggestions } from "../lib/shopping-catalog.server";
 
 const MIN_SEARCH_LENGTH = 2;
 
-export async function loader({ request }: { request: Request }) {
-  await requireUser(request);
+export async function loader({
+  params,
+  request,
+}: {
+  params: {
+    familyId?: string;
+  };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireFamilyId(params.familyId);
+
+  await requireFamilyMembership({
+    familyId,
+    userId: user.id,
+  });
 
   const searchQuery = new URL(request.url).searchParams.get("q")?.trim() ?? "";
 
@@ -15,6 +30,20 @@ export async function loader({ request }: { request: Request }) {
   }
 
   return {
-    ingredientSearchResults: await searchCanonicalIngredients(searchQuery),
+    ingredientSearchResults: await searchShoppingQuickAddSuggestions({
+      familyId,
+      query: searchQuery,
+    }),
   };
+}
+
+function requireFamilyId(familyId: string | undefined) {
+  if (!familyId) {
+    throw new Response("Fant ikke familien.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return familyId;
 }

--- a/app/routes/family-shopping.test.ts
+++ b/app/routes/family-shopping.test.ts
@@ -164,6 +164,7 @@ describe("family shopping route", () => {
   it("returns quick-add success data without redirecting", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      catalogItemId: "",
       ingredientId: "ingredient-1",
       name: "Melk",
       quantity: "",
@@ -209,6 +210,7 @@ describe("family shopping route", () => {
     expect(createQuickFamilyShoppingItem).toHaveBeenCalledWith({
       familyId: "family-1",
       input: {
+        catalogItemId: "",
         ingredientId: "ingredient-1",
         name: "Melk",
         quantity: "",
@@ -246,6 +248,7 @@ describe("family shopping route", () => {
   it("returns quick-add validation errors without redirecting", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(parseQuickAddFamilyShoppingItemInput).mockReturnValue({
+      catalogItemId: "",
       ingredientId: "",
       name: "",
       quantity: "",

--- a/prisma/migrations/20260818140000_add_family_shopping_catalog_item/migration.sql
+++ b/prisma/migrations/20260818140000_add_family_shopping_catalog_item/migration.sql
@@ -1,0 +1,91 @@
+-- CreateTable
+CREATE TABLE "FamilyShoppingCatalogItem" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "nameNormalized" TEXT NOT NULL,
+    "defaultQuantity" TEXT,
+    "defaultCategoryId" TEXT NOT NULL,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FamilyShoppingCatalogItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FamilyShoppingCatalogItem_familyId_idx" ON "FamilyShoppingCatalogItem"("familyId");
+
+-- CreateIndex
+CREATE INDEX "FamilyShoppingCatalogItem_defaultCategoryId_idx" ON "FamilyShoppingCatalogItem"("defaultCategoryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FamilyShoppingCatalogItem_familyId_nameNormalized_key" ON "FamilyShoppingCatalogItem"("familyId", "nameNormalized");
+
+-- AddForeignKey
+ALTER TABLE "FamilyShoppingCatalogItem" ADD CONSTRAINT "FamilyShoppingCatalogItem_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FamilyShoppingCatalogItem" ADD CONSTRAINT "FamilyShoppingCatalogItem_defaultCategoryId_fkey" FOREIGN KEY ("defaultCategoryId") REFERENCES "IngredientCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Backfill distinct historical custom names (latest updatedAt wins).
+INSERT INTO "FamilyShoppingCatalogItem" (
+    "id",
+    "familyId",
+    "displayName",
+    "nameNormalized",
+    "defaultQuantity",
+    "defaultCategoryId",
+    "lastUsedAt",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    gen_random_uuid()::text,
+    source."familyId",
+    source."displayName",
+    source."nameNormalized",
+    source."defaultQuantity",
+    source."defaultCategoryId",
+    source."lastUsedAt",
+    source."lastUsedAt",
+    source."lastUsedAt"
+FROM (
+    SELECT DISTINCT ON ("familyId", "nameNormalized")
+        "familyId",
+        "displayName",
+        "nameNormalized",
+        "defaultQuantity",
+        "defaultCategoryId",
+        "lastUsedAt"
+    FROM (
+        SELECT
+            "MealPlan"."familyId" AS "familyId",
+            TRIM("ManualShoppingItem"."name") AS "displayName",
+            LOWER(TRIM("ManualShoppingItem"."name")) AS "nameNormalized",
+            NULLIF(TRIM("ManualShoppingItem"."quantity"), '') AS "defaultQuantity",
+            "ManualShoppingItem"."categoryId" AS "defaultCategoryId",
+            "ManualShoppingItem"."updatedAt" AS "lastUsedAt"
+        FROM "ManualShoppingItem"
+        INNER JOIN "MealPlan" ON "MealPlan"."id" = "ManualShoppingItem"."mealPlanId"
+        WHERE TRIM("ManualShoppingItem"."name") <> ''
+
+        UNION ALL
+
+        SELECT
+            "FamilyShoppingItem"."familyId" AS "familyId",
+            TRIM("FamilyShoppingItem"."name") AS "displayName",
+            LOWER(TRIM("FamilyShoppingItem"."name")) AS "nameNormalized",
+            NULLIF(TRIM("FamilyShoppingItem"."quantity"), '') AS "defaultQuantity",
+            "FamilyShoppingItem"."categoryId" AS "defaultCategoryId",
+            "FamilyShoppingItem"."updatedAt" AS "lastUsedAt"
+        FROM "FamilyShoppingItem"
+        WHERE TRIM("FamilyShoppingItem"."name") <> ''
+    ) AS combined
+    ORDER BY "familyId", "nameNormalized", "lastUsedAt" DESC
+) AS source
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM "Ingredient"
+    WHERE LOWER("Ingredient"."canonicalName") = source."nameNormalized"
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,7 @@ model Family {
   stockIngredients           FamilyStockIngredient[]
   freezerItems               FamilyFreezerItem[]
   shoppingItems       FamilyShoppingItem[]
+  shoppingCatalogItems FamilyShoppingCatalogItem[]
   shoppingItemCheckEvents ShoppingItemCheckEvent[]
 
   @@index([createdByUserId])
@@ -139,6 +140,7 @@ model IngredientCategory {
   recipeIngredients   RecipeIngredient[]
   manualShoppingItems ManualShoppingItem[]
   familyShoppingItems FamilyShoppingItem[]
+  shoppingCatalogItems FamilyShoppingCatalogItem[]
   storeSections       StoreSection[]
 
   @@index([displayName])
@@ -404,6 +406,24 @@ model FamilyShoppingItem {
   @@index([updatedByUserId])
   @@index([categoryId])
   @@index([preferredStoreId])
+}
+
+model FamilyShoppingCatalogItem {
+  id                String   @id @default(cuid())
+  familyId          String
+  displayName       String
+  nameNormalized    String
+  defaultQuantity   String?
+  defaultCategoryId String
+  lastUsedAt        DateTime @default(now())
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+  family            Family             @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  defaultCategory   IngredientCategory @relation(fields: [defaultCategoryId], references: [id], onDelete: Restrict)
+
+  @@unique([familyId, nameNormalized])
+  @@index([familyId])
+  @@index([defaultCategoryId])
 }
 
 model ShoppingItemOverride {


### PR DESCRIPTION
## Summary
- Store custom quick-add names in a family-scoped catalog so they remain searchable on later meal-plan shopping lists.
- Apply catalog defaults (name, quantity, category) when selecting or typing a known familievare; register ingredients stay separate.
- Add Handlevarer admin to rename items, set default amounts/categories, and delete catalog entries without touching historical list lines.

## Related issue
Closes #189

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] Apply the Prisma migration, then add a custom name via quick-add
- [ ] Open a new week's shopping list, type the name, and confirm it appears as a Familievare with the default quantity
- [ ] Rename the item and change default quantity in Handlevarer, then confirm typeahead uses the new values
- [ ] Confirm deleting a catalog item does not remove old shopping-list lines
- [ ] Confirm picking a register ingredient does not create a catalog row

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (421 tests)
- npm run typecheck