### PR TITLE
Store mode: per-aisle Handlet folds + sticky Angre

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,28 +2,33 @@
 
 ## Current Objective
 
-Ship square week-menu thumbnails on family home (#209) — ready for PR merge.
+Ship #211 store-mode Handlet + sticky Angre — validated; opening PR.
 
 ## Completed
 
-- `WeekDayMenuCard` image classes changed from `w-full max-h-28` to `w-28 max-w-full` so covers stay square on mobile and shrink cleanly in `md:grid-cols-7`
-- Branch `issue/209-week-menu-square-images` cut from current `origin/main`
+- Per-aisle **Handlet** folds; removed global **Kjøpt**
+- Sticky **Krysset av · Angre** above quick-add dock
+- Partition API keeps fully checked sections with per-section `boughtItems`
+- Branch `issue/211-store-mode-handlet-undo` from `origin/main`
 
 ## Files To Read First
 
-- `app/routes/family.tsx` — `WeekDayMenuCard` thumbnail `className`
+- `app/routes/family-meal-plan-store-mode.tsx`
+- `app/lib/shopping-store-mode-client.ts`
+- `app/lib/store-mode-theme.ts`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 458 tests passed
+- `npm run test:run` — 459 tests passed
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual smoke: Oversikt week cards with images at ~375px and at `md+` 7-column grid after deploy
+- Manual phone smoke of aisle check / Angre / Handlet after deploy
+- Untracked `.cursor/rules/ux-flow-sparring.mdc` left out of this PR
 
 ## Next Step
 
-Review/merge the PR; confirm mobile thumbs look square, not thin strips.
+Review/merge the PR; issue #211 closes via `Closes #211` on merge.

--- a/app/components/store-mode-deprioritize-bought-toggle.tsx
+++ b/app/components/store-mode-deprioritize-bought-toggle.tsx
@@ -18,7 +18,7 @@ export function StoreModeDeprioritizeBoughtToggle({
       onClick={() => onChange(!enabled)}
       type="button"
     >
-      Flytt kjøpte varer til bunnen
+      Skjul kjøpte varer
     </button>
   );
 }

--- a/app/lib/shopping-store-mode-client.test.ts
+++ b/app/lib/shopping-store-mode-client.test.ts
@@ -364,7 +364,7 @@ describe("shopping-store-mode-client", () => {
     ).toEqual(["family:1", "family:2"]);
   });
 
