### PR TITLE
Keep family week menu images square on mobile

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,18 +2,16 @@
 
 ## Current Objective
 
-Ship family week overview recipe cover thumbnails (#207) — PR ready on `issue/207-family-week-recipe-images`.
+Ship square week-menu thumbnails on family home (#209) — ready for PR merge.
 
 ## Completed
 
-- `getFamilyWeekDinnerMenu` selects `recipe.imageKey` and exposes `imageUrl` via `getRecipeImageUrl`
-- `WeekDayMenuCard` on family oversikt shows a compact cover when present; omits media when absent
-- Unit/route tests updated for image URL mapping
+- `WeekDayMenuCard` image classes changed from `w-full max-h-28` to `w-28 max-w-full` so covers stay square on mobile and shrink cleanly in `md:grid-cols-7`
+- Branch `issue/209-week-menu-square-images` cut from current `origin/main`
 
 ## Files To Read First
 
-- `app/lib/family-home.server.ts` — week dinner menu + imageUrl
-- `app/routes/family.tsx` — `WeekDayMenuCard` thumbnail UI
+- `app/routes/family.tsx` — `WeekDayMenuCard` thumbnail `className`
 
 ## Validation
 
@@ -24,8 +22,8 @@ Ship family week overview recipe cover thumbnails (#207) — PR ready on `issue/
 
 ## Open Items
 
-- Manual smoke: mixed week (cover / no cover / freezer) on family oversikt after deploy
+- Manual smoke: Oversikt week cards with images at ~375px and at `md+` 7-column grid after deploy
 
 ## Next Step
 
-Review/merge the PR; confirm week cards show covers only when recipes have images.
+Review/merge the PR; confirm mobile thumbs look square, not thin strips.

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -178,7 +178,7 @@ function WeekDayMenuCard({
       {day.imageUrl ? (
         <img
           alt=""
-          className="mt-3 aspect-square w-full max-h-28 rounded-xl object-cover"
+          className="mt-3 aspect-square w-28 max-w-full rounded-xl object-cover"
           loading="lazy"
           src={day.imageUrl}
         />


### PR DESCRIPTION
## Summary
- Fix stretched recipe covers on family home week cards by using a constrained square thumbnail (`w-28 max-w-full`) instead of full-width + `max-h-28`
- Images stay readable on mobile and still fit the `md:grid-cols-7` layout

## Related issue
Closes #209

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Manual: family Oversikt with recipe images at ~375px — thumbs look square, not thin strips
- [ ] Manual: same view at `md+` 7-column grid — images do not overflow
- [ ] Manual: days without images unchanged

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck