### PR TITLE
Fix iOS zoom on recipe search inputs

### DIFF
--- a/.cursor/rules/frontend-standards.mdc
+++ b/.cursor/rules/frontend-standards.mdc
@@ -17,7 +17,7 @@ alwaysApply: true
 - In Tailwind, prefer readable utility composition and shared patterns over long repeated class strings.
 - Match existing project conventions and keep changes minimal.
 - Client form submissions must update visible data immediately (optimistic). Pending-only `"Lagrer..."` is not enough; follow `.cursor/rules/optimistic-form-updates.mdc`.
-- Use text-base as font size for any text inputs to prevent auto-zoom in iOS devices
+- Text inputs (`input`, `textarea`, searchable fields) must use `text-base` (16px) or larger — never `text-sm`/`text-xs` — to prevent iOS Safari focus zoom. See `.cursor/rules/ios-input-font-size.mdc`.
 
 ```tsx
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/.cursor/rules/ios-input-font-size.mdc
+++ b/.cursor/rules/ios-input-font-size.mdc
@@ -1,0 +1,29 @@
+---
+description: Keep text inputs at least 16px to prevent iOS Safari auto-zoom on focus
+alwaysApply: true
+---
+
+# iOS Input Font Size
+
+iOS Safari automatically zooms the viewport when focusing a text field whose computed font size is under **16px**.
+
+## Required
+
+- Any focusable text control must use **`text-base` (16px)** or larger in Tailwind: `input`, `textarea`, `select` (when typed into), and `contenteditable`.
+- Prefer `text-base` over `text-sm` / `text-xs` on those controls.
+- Do not use `text-sm` on search boxes, quantity fields, notes, titles, or other typed fields.
+
+## Allowed
+
+- Labels, helper text, buttons, and chips may stay smaller (`text-sm`, `text-xs`).
+- If a field must look smaller visually, keep computed font-size ≥ 16px and scale with CSS `transform` — do not reduce font-size below 16px.
+
+## Examples
+
+```tsx
+// ❌ BAD — text-sm is 14px; iOS zooms on focus
+<input className="... text-sm ..." type="search" />
+
+// ✅ GOOD — text-base is 16px; no auto-zoom
+<input className="... text-base ..." type="search" />
+```

--- a/.cursor/rules/issue-implementation-branching.mdc
+++ b/.cursor/rules/issue-implementation-branching.mdc
@@ -1,0 +1,53 @@
+---
+description: Start new GitHub issue work from an up-to-date main branch to avoid merge conflicts
+alwaysApply: true
+---
+
+# Issue Implementation Branching
+
+When starting work on a **new** GitHub issue (planning, implementation, or shipping), always branch from the latest `main`.
+
+## When this applies
+
+- User asks to implement, plan, or ship a GitHub issue
+- User references a new issue number you have not started on this branch yet
+- User says "pick up issue #N" and you are not already on `issue/<N>-*`
+
+## Required git setup (before code changes)
+
+Run in order:
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+git checkout -b issue/<number>-<short-slug>
+```
+
+Branch naming: `issue/<number>-<short-slug>` (lowercase, hyphens, ~40 chars max).
+
+## Do not
+
+- Create a feature branch from a stale local `main`
+- Start new issue work while still on another issue's branch without syncing `main` first
+- Implement on `main` / `master` directly
+
+## Resuming existing issue work
+
+If you are already on the correct `issue/<number>-*` branch for that issue and have in-progress commits, stay on it. Before opening or updating a PR, sync with main:
+
+```bash
+git fetch origin
+git merge origin/main
+# or: git rebase origin/main — only if the user or team prefers rebase
+```
+
+Resolve conflicts locally, re-run validation, then push.
+
+## Uncommitted changes
+
+If `git checkout main` or `git pull` is blocked by local changes, stop and ask the user whether to stash, commit, or discard — do not force checkout.
+
+## Mention in handoff / PR
+
+When creating a branch, note in the plan or handoff that it was cut from current `origin/main` after `git pull --ff-only`.

--- a/.cursor/skills/plan-from-github-issue/SKILL.md
+++ b/.cursor/skills/plan-from-github-issue/SKILL.md
@@ -22,7 +22,7 @@ Use this skill when:
 Follow this sequence:
 
 1. Resolve the repository context from git@github.com:sndrem/mealplanner.git
-2. Ensure a feature branch (not `main` / `master`).
+2. Sync `main` and ensure a feature branch (not `main` / `master`) — see Step 2.
 3. Fetch the GitHub issue.
 4. Summarize the issue in your own words.
 5. Have a look at the file AGENT_HANDOFF.md for context of the previous issue resolved
@@ -41,30 +41,35 @@ If the repository is not obvious from the current workspace:
 
 If the repository is known, use that repository with the issue number directly.
 
-## Step 2: Ensure Feature Branch
+## Step 2: Sync Main And Ensure Feature Branch
 
-Before fetching the issue or editing code, check the current branch:
+Before fetching the issue or editing code, start from the latest `main` so the branch does not fall behind and cause merge conflicts later.
 
-```bash
-git branch --show-current
-```
-
-If the branch is `main` or `master`, create and check out a feature branch:
+**Starting a new issue** (not already on `issue/<number>-*` for this issue):
 
 ```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
 git checkout -b issue/<number>-<short-slug>
 ```
+
+If the issue number is not known yet, run `gh issue view` first for the title, or use `issue/<number>-plan` temporarily.
+
+**Already on the correct `issue/<number>-*` branch** for this issue with in-progress work: stay on it; do not recreate the branch.
+
+**On a different feature branch** or stale `main`: always run the sync + new branch flow above for the new issue.
 
 Branch naming:
 
 - Prefix with `issue/<number>-` (e.g. `issue/42-fly-deploy`)
 - `<short-slug>`: a few lowercase words from the issue title (drop filler words, use hyphens, max ~40 chars)
 
