### PR TITLE
Show recipe covers on family week overview

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,21 +2,18 @@
 
 ## Current Objective
 
-Ship recipe cover images via Cloudflare R2 (#205) — PR ready on `issue/205-recipe-cover-images`.
+Ship family week overview recipe cover thumbnails (#207) — PR ready on `issue/207-family-week-recipe-images`.
 
 ## Completed
 
-- `Recipe.imageKey` + migration; R2 client and optional env
-- Multipart create/update/delete with upload, replace, remove, and object cleanup
-- Images on recipe list, detail, and meal-plan picker/bank
-- Docs for R2 setup in `.env.example` and `docs/deploy-fly.md`
-- Validation passed; commit + PR for #205
+- `getFamilyWeekDinnerMenu` selects `recipe.imageKey` and exposes `imageUrl` via `getRecipeImageUrl`
+- `WeekDayMenuCard` on family oversikt shows a compact cover when present; omits media when absent
+- Unit/route tests updated for image URL mapping
 
 ## Files To Read First
 
-- `app/lib/r2.server.ts` — upload/delete/URL helpers
-- `app/lib/recipe-write.server.ts` — cover write path
-- `docs/deploy-fly.md` — operator R2 checklist
+- `app/lib/family-home.server.ts` — week dinner menu + imageUrl
+- `app/routes/family.tsx` — `WeekDayMenuCard` thumbnail UI
 
 ## Validation
 
@@ -27,9 +24,8 @@ Ship recipe cover images via Cloudflare R2 (#205) — PR ready on `issue/205-rec
 
 ## Open Items
 
-- Set `R2_*` secrets on Fly before production uploads work
-- Manual smoke against a real R2 bucket after merge/deploy
+- Manual smoke: mixed week (cover / no cover / freezer) on family oversikt after deploy
 
 ## Next Step
 
-Review/merge the PR; configure Fly R2 secrets; smoke-test cover upload in production.
+Review/merge the PR; confirm week cards show covers only when recipes have images.

--- a/app/lib/family-home.server.test.ts
+++ b/app/lib/family-home.server.test.ts
@@ -12,6 +12,12 @@ vi.mock("./family.server", () => ({
   requireFamilyMembership: vi.fn(),
 }));
 
+vi.mock("./r2.server", () => ({
+  getRecipeImageUrl: vi.fn((imageKey: string | null | undefined) =>
+    imageKey ? `https://images.example.com/${imageKey}` : null,
+  ),
+}));
+
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
 import { getFamilyWeekDinnerMenu } from "./family-home.server";
@@ -45,7 +51,10 @@ describe("getFamilyWeekDinnerMenu", () => {
           {
             date: new Date("2026-06-04T00:00:00.000Z"),
             note: null,
-            recipe: { title: "Taco" },
+            recipe: {
+              imageKey: "families/family-1/recipes/recipe-1/cover.jpg",
+              title: "Taco",
+            },
             recipeId: "recipe-1",
             responsibleUser: { displayName: "Kari" },
           },
@@ -54,6 +63,16 @@ describe("getFamilyWeekDinnerMenu", () => {
             note: "Restemat",
             recipe: null,
             recipeId: null,
+            responsibleUser: null,
+          },
+          {
+            date: new Date("2026-06-06T00:00:00.000Z"),
+            note: null,
+            recipe: {
+              imageKey: null,
+              title: "Pasta",
+            },
+            recipeId: "recipe-2",
             responsibleUser: null,
           },
         ],
@@ -71,6 +90,8 @@ describe("getFamilyWeekDinnerMenu", () => {
     expect(result).toHaveLength(7);
     expect(result[3]).toMatchObject({
       date: "2026-06-04",
+      imageUrl:
+        "https://images.example.com/families/family-1/recipes/recipe-1/cover.jpg",
       isToday: true,
       mealPlanId: "meal-plan-1",
       mealPlanTitle: "Uke 23",
@@ -79,15 +100,23 @@ describe("getFamilyWeekDinnerMenu", () => {
     });
     expect(result[4]).toMatchObject({
       date: "2026-06-05",
+      imageUrl: null,
       menuLabel: "Restemat",
       responsibleDisplayName: null,
     });
+    expect(result[5]).toMatchObject({
+      date: "2026-06-06",
+      imageUrl: null,
+      menuLabel: "Pasta",
+    });
     expect(result[0]).toMatchObject({
       date: "2026-06-01",
+      imageUrl: null,
       menuLabel: "Ikke planlagt",
     });
     expect(result[6]).toMatchObject({
       date: "2026-06-07",
+      imageUrl: null,
       menuLabel: "Ikke planlagt",
       mealPlanId: "meal-plan-1",
     });

--- a/app/lib/family-home.server.ts
+++ b/app/lib/family-home.server.ts
@@ -12,10 +12,12 @@ import {
   getCalendarWeekBounds,
   getCalendarWeekDates,
 } from "./meal-plan-week";
+import { getRecipeImageUrl } from "./r2.server";
 
 export type FamilyWeekDayMenu = {
   date: string;
   dateLabel: string;
+  imageUrl: string | null;
   isToday: boolean;
   mealPlanId: string | null;
   mealPlanTitle: string | null;
@@ -59,6 +61,7 @@ export async function getFamilyWeekDinnerMenu({
           note: true,
           recipe: {
             select: {
+              imageKey: true,
               title: true,
             },
           },
@@ -100,6 +103,7 @@ export async function getFamilyWeekDinnerMenu({
     return {
       date,
       dateLabel: formatShortDateLabel(date),
+      imageUrl: getRecipeImageUrl(dinnerEntry?.recipe?.imageKey),
       isToday: isPlanDateToday(date, referenceDate),
       mealPlanId: coveringPlan?.id ?? null,
       mealPlanTitle: coveringPlan?.title ?? null,

--- a/app/routes/family.test.ts
+++ b/app/routes/family.test.ts
@@ -94,6 +94,7 @@ const mockWeekDays = [
   {
     date: "2026-06-01",
     dateLabel: "1. jun.",
+    imageUrl: null,
     isToday: false,
     mealPlanId: "meal-plan-1",
     mealPlanTitle: "Uke 23",
@@ -104,6 +105,7 @@ const mockWeekDays = [
   {
     date: "2026-06-04",
     dateLabel: "4. jun.",
+    imageUrl: "https://images.example.com/families/family-1/recipes/recipe-1/cover.jpg",
     isToday: true,
     mealPlanId: "meal-plan-1",
     mealPlanTitle: "Uke 23",

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -175,6 +175,14 @@ function WeekDayMenuCard({
         {day.weekdayLabel}
       </p>
       <p className="mt-1 text-sm text-slate-500">{day.dateLabel}</p>
+      {day.imageUrl ? (
+        <img
+          alt=""
+          className="mt-3 aspect-square w-full max-h-28 rounded-xl object-cover"
+          loading="lazy"
+          src={day.imageUrl}
+        />
+      ) : null}
       <p className="mt-3 text-base font-semibold leading-snug text-slate-950">
         {day.menuLabel}
       </p>
@@ -199,24 +207,24 @@ function WeekDayMenuCard({
         className={`${cardClassName} block transition hover:border-slate-300 hover:bg-white`}
         to={`/families/${familyId}/meal-plans/${day.mealPlanId}`}
       >
+        {content}
         {day.isToday ? (
           <span className="mb-2 inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-800">
             I dag
           </span>
         ) : null}
-        {content}
       </Link>
     );
   }
 
   return (
     <article className={cardClassName}>
+      {content}
       {day.isToday ? (
         <span className="mb-2 inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-800">
           I dag
         </span>
       ) : null}
-      {content}
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- Week dinner cards on family oversikt show recipe cover thumbnails when available
- Days without a recipe image (or freezer/note/empty) render no media placeholder

## Related issue
Closes #207

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] Family oversikt with a recipe that has a cover — thumbnail appears on that day
- [ ] Recipe without cover / freezer / empty day — no image UI
- [ ] Seven-column desktop and stacked mobile layouts remain readable

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck