### PR TITLE
Deploy to Fly after auto-merge

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_run:
+    # Auto-merge uses GITHUB_TOKEN; that merge does not fire push workflows.
+    workflows: ["Auto-merge PR"]
+    types:
+      - completed
+    branches:
+      - main
 
 concurrency:
   group: fly-deploy-mealplanner-xzvzow
@@ -13,6 +20,7 @@ concurrency:
 jobs:
   validate:
     name: Validate
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,7 +61,13 @@ jobs:
   deploy:
     name: Deploy
     needs: validate
-    if: github.ref == 'refs/heads/main'
+    if: |
+      always() &&
+      needs.validate.result == 'success' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.ref == 'refs/heads/main'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -110,6 +110,7 @@ Routine production releases use [`.github/workflows/fly-deploy.yml`](../.github/
 | Trigger | When it runs |
 | ------- | ------------- |
 | Push to `main` | Automatically after validation passes |
+| `workflow_run` (`Auto-merge PR` completed) | After auto-merge squash-merges a PR — needed because GITHUB_TOKEN merges do not fire `push` |
 | `workflow_dispatch` | Manually from **Actions → Deploy to Fly.io → Run workflow** (must run on the `main` branch) |
 
 Pull request branches do not trigger this workflow.


### PR DESCRIPTION
## Summary
- Auto-merge squash merges via `GITHUB_TOKEN` do not trigger `push` workflows, so PR #202 merged without deploying.
- Add `workflow_run` on **Auto-merge PR** completion to run the existing Fly deploy pipeline.
- Document the extra trigger in `docs/deploy-fly.md`.

## Related issue
Follow-up to #201 / auto-merge (#197).

## Test plan
- [x] Manually triggered `fly-deploy.yml` on `main` after #202 merge — deploy succeeded
- [ ] After this merges, next auto-merged PR should run Fly deploy without manual dispatch

## Validation
- Workflow YAML only (no app code changes)