-  it("returns sections unchanged when deprioritize-bought is off", () => {
+  it("returns sections with empty boughtItems when deprioritize-bought is off", () => {
     const sections = [
       {
         displayName: "Produce",
@@ -376,12 +376,20 @@ describe("shopping-store-mode-client", () => {
     ];
 
     expect(partitionStoreModeSections(sections, false)).toEqual({
-      activeSections: sections,
-      boughtItems: [],
+      activeSections: [
+        {
+          displayName: "Produce",
+          boughtItems: [],
+          items: [
+            { checked: true, id: "a" },
+            { checked: false, id: "b" },
+          ],
+        },
+      ],
     });
   });
 
-  it("partitions unchecked into active sections and checked into bought items", () => {
+  it("keeps bought items on each section and retains fully checked aisles", () => {
     const sections = [
       {
         displayName: "Produce",
@@ -400,12 +408,14 @@ describe("shopping-store-mode-client", () => {
       activeSections: [
         {
           displayName: "Produce",
+          boughtItems: [{ checked: true, id: "a" }],
           items: [{ checked: false, id: "b" }],
         },
-      ],
-      boughtItems: [
-        { checked: true, id: "a" },
-        { checked: true, id: "c" },
+        {
+          displayName: "Dairy",
+          boughtItems: [{ checked: true, id: "c" }],
+          items: [],
+        },
       ],
     });
   });

--- a/app/lib/shopping-store-mode-client.ts
+++ b/app/lib/shopping-store-mode-client.ts
@@ -140,26 +140,34 @@ export function sortStoreModeItemsByName<
   return [...items].sort(compareStoreModeItemsByName);
 }
 
+export type StoreModePartitionedSection<
+  TSection extends { items: Array<{ checked: boolean }> },
+> = Omit<TSection, "items"> & {
+  boughtItems: TSection["items"];
+  items: TSection["items"];
+};
+
 export function partitionStoreModeSections<
-  TItem extends { checked: boolean },
-  TSection extends { items: TItem[] },
+  TSection extends { items: Array<{ checked: boolean }> },
 >(
   sections: TSection[],
   deprioritizeBought: boolean,
-): { activeSections: TSection[]; boughtItems: TItem[] } {
+): { activeSections: Array<StoreModePartitionedSection<TSection>> } {
   if (!deprioritizeBought) {
     return {
-      activeSections: sections,
-      boughtItems: [],
+      activeSections: sections.map((section) => ({
+        ...section,
+        boughtItems: [] as TSection["items"],
+        items: section.items,
+      })),
     };
   }
 
-  const activeSections: TSection[] = [];
-  const boughtItems: TItem[] = [];
+  const activeSections: Array<StoreModePartitionedSection<TSection>> = [];
 
   for (const section of sections) {
-    const uncheckedItems: TItem[] = [];
-    const checkedItems: TItem[] = [];
+    const uncheckedItems = [] as TSection["items"];
+    const checkedItems = [] as TSection["items"];
 
     for (const item of section.items) {
       if (item.checked) {
@@ -169,19 +177,19 @@ export function partitionStoreModeSections<
       }
     }
 
-    if (uncheckedItems.length > 0) {
-      activeSections.push({
-        ...section,
-        items: uncheckedItems,
-      });
+    if (uncheckedItems.length === 0 && checkedItems.length === 0) {
+      continue;
     }
 
-    boughtItems.push(...checkedItems);
+    activeSections.push({
+      ...section,
+      boughtItems: checkedItems,
+      items: uncheckedItems,
+    });
   }
 
   return {
     activeSections,
-    boughtItems,
   };
 }
 

--- a/app/lib/store-mode-theme.test.ts
+++ b/app/lib/store-mode-theme.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
   getStoreModeBannerClass,
   getStoreModeSyncOverlayClass,
+  storeModeBottomChromeShellClass,
   storeModeMetaDateSelectClass,
   storeModeMetaStoreSelectClass,
   storeModeSelectClass,
   storeModeSyncOverlayShellClass,
+  storeModeUndoBarActionClass,
+  storeModeUndoBarClass,
 } from "./store-mode-theme";
 
 describe("store-mode-theme", () => {
@@ -38,5 +41,12 @@ describe("store-mode-theme", () => {
     expect(storeModeMetaStoreSelectClass).not.toContain("w-full");
     expect(storeModeMetaDateSelectClass).toContain("max-w-[9rem]");
     expect(storeModeSelectClass).toContain("w-full");
+  });
+
+  it("exposes thumb-friendly bottom undo chrome", () => {
+    expect(storeModeBottomChromeShellClass).toContain("fixed");
+    expect(storeModeBottomChromeShellClass).toContain("bottom-0");
+    expect(storeModeUndoBarClass).toContain("min-h-11");
+    expect(storeModeUndoBarActionClass).toContain("min-h-11");
   });
 });

--- a/app/lib/store-mode-theme.ts
+++ b/app/lib/store-mode-theme.ts
@@ -40,6 +40,22 @@ export const storeModeLaterChipClass =
 export const storeModeQuickAddDockClass =
   "min-w-0 max-w-full rounded-[28px] bg-white p-4 shadow-2xl ring-2 ring-store-accent";
 
+/** Fixed bottom stack (undo + quick-add) — out of document flow. */
+export const storeModeBottomChromeShellClass =
+  "pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3";
+
+export const storeModeUndoBarClass =
+  "flex min-h-11 items-center gap-3 rounded-2xl border border-stone-200 bg-white/95 px-3 py-2 text-sm text-stone-900 shadow-lg backdrop-blur-sm";
+
+export const storeModeUndoBarActionClass =
+  "inline-flex min-h-11 shrink-0 items-center justify-center rounded-xl bg-store-accent-light px-3 text-sm font-semibold text-store-accent-text ring-1 ring-store-accent/40 transition hover:bg-store-accent-light/80";
+
+export const storeModeUndoBarDismissClass =
+  "inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-xl text-stone-500 transition hover:bg-stone-100 hover:text-stone-950";
+
+export const storeModeHandletFoldClass =
+  "rounded-2xl border border-stone-200/80 bg-stone-50/90 p-3";
+
 export type StoreModeBannerTone = "success" | "sync" | "error";
 
 export type StoreModeSyncOverlayTone = "sync" | "error";

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -79,7 +79,9 @@ import {
   getStoreModeBannerClass,
   getStoreModeSyncOverlayClass,
   storeModeAccentBarClass,
+  storeModeBottomChromeShellClass,
   storeModeCountChipClass,
+  storeModeHandletFoldClass,
   storeModeLaterChipClass,
   storeModeMetaDateSelectClass,
   storeModeMetaStoreSelectClass,
@@ -92,6 +94,9 @@ import {
   storeModeSectionCardClass,
   storeModeSurfaceCardClass,
   storeModeSyncOverlayShellClass,
+  storeModeUndoBarActionClass,
+  storeModeUndoBarClass,
+  storeModeUndoBarDismissClass,
 } from "../lib/store-mode-theme";
 import {
   STORE_MODE_SYNC_PROGRESS_MESSAGE,
@@ -949,14 +954,53 @@ export default function FamilyMealPlanStoreModeRoute({
     );
   }, [deprioritizeBoughtStorageKey]);
   type StoreModeDisplayItem = (typeof displayDueItems)[number];
-  type StoreModeDisplaySection = (typeof displaySectionGroups)[number];
-  const { activeSections, boughtItems } = useMemo(
-    (): {
-      activeSections: StoreModeDisplaySection[];
-      boughtItems: StoreModeDisplayItem[];
-    } => partitionStoreModeSections(displaySectionGroups, deprioritizeBought),
+  const { activeSections } = useMemo(
+    () => partitionStoreModeSections(displaySectionGroups, deprioritizeBought),
     [deprioritizeBought, displaySectionGroups],
   );
+  const hasUncheckedDueItems = useMemo(
+    () => activeSections.some((section) => section.items.length > 0),
+    [activeSections],
+  );
+  const [lastCheckedAction, setLastCheckedAction] =
+    useState<StoreModeDisplayItem | null>(null);
+
+  const handleToggleWithUndoFeedback = useCallback(
+    (item: StoreModeDisplayItem) => {
+      const displayItem = displayItemsBySourceKey.get(item.sourceKey) ?? item;
+      const nextChecked = !displayItem.checked;
+      handleToggle(item);
+
+      if (nextChecked) {
+        setLastCheckedAction({
+          ...displayItem,
+          checked: true,
+        });
+        return;
+      }
+
+      setLastCheckedAction((current) =>
+        current?.sourceKey === item.sourceKey ? null : current,
+      );
+    },
+    [displayItemsBySourceKey, handleToggle],
+  );
+
+  const handleUndoLastCheck = useCallback(() => {
+    if (!lastCheckedAction) {
+      return;
+    }
+
+    handleToggle(lastCheckedAction);
+    setLastCheckedAction(null);
+  }, [handleToggle, lastCheckedAction]);
+
+  const handleDismissLastCheck = useCallback(() => {
+    setLastCheckedAction(null);
+  }, []);
+  const pageClass = lastCheckedAction
+    ? storeModePageClass.replace("pb-36", "pb-52")
+    : storeModePageClass;
   const noticeContent = loaderData.notice
     ? getStoreModeNoticeContent(loaderData.notice)
     : null;
@@ -987,7 +1031,7 @@ export default function FamilyMealPlanStoreModeRoute({
       : undefined);
 
   return (
-    <main className={storeModePageClass}>
+    <main className={pageClass}>
       <div className="mx-auto flex max-w-4xl flex-col gap-5">
         <section className={storeModeMetaStripClass}>
           <div className="min-w-0">
@@ -1133,63 +1177,75 @@ export default function FamilyMealPlanStoreModeRoute({
                       {section.displayName}
                     </span>
                     <span className={storeModeCountChipClass}>
-                      {section.items.length} varer
+                      {section.items.length > 0
+                        ? `${section.items.length} varer`
+                        : `${section.boughtItems.length} handlet`}
                     </span>
                   </summary>
 
-                  <StoreModeItemGrid
-                    categories={loaderData.categories}
-                    categoryFetcherError={categoryFetcherError}
-                    categoryInteractionSourceKey={categoryInteractionSourceKey}
-                    isSavingCategorySourceKey={isSavingCategorySourceKey}
-                    items={section.items}
-                    layout={shoppingView}
-                    onQuickAddFromCard={handleQuickAddFromCard}
-                    onUpdateCategory={handleUpdateCategory}
-                    onUpdateQuantity={handleUpdateQuantity}
-                    onToggleItem={handleToggle}
-                    recentlyAddedSourceKey={recentlyAddedSourceKey}
-                    selectedStoreId={loaderData.selectedStore?.id}
-                  />
+                  {section.items.length > 0 ? (
+                    <StoreModeItemGrid
+                      categories={loaderData.categories}
+                      categoryFetcherError={categoryFetcherError}
+                      categoryInteractionSourceKey={categoryInteractionSourceKey}
+                      isSavingCategorySourceKey={isSavingCategorySourceKey}
+                      items={section.items}
+                      layout={shoppingView}
+                      onQuickAddFromCard={handleQuickAddFromCard}
+                      onUpdateCategory={handleUpdateCategory}
+                      onUpdateQuantity={handleUpdateQuantity}
+                      onToggleItem={handleToggleWithUndoFeedback}
+                      recentlyAddedSourceKey={recentlyAddedSourceKey}
+                      selectedStoreId={loaderData.selectedStore?.id}
+                    />
+                  ) : null}
+
+                  {deprioritizeBought && section.boughtItems.length > 0 ? (
+                    <details
+                      className={`${storeModeHandletFoldClass}${section.items.length > 0 ? " mt-4" : " mt-3"}`}
+                    >
+                      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 marker:content-none [&::-webkit-details-marker]:hidden">
+                        <span className="text-sm font-semibold text-stone-700">
+                          Handlet
+                        </span>
+                        <span className={storeModeCountChipClass}>
+                          {section.boughtItems.length} varer
+                        </span>
+                      </summary>
+
+                      <StoreModeItemGrid
+                        categories={loaderData.categories}
+                        categoryFetcherError={categoryFetcherError}
+                        categoryInteractionSourceKey={
+                          categoryInteractionSourceKey
+                        }
+                        isSavingCategorySourceKey={isSavingCategorySourceKey}
+                        items={section.boughtItems}
+                        layout={shoppingView}
+                        onQuickAddFromCard={handleQuickAddFromCard}
+                        onUpdateCategory={handleUpdateCategory}
+                        onUpdateQuantity={handleUpdateQuantity}
+                        onToggleItem={handleToggleWithUndoFeedback}
+                        recentlyAddedSourceKey={recentlyAddedSourceKey}
+                        selectedStoreId={loaderData.selectedStore?.id}
+                      />
+                    </details>
+                  ) : null}
                 </details>
               ))
-            ) : deprioritizeBought ? (
+            ) : null}
+            {deprioritizeBought &&
+            activeSections.length > 0 &&
+            !hasUncheckedDueItems ? (
               <article className={`${storeModeSurfaceCardClass} p-6`}>
                 <h3 className="text-base font-semibold text-stone-950">
                   Alt er krysset av
                 </h3>
                 <p className="mt-3 text-sm leading-6 text-stone-600">
-                  Du har handlet alle varene for denne turen. Kjøpte varer
-                  ligger nedenfor hvis du vil se eller endre dem.
+                  Du har handlet alle varene for denne turen. Åpne Handlet i
+                  hver seksjon hvis du vil se eller endre dem.
                 </p>
               </article>
-            ) : null}
-            {deprioritizeBought && boughtItems.length > 0 ? (
-              <details className={storeModeMutedPanelClass}>
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 marker:content-none [&::-webkit-details-marker]:hidden">
-                  <span className="text-lg font-semibold tracking-tight text-stone-950">
-                    Kjøpt
-                  </span>
-                  <span className={storeModeCountChipClass}>
-                    {boughtItems.length} varer
-                  </span>
-                </summary>
-
-                <StoreModeItemGrid
-                  categories={loaderData.categories}
-                  categoryFetcherError={categoryFetcherError}
-                  categoryInteractionSourceKey={categoryInteractionSourceKey}
-                  isSavingCategorySourceKey={isSavingCategorySourceKey}
-                  items={boughtItems}
-                  layout={shoppingView}
-                  onQuickAddFromCard={handleQuickAddFromCard}
-                  onUpdateCategory={handleUpdateCategory}
-                  onUpdateQuantity={handleUpdateQuantity}
-                  onToggleItem={handleToggle}
-                  recentlyAddedSourceKey={recentlyAddedSourceKey}
-                  selectedStoreId={loaderData.selectedStore?.id}
-                />
-              </details>
             ) : null}
           </section>
         ) : (
@@ -1299,8 +1355,35 @@ export default function FamilyMealPlanStoreModeRoute({
         </div>
       ) : null}
 
-      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3">
-        <div className="pointer-events-auto mx-auto max-w-4xl min-w-0">
+      <div className={storeModeBottomChromeShellClass}>
+        <div className="pointer-events-auto mx-auto flex max-w-4xl min-w-0 flex-col gap-2">
+          {lastCheckedAction ? (
+            <div
+              aria-live="polite"
+              className={storeModeUndoBarClass}
+              role="status"
+            >
+              <p className="min-w-0 flex-1 truncate leading-5">
+                Krysset av:{" "}
+                <span className="font-semibold">{lastCheckedAction.name}</span>
+              </p>
+              <button
+                className={storeModeUndoBarActionClass}
+                onClick={handleUndoLastCheck}
+                type="button"
+              >
+                Angre
+              </button>
+              <button
+                aria-label="Lukk"
+                className={storeModeUndoBarDismissClass}
+                onClick={handleDismissLastCheck}
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+          ) : null}
           <div className={storeModeQuickAddDockClass}>
             <ManualShoppingQuickAdd
               appearance="store-mode"


### PR DESCRIPTION
## Summary
- Hide bought items in per-aisle **Handlet** folds instead of a global **Kjøpt** dump, so mis-taps stay findable in the aisle
- Show a sticky **Krysset av: {name} · Angre** bar above quick-add for the latest local check
- Keep Handlehistorikk as the audit log only

## Related issue
Closes #211

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Phone: check item → sticky shows name → Angre restores to aisle
- [ ] Open Handlet in that aisle; rapid checks update sticky to latest
- [ ] Grid and list views; deprioritize off still shows checked inline

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck