### PR TITLE
Auto-merge PRs when all validation checks pass

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,63 @@
+name: Auto-merge PR
+
+on:
+  workflow_run:
+    workflows: ["Pull Request Validation"]
+    types:
+      - completed
+
+jobs:
+  auto-merge:
+    name: Auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Merge associated pull requests
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequests = context.payload.workflow_run.pull_requests;
+            if (!pullRequests || pullRequests.length === 0) {
+              core.info('No pull requests associated with this workflow run.');
+              return;
+            }
+
+            for (const pr of pullRequests) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+
+              if (pull.state !== 'open') {
+                core.info(`PR #${pr.number} is not open (${pull.state}), skipping.`);
+                continue;
+              }
+              if (pull.draft) {
+                core.info(`PR #${pr.number} is a draft, skipping.`);
+                continue;
+              }
+              if (pull.base.ref !== 'main') {
+                core.info(`PR #${pr.number} targets ${pull.base.ref}, not main. Skipping.`);
+                continue;
+              }
+              if (pull.head.repo.fork) {
+                core.info(`PR #${pr.number} is from a fork, skipping.`);
+                continue;
+              }
+
+              try {
+                await github.rest.pulls.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  merge_method: 'squash',
+                });
+                core.info(`PR #${pr.number} merged successfully.`);
+              } catch (error) {
+                core.setFailed(`Failed to merge PR #${pr.number}: ${error.message}`);
+              }
+            }

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,26 +2,18 @@
 
 ## Current Objective
 
-Allow families to create custom store sections by introducing family-owned ingredient categories (issue #194).
+Auto-merge PRs when all validation checks pass (issue #197).
 
 ## Completed
 
-- Added optional `familyId` to `IngredientCategory` model with migration
-- `listIngredientCategories()` now returns global + family-scoped categories
-- Added `createFamilyCategory` and `deleteFamilyCategory` server functions
-- Relaxed store validation to allow partial section sets (no longer requires all categories)
-- `updateFamilyStore` handles adding new sections and removing old ones in a single transaction
-- Added `create-category` and `delete-category` intents to the stores route
-- Store editor card supports adding sections from a dropdown and removing them per row
-- Category management UI with inline create and delete on the stores page
-- Fixed 6 test files to include `familyId` in category mock objects
+- Added `.github/workflows/auto-merge.yml` triggered by `workflow_run` completion of `Pull Request Validation`
+- Workflow uses `actions/github-script` to squash-merge eligible PRs via the GitHub API
+- Skips draft PRs, fork PRs, closed PRs, and PRs not targeting `main`
 
 ## Files To Read First
 
-- `prisma/schema.prisma` - `IngredientCategory` now has optional `familyId`
-- `app/lib/store-write.server.ts` - New category CRUD and relaxed store validation
-- `app/routes/family-stores.tsx` - New intents and category management UI
-- `app/components/family-store-editor-card.tsx` - Add/remove section controls
+- `.github/workflows/auto-merge.yml` — the new auto-merge workflow
+- `.github/workflows/pr-validation.yml` — the existing validation workflow it depends on
 
 ## Validation
 
@@ -32,10 +24,9 @@ Allow families to create custom store sections by introducing family-owned ingre
 
 ## Open Items
 
-- No tests added for the new `createFamilyCategory` / `deleteFamilyCategory` functions
-- Delete guard only checks `RecipeIngredient` usage; `ManualShoppingItem` and `FamilyShoppingItem` also reference categories
-- The `key` field on family-owned categories uses a generated slug — uniqueness is probabilistic (randomBytes)
+- Repository settings must have "Allow auto-merge" enabled (Settings → General → Pull Requests) — this is a manual admin step
+- Branch protection on `main` should require the `Validate` status check for full safety
 
 ## Next Step
 
-Add unit tests for `createFamilyCategory` and `deleteFamilyCategory` in `store-write.server.test.ts`.
+Enable auto-merge in repository settings and configure branch protection rules.


### PR DESCRIPTION
## Summary
- Adds a new `auto-merge.yml` workflow that listens for successful completion of the `Pull Request Validation` workflow
- Automatically squash-merges eligible PRs (same-repo, non-draft, targeting main) via `actions/github-script`

## Related issue
Closes #197

## Test plan
- [ ] Validation ran locally: prisma:generate, lint, test:run, typecheck
- [ ] Open a test PR and confirm it auto-merges after checks pass
- [ ] Verify draft PRs are skipped

## Validation
- `npm run prisma:generate` — passed
- `npm run lint` — passed
- `npm run test:run` — 442 tests passed
- `npm run typecheck` — passed

## Note
Repository settings must have "Allow auto-merge" enabled and branch protection should require the `Validate` check for full safety.