-If you already know the issue number from the user, you may create the branch after a quick `gh issue view` for the title. Otherwise use a temporary slug like `issue/<number>-plan` and rename only if the team prefers that workflow.
-
-If already on a feature branch, stay on it — do not branch from `main` again.
+If `git checkout main` or `git pull` is blocked by uncommitted changes, stop and ask the user — do not force checkout.
 
 Do not commit or push as part of this step unless the user explicitly asks.
+
+See also: `.cursor/rules/issue-implementation-branching.mdc`
 
 ## Step 3: Fetch The Issue
 

--- a/.cursor/skills/ship-via-github/SKILL.md
+++ b/.cursor/skills/ship-via-github/SKILL.md
@@ -15,6 +15,7 @@ Before starting:
 
 - `gh` is installed and authenticated (`gh auth status`)
 - Current branch is not `main` / `master` (create a feature branch first if needed)
+- For **new** issue work, branch was created from up-to-date `main` (`git fetch origin && git checkout main && git pull --ff-only origin main`) — see `.cursor/rules/issue-implementation-branching.mdc`
 - Default repository: `sndrem/mealplanner` (use current workspace remote if different)
 
 Resolve the related issue number from, in order:

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,37 +2,31 @@
 
 ## Current Objective
 
-Ship searchable, tag-filtered meal-plan recipe picker (issue #201), including recipe-bank assign. Merge conflicts with main resolved.
+Ship iOS search-input font-size fix and Cursor rules for ≥16px text inputs (PR #204).
 
 ## Completed
 
-- Replaced native recipe `<select>` with inline `MealPlanRecipePicker` (search, tag AND filters, Fryser / I planen / Nylig brukt / Alle sections)
-- Added image-ready `RecipePickerCard` media slot with letter placeholders
-- Planning loader returns `recentlyUsedRecipeIds` via existing `getRecentlyUsedRecipeIds`
-- Oppskriftsbank: search, tag filters, and “Legg til på [dag]” (open day or day dropdown)
-- Form still submits `mealSelection:{date}` with `recipe:` / `freezer:` encoding
-- Merged `origin/main` and kept bank scroll height + `whitespace-break-spaces` from main
+- Recipe picker and Oppskriftsbank search inputs use `text-base` (16px) to prevent iOS Safari focus zoom
+- Added `.cursor/rules/ios-input-font-size.mdc` and strengthened `frontend-standards.mdc`
+- Added `.cursor/rules/issue-implementation-branching.mdc` plus plan/ship skill updates to branch from fresh `main`
 
 ## Files To Read First
 
-- `app/components/meal-plan-recipe-picker.tsx` - picker UI and filter wiring
-- `app/components/meal-plan-week-entries-form.tsx` - day rows + controlled active day
-- `app/routes/family-meal-plan.tsx` - lifted selections + recipe bank assign
-- `app/lib/recipe-list-search.ts` - tag filter and section grouping helpers
+- `app/components/meal-plan-recipe-picker.tsx` — picker search input classes
+- `app/routes/family-meal-plan.tsx` — recipe bank search input
+- `.cursor/rules/ios-input-font-size.mdc` — always-on input font rule
 
 ## Validation
 
-- `npm run prisma:generate` — passed (pre-merge)
-- `npm run lint` — re-run after conflict resolution
-- `npm run test:run` — re-run after conflict resolution
-- `npm run typecheck` — re-run after conflict resolution
+- `npm run prisma:generate` — passed
+- `npm run lint` — passed
+- `npm run test:run` — 449 tests passed
+- `npm run typecheck` — passed
 
 ## Open Items
 
-- No recipe `imageUrl` in Prisma yet; UI is placeholder-ready only
-- Keyboard arrow navigation in picker is basic (click + Escape/outside close); could harden listbox roving tabindex later
-- Manual UI smoke on a large recipe catalog still recommended after merge
+- PR #204 CI in progress; auto-merge should deploy via the post-auto-merge Fly hook once merged
 
 ## Next Step
 
-Confirm PR #202 is mergeable after push; merge when checks pass.
+Wait for PR #204 checks / auto-merge, then smoke-test search focus on iOS Safari.

--- a/app/components/meal-plan-recipe-picker.tsx
+++ b/app/components/meal-plan-recipe-picker.tsx
@@ -170,7 +170,7 @@ export function MealPlanRecipePicker({
             Søk
             <input
               autoComplete="off"
-              className="mt-1.5 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+              className="mt-1.5 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-base text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
               onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="For eksempel tomatsuppe"
               ref={searchInputRef}

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -1794,7 +1794,7 @@ function RecipeBankContent({
           Søk oppskrifter
           <input
             autoComplete="off"
-            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-base text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
             onChange={(event) => setSearchQuery(event.target.value)}
             placeholder="For eksempel tomatsuppe"
             type="search"


### PR DESCRIPTION
## Summary
- Set Velg middag and Oppskriftsbank search fields to `text-base` (16px) so iOS Safari no longer zooms on focus.
- Add `.cursor/rules/ios-input-font-size.mdc` and strengthen frontend standards for text inputs.
- Include the earlier always-on rule + skills updates to branch new issue work from an up-to-date `main`.

## Test plan
- [ ] On iOS Safari, open a meal-plan day → Velg middag → tap Søk — viewport should not zoom
- [ ] Same for Oppskriftsbank search

## Validation
- CSS-only / Cursor rules change (no app logic)