### PR TITLE
Add store-mode trip focus by meal plan

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,35 @@
 
 ## Current Objective
 
-Ship #211 store-mode Handlet + sticky Angre — PR open, awaiting merge.
+Ship #213 store-mode trip focus — PR opened, awaiting merge.
 
 ## Completed
 
-- Per-aisle **Handlet** folds; removed global **Kjøpt**
-- Sticky **Krysset av · Angre** above quick-add dock
-- Validated, committed, pushed; PR https://github.com/sndrem/mealplanner/pull/212 (`Closes #211`)
+- Trip focus control in Butikkmodus: Denne uken / Neste uke / Alle åpne
+- Persisted on `UserStorePreference.storeModeTripFocus` (default CURRENT)
+- Store-mode list filters by focus; family manuals always included
+- Validated, committed, pushed; PR with `Closes #213`
 
 ## Files To Read First
 
 - `app/routes/family-meal-plan-store-mode.tsx`
-- `app/lib/shopping-store-mode-client.ts`
+- `app/lib/shopping.server.ts`
+- `app/lib/meal-plan-for-date.server.ts`
+- `prisma/migrations/20260821090000_add_store_mode_trip_focus/migration.sql`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 459 tests passed
+- `npm run test:run` — 472 tests passed
 - `npm run typecheck` — passed
 
 ## Open Items
 
-- Manual phone smoke after deploy
-- Issue #211 closes on PR merge via `Closes #211`
-- Untracked `.cursor/rules/ux-flow-sparring.mdc` left out of this PR
+- Apply migration on deploy (`prisma migrate deploy`)
+- Manual smoke after deploy: CURRENT hides next week; NEXT mid-week; Alle åpne
+- Issue #213 closes on PR merge via `Closes #213`
 
 ## Next Step
 
-Review/merge https://github.com/sndrem/mealplanner/pull/212
+Review/merge the open PR for #213.

--- a/app/lib/meal-plan-for-date.server.test.ts
+++ b/app/lib/meal-plan-for-date.server.test.ts
@@ -14,7 +14,10 @@ vi.mock("./db.server", () => ({
 
 import {
   findMealPlanCoveringDate,
+  resolveEffectiveStoreModeTripFocus,
   resolveStoreModeAnchorMealPlan,
+  resolveStoreModeNextMealPlan,
+  selectMealPlansForTripFocus,
 } from "./meal-plan-for-date.server";
 
 describe("findMealPlanCoveringDate", () => {
@@ -116,5 +119,101 @@ describe("resolveStoreModeAnchorMealPlan", () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe("resolveStoreModeNextMealPlan", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the earliest meal plan that starts after today", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({ id: "meal-plan-next" });
+
+    const result = await resolveStoreModeNextMealPlan({
+      familyId: "family-1",
+      referenceDate: new Date("2026-05-14T12:00:00.000Z"),
+    });
+
+    expect(result).toEqual({ id: "meal-plan-next" });
+    expect(dbMock.mealPlan.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ startDate: "asc" }, { id: "asc" }],
+        where: expect.objectContaining({
+          familyId: "family-1",
+          startDate: {
+            gt: new Date("2026-05-14T00:00:00.000Z"),
+          },
+        }),
+      }),
+    );
+  });
+});
+
+describe("resolveEffectiveStoreModeTripFocus", () => {
+  it("keeps NEXT when a next plan exists", () => {
+    expect(
+      resolveEffectiveStoreModeTripFocus({
+        canFocusNext: true,
+        tripFocus: "NEXT",
+      }),
+    ).toBe("NEXT");
+  });
+
+  it("coerces NEXT to CURRENT when no next plan exists", () => {
+    expect(
+      resolveEffectiveStoreModeTripFocus({
+        canFocusNext: false,
+        tripFocus: "NEXT",
+      }),
+    ).toBe("CURRENT");
+  });
+});
+
+describe("selectMealPlansForTripFocus", () => {
+  const currentPlan = {
+    id: "meal-plan-1",
+    startDate: new Date("2026-05-12T00:00:00.000Z"),
+  };
+  const nextPlan = {
+    id: "meal-plan-2",
+    startDate: new Date("2026-05-19T00:00:00.000Z"),
+  };
+  const openPlans = [currentPlan, nextPlan];
+
+  it("returns only the covering plan for CURRENT", () => {
+    expect(
+      selectMealPlansForTripFocus({
+        anchorPlan: currentPlan,
+        currentPlanId: currentPlan.id,
+        focus: "CURRENT",
+        nextPlanId: nextPlan.id,
+        openPlans,
+      }),
+    ).toEqual([currentPlan]);
+  });
+
+  it("returns only the next plan for NEXT", () => {
+    expect(
+      selectMealPlansForTripFocus({
+        anchorPlan: currentPlan,
+        currentPlanId: currentPlan.id,
+        focus: "NEXT",
+        nextPlanId: nextPlan.id,
+        openPlans,
+      }),
+    ).toEqual([nextPlan]);
+  });
+
+  it("returns all open plans for ALL", () => {
+    expect(
+      selectMealPlansForTripFocus({
+        anchorPlan: currentPlan,
+        currentPlanId: currentPlan.id,
+        focus: "ALL",
+        nextPlanId: nextPlan.id,
+        openPlans,
+      }),
+    ).toEqual(openPlans);
   });
 });

--- a/app/lib/meal-plan-for-date.server.ts
+++ b/app/lib/meal-plan-for-date.server.ts
@@ -7,6 +7,12 @@ const storeModeAnchorMealPlanSelect = {
 
 export const FAMILY_SHOPPING_LIST_MODES = ["GLOBAL", "COMBINED"] as const;
 
+export const STORE_MODE_TRIP_FOCUS_VALUES = [
+  "CURRENT",
+  "NEXT",
+  "ALL",
+] as const;
+
 const mealPlanForDateSelect = {
   endDate: true,
   id: true,
@@ -22,6 +28,9 @@ export type MealPlanForDateSummary = {
   status: "APPROVED" | "DRAFT";
   title: string;
 };
+
+export type StoreModeTripFocusValue =
+  (typeof STORE_MODE_TRIP_FOCUS_VALUES)[number];
 
 export async function findMealPlanCoveringDate({
   familyId,
@@ -66,6 +75,90 @@ export async function resolveStoreModeAnchorMealPlan({
     select: storeModeAnchorMealPlanSelect,
     where: { familyId },
   });
+}
+
+export async function resolveStoreModeNextMealPlan({
+  familyId,
+  referenceDate = new Date(),
+}: {
+  familyId: string;
+  referenceDate?: Date;
+}): Promise<{ id: string } | null> {
+  const dateOnly = formatDateOnly(referenceDate);
+  const dateAtUtcMidnight = new Date(`${dateOnly}T00:00:00.000Z`);
+
+  return db.mealPlan.findFirst({
+    orderBy: [{ startDate: "asc" }, { id: "asc" }],
+    select: storeModeAnchorMealPlanSelect,
+    where: {
+      familyId,
+      startDate: {
+        gt: dateAtUtcMidnight,
+      },
+    },
+  });
+}
+
+export function resolveEffectiveStoreModeTripFocus({
+  canFocusNext,
+  tripFocus,
+}: {
+  canFocusNext: boolean;
+  tripFocus: StoreModeTripFocusValue;
+}): StoreModeTripFocusValue {
+  if (tripFocus === "NEXT" && !canFocusNext) {
+    return "CURRENT";
+  }
+
+  return tripFocus;
+}
+
+export function selectMealPlansForTripFocus<
+  T extends { id: string; startDate: Date },
+>({
+  anchorPlan,
+  currentPlanId,
+  focus,
+  nextPlanId,
+  openPlans,
+}: {
+  anchorPlan: T;
+  currentPlanId: string | null;
+  focus: StoreModeTripFocusValue;
+  nextPlanId: string | null;
+  openPlans: T[];
+}): T[] {
+  if (focus === "ALL") {
+    if (openPlans.some((plan) => plan.id === anchorPlan.id)) {
+      return openPlans;
+    }
+
+    return [...openPlans, anchorPlan].sort((left, right) => {
+      if (left.startDate.getTime() !== right.startDate.getTime()) {
+        return left.startDate.getTime() - right.startDate.getTime();
+      }
+
+      return left.id.localeCompare(right.id, "nb");
+    });
+  }
+
+  if (focus === "NEXT" && nextPlanId) {
+    const nextPlan =
+      openPlans.find((plan) => plan.id === nextPlanId) ??
+      (anchorPlan.id === nextPlanId ? anchorPlan : null);
+
+    if (nextPlan) {
+      return [nextPlan];
+    }
+  }
+
+  const resolvedCurrentId = currentPlanId ?? anchorPlan.id;
+  const currentPlan =
+    openPlans.find((plan) => plan.id === resolvedCurrentId) ??
+    (anchorPlan.id === resolvedCurrentId ? anchorPlan : null) ??
+    anchorPlan;
+
+  return [currentPlan];
 }
 
 export function serializeMealPlanForDateSummary(plan: MealPlanForDateSummary) {

--- a/app/lib/shopping.server.test.ts
+++ b/app/lib/shopping.server.test.ts
@@ -1381,6 +1381,11 @@ describe("shopping.server", () => {
     function registerStoreModePlans(
       anchorPlan: Record<string, unknown>,
       extraPlans: Record<string, unknown>[] = [],
+      options: {
+        coveringPlan?: Record<string, unknown> | null;
+        nextPlan?: Record<string, unknown> | null;
+        tripFocus?: "CURRENT" | "NEXT" | "ALL";
+      } = {},
     ) {
       const plans = [...extraPlans];
 
@@ -1399,7 +1404,42 @@ describe("shopping.server", () => {
         return String(left.id).localeCompare(String(right.id), "nb");
       });
 
-      dbMock.mealPlan.findFirst.mockResolvedValue(anchorPlan);
+      const coveringPlan =
+        options.coveringPlan === undefined ? anchorPlan : options.coveringPlan;
+      const nextPlan =
+        options.nextPlan === undefined
+          ? (extraPlans.find(
+              (plan) =>
+                (plan.startDate as Date).getTime() >
+                new Date("2026-05-14T00:00:00.000Z").getTime(),
+            ) ?? null)
+          : options.nextPlan;
+
+      dbMock.mealPlan.findFirst.mockImplementation(
+        (args: { where?: Record<string, unknown> }) => {
+          const where = args.where ?? {};
+
+          if (typeof where.id === "string") {
+            return (
+              plans.find((plan) => plan.id === where.id) ?? anchorPlan
+            );
+          }
+
+          const startDateFilter = where.startDate as
+            | { gt?: Date; lte?: Date }
+            | undefined;
+
+          if (startDateFilter?.lte) {
+            return coveringPlan;
+          }
+
+          if (startDateFilter?.gt) {
+            return nextPlan ? { id: nextPlan.id } : null;
+          }
+
+          return anchorPlan;
+        },
+      );
       dbMock.mealPlan.findMany.mockImplementation(
         (args: { select?: Record<string, unknown> }) => {
           if (args.select && "entries" in args.select) {
@@ -1412,6 +1452,10 @@ describe("shopping.server", () => {
           }));
         },
       );
+      dbMock.userStorePreference.findUnique.mockResolvedValue({
+        selectedStoreId: null,
+        storeModeTripFocus: options.tripFocus ?? "CURRENT",
+      });
     }
 
     beforeEach(() => {
@@ -1557,6 +1601,7 @@ describe("shopping.server", () => {
     ]);
     dbMock.userStorePreference.findUnique.mockResolvedValue({
       selectedStoreId: "store-2",
+      storeModeTripFocus: "CURRENT",
     });
 
     const result = await getMealPlanStoreModeData({
@@ -1568,6 +1613,7 @@ describe("shopping.server", () => {
     expect(dbMock.userStorePreference.findUnique).toHaveBeenCalledWith({
       select: {
         selectedStoreId: true,
+        storeModeTripFocus: true,
       },
       where: {
         userId_familyId: {
@@ -2257,7 +2303,11 @@ describe("shopping.server", () => {
       updatedAt: new Date("2026-05-02T12:00:00.000Z"),
     };
 
-    registerStoreModePlans(anchorPlan, [nextWeekPlan]);
+    registerStoreModePlans(anchorPlan, [nextWeekPlan], {
+      coveringPlan: null,
+      nextPlan: nextWeekPlan,
+      tripFocus: "ALL",
+    });
     dbMock.store.findMany.mockResolvedValue([
       {
         familyId: null,
@@ -2286,6 +2336,7 @@ describe("shopping.server", () => {
       userId: "user-1",
     });
 
+    expect(result.effectiveTripFocus).toBe("ALL");
     expect(result.includedMealPlans).toEqual([
       {
         id: "meal-plan-1",
@@ -2315,6 +2366,256 @@ describe("shopping.server", () => {
         }),
       ]),
     );
+  });
+
+  it("limits store mode to the covering meal plan for CURRENT trip focus", async () => {
+    const currentPlan = {
+      activeShoppingDate: new Date("2026-05-14T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-17T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-bakery", name: "Brod" },
+                categoryId: "category-bakery",
+                displayName: "Wraps",
+                id: "ingredient-1",
+                ingredientId: "canonical-wraps",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "pk",
+              },
+            ],
+            title: "Tacofredag",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-12T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Denne uken",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    };
+    const nextWeekPlan = {
+      activeShoppingDate: new Date("2026-05-19T00:00:00.000Z"),
+      endDate: new Date("2026-05-25T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-19T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-pasta", name: "Pasta" },
+                categoryId: "category-pasta",
+                displayName: "Spaghetti",
+                id: "ingredient-2",
+                ingredientId: "canonical-spaghetti",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "pk",
+              },
+            ],
+            title: "Pasta mandag",
+          },
+          recipeId: "recipe-2",
+        },
+      ],
+      id: "meal-plan-2",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-19T00:00:00.000Z"),
+      status: "APPROVED",
+      title: "Neste uke",
+      updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+    };
+
+    registerStoreModePlans(currentPlan, [nextWeekPlan], {
+      coveringPlan: currentPlan,
+      nextPlan: nextWeekPlan,
+      tripFocus: "CURRENT",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-1",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-pasta",
+            displayName: "Pasta",
+            id: "section-2",
+            sortOrder: 2,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.effectiveTripFocus).toBe("CURRENT");
+    expect(result.canFocusNext).toBe(true);
+    expect(result.includedMealPlans).toEqual([
+      {
+        id: "meal-plan-1",
+        status: "DRAFT",
+        title: "Denne uken",
+      },
+    ]);
+    expect(result.mealPlan.id).toBe("meal-plan-1");
+    expect(
+      result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name)),
+    ).toEqual(["Wraps"]);
+  });
+
+  it("limits store mode to the next meal plan for NEXT trip focus", async () => {
+    const currentPlan = {
+      activeShoppingDate: new Date("2026-05-14T00:00:00.000Z"),
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-17T00:00:00.000Z"),
+          id: "entry-1",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-1",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-bakery", name: "Brod" },
+                categoryId: "category-bakery",
+                displayName: "Wraps",
+                id: "ingredient-1",
+                ingredientId: "canonical-wraps",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "pk",
+              },
+            ],
+            title: "Tacofredag",
+          },
+          recipeId: "recipe-1",
+        },
+      ],
+      id: "meal-plan-1",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-12T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Denne uken",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    };
+    const nextWeekPlan = {
+      activeShoppingDate: new Date("2026-05-19T00:00:00.000Z"),
+      endDate: new Date("2026-05-25T00:00:00.000Z"),
+      entries: [
+        {
+          date: new Date("2026-05-19T00:00:00.000Z"),
+          id: "entry-2",
+          mealType: "DINNER",
+          recipe: {
+            id: "recipe-2",
+            ingredients: [
+              {
+                amount: "1",
+                category: { id: "category-pasta", name: "Pasta" },
+                categoryId: "category-pasta",
+                displayName: "Spaghetti",
+                id: "ingredient-2",
+                ingredientId: "canonical-spaghetti",
+                preferredStore: null,
+                preferredStoreId: null,
+                sortOrder: 1,
+                unit: "pk",
+              },
+            ],
+            title: "Pasta mandag",
+          },
+          recipeId: "recipe-2",
+        },
+      ],
+      id: "meal-plan-2",
+      manualShoppingItems: [],
+      shoppingOverrides: [],
+      startDate: new Date("2026-05-19T00:00:00.000Z"),
+      status: "APPROVED",
+      title: "Neste uke",
+      updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+    };
+
+    registerStoreModePlans(currentPlan, [nextWeekPlan], {
+      coveringPlan: currentPlan,
+      nextPlan: nextWeekPlan,
+      tripFocus: "NEXT",
+    });
+    dbMock.store.findMany.mockResolvedValue([
+      {
+        familyId: null,
+        id: "store-1",
+        name: "Coop Mega",
+        sections: [
+          {
+            categoryId: "category-bakery",
+            displayName: "Brod",
+            id: "section-1",
+            sortOrder: 1,
+          },
+          {
+            categoryId: "category-pasta",
+            displayName: "Pasta",
+            id: "section-2",
+            sortOrder: 2,
+          },
+        ],
+      },
+    ]);
+
+    const result = await getMealPlanStoreModeData({
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+
+    expect(result.effectiveTripFocus).toBe("NEXT");
+    expect(result.includedMealPlans).toEqual([
+      {
+        id: "meal-plan-2",
+        status: "APPROVED",
+        title: "Neste uke",
+      },
+    ]);
+    expect(result.mealPlan.id).toBe("meal-plan-2");
+    expect(result.activeShoppingDate).toEqual(
+      new Date("2026-05-19T00:00:00.000Z"),
+    );
+    expect(
+      result.dueSectionGroups.flatMap((section) => section.items.map((item) => item.name)),
+    ).toEqual(["Spaghetti"]);
   });
 
   it("dedupes meal-plan items against family items in merged store mode", async () => {

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -5,7 +5,10 @@ import { requireFamilyMembership } from "./family.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import {
   findMealPlanCoveringDate,
+  resolveEffectiveStoreModeTripFocus,
   resolveStoreModeAnchorMealPlan,
+  resolveStoreModeNextMealPlan,
+  selectMealPlansForTripFocus,
 } from "./meal-plan-for-date.server";
 import {
   getMealPlanDateRange,
@@ -17,7 +20,6 @@ import {
   isStockIngredientMatch,
   type FamilyStockMatchSet,
 } from "./stock.server";
-
 const storeSummarySelect = Prisma.validator<Prisma.StoreSelect>()({
   id: true,
   name: true,
@@ -873,7 +875,8 @@ export async function getMealPlanStoreModeData({
     stores,
     selectedStorePreference,
     stockMatchSet,
-    familyMealPlanDateRanges,
+    coveringMealPlan,
+    nextMealPlan,
   ] = await Promise.all([
     db.mealPlan.findFirst({
       select: shoppingMealPlanSelect,
@@ -902,6 +905,7 @@ export async function getMealPlanStoreModeData({
     db.userStorePreference.findUnique({
       select: {
         selectedStoreId: true,
+        storeModeTripFocus: true,
       },
       where: {
         userId_familyId: {
@@ -911,15 +915,13 @@ export async function getMealPlanStoreModeData({
       },
     }),
     getFamilyStockMatchSet(familyId),
-    db.mealPlan.findMany({
-      orderBy: [{ startDate: "asc" }, { id: "asc" }],
-      select: {
-        endDate: true,
-        startDate: true,
-      },
-      where: {
-        familyId,
-      },
+    findMealPlanCoveringDate({
+      familyId,
+      referenceDate: todayAtUtcMidnight,
+    }),
+    resolveStoreModeNextMealPlan({
+      familyId,
+      referenceDate: todayAtUtcMidnight,
     }),
   ]);
 
@@ -930,12 +932,25 @@ export async function getMealPlanStoreModeData({
     });
   }
 
-  const mealPlansForStoreMode = ensureAnchorMealPlanIncluded({
-    anchorMealPlan,
-    includedMealPlans,
+  const savedTripFocus = selectedStorePreference?.storeModeTripFocus ?? "CURRENT";
+  const canFocusNext = nextMealPlan !== null;
+  const effectiveTripFocus = resolveEffectiveStoreModeTripFocus({
+    canFocusNext,
+    tripFocus: savedTripFocus,
   });
+  const mealPlansForStoreMode = selectMealPlansForTripFocus({
+    anchorPlan: anchorMealPlan,
+    currentPlanId: coveringMealPlan?.id ?? null,
+    focus: effectiveTripFocus,
+    nextPlanId: nextMealPlan?.id ?? null,
+    openPlans: includedMealPlans,
+  });
+  const shoppingDateOwnerPlan =
+    effectiveTripFocus === "ALL"
+      ? anchorMealPlan
+      : (mealPlansForStoreMode[0] ?? anchorMealPlan);
   const activeShoppingDate =
-    anchorMealPlan.activeShoppingDate ?? anchorMealPlan.startDate;
+    shoppingDateOwnerPlan.activeShoppingDate ?? shoppingDateOwnerPlan.startDate;
   const selectedStore = resolveSelectedStoreSummary(
     stores,
     selectedStorePreference?.selectedStoreId ?? null,
@@ -999,14 +1014,20 @@ export async function getMealPlanStoreModeData({
         storeSectionsByStoreId,
       ),
   );
+  const focusedDateRanges = mealPlansForStoreMode.map((plan) => ({
+    endDate: plan.endDate,
+    startDate: plan.startDate,
+  }));
 
   return {
     activeShoppingDate,
+    canFocusNext,
     dueSectionGroups: buildStoreModeSectionGroups({
       items: mergedDueItems,
       selectedStore,
       storeSectionsByStoreId,
     }),
+    effectiveTripFocus,
     family: {
       id: membership.family.id,
       name: membership.family.name,
@@ -1017,21 +1038,17 @@ export async function getMealPlanStoreModeData({
       title: plan.title,
     })),
     laterItems,
-    mealPlan: anchorMealPlan,
+    mealPlan: shoppingDateOwnerPlan,
     progress: buildStoreModeProgress(mergedDueItems),
     selectedStore,
     stores: stores.map((store) => ({
       id: store.id,
       name: store.name,
     })),
+    tripFocus: savedTripFocus,
     userRole: membership.role,
-    selectableShoppingDates: unionMealPlanDateRanges(familyMealPlanDateRanges),
-    visibleDates: unionMealPlanDateRanges(
-      mealPlansForStoreMode.map((plan) => ({
-        endDate: plan.endDate,
-        startDate: plan.startDate,
-      })),
-    ),
+    selectableShoppingDates: unionMealPlanDateRanges(focusedDateRanges),
+    visibleDates: unionMealPlanDateRanges(focusedDateRanges),
   };
 }
 
@@ -1389,26 +1406,6 @@ function projectManualShoppingItems({
       stores,
     }),
   );
-}
-
-function ensureAnchorMealPlanIncluded({
-  anchorMealPlan,
-  includedMealPlans,
-}: {
-  anchorMealPlan: ShoppingMealPlan;
-  includedMealPlans: ShoppingMealPlan[];
-}) {
-  if (includedMealPlans.some((plan) => plan.id === anchorMealPlan.id)) {
-    return includedMealPlans;
-  }
-
-  return [...includedMealPlans, anchorMealPlan].sort((left, right) => {
-    if (left.startDate.getTime() !== right.startDate.getTime()) {
-      return left.startDate.getTime() - right.startDate.getTime();
-    }
-
-    return left.id.localeCompare(right.id, "nb");
-  });
 }
 
 function buildStoreModeItemsForPlan({

--- a/app/lib/store-mode-theme.test.ts
+++ b/app/lib/store-mode-theme.test.ts
@@ -6,6 +6,7 @@ import {
   storeModeBottomChromeShellClass,
   storeModeMetaDateSelectClass,
   storeModeMetaStoreSelectClass,
+  storeModeMetaTripFocusSelectClass,
   storeModeSelectClass,
   storeModeSyncOverlayShellClass,
   storeModeUndoBarActionClass,
@@ -40,6 +41,7 @@ describe("store-mode-theme", () => {
     expect(storeModeMetaStoreSelectClass).toContain("w-auto");
     expect(storeModeMetaStoreSelectClass).not.toContain("w-full");
     expect(storeModeMetaDateSelectClass).toContain("max-w-[9rem]");
+    expect(storeModeMetaTripFocusSelectClass).toContain("max-w-[10rem]");
     expect(storeModeSelectClass).toContain("w-full");
   });
 

--- a/app/lib/store-mode-theme.ts
+++ b/app/lib/store-mode-theme.ts
@@ -31,6 +31,8 @@ export const storeModeMetaStoreSelectClass = `${storeModeMetaSelectBase} max-w-[
 
 export const storeModeMetaDateSelectClass = `${storeModeMetaSelectBase} max-w-[9rem]`;
 
+export const storeModeMetaTripFocusSelectClass = `${storeModeMetaSelectBase} max-w-[10rem]`;
+
 export const storeModeCountChipClass =
   "rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600";
 

--- a/app/lib/store-mode-trip-focus-write.server.test.ts
+++ b/app/lib/store-mode-trip-focus-write.server.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, requireFamilyMembershipMock } = vi.hoisted(() => ({
+  dbMock: {
+    userStorePreference: {
+      upsert: vi.fn(),
+    },
+  },
+  requireFamilyMembershipMock: vi.fn(),
+}));
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+import {
+  parseStoreModeTripFocus,
+  updateStoreModeTripFocus,
+} from "./store-mode-trip-focus-write.server";
+
+describe("store-mode-trip-focus-write.server", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses valid trip focus values", () => {
+    expect(parseStoreModeTripFocus("CURRENT")).toBe("CURRENT");
+    expect(parseStoreModeTripFocus("NEXT")).toBe("NEXT");
+    expect(parseStoreModeTripFocus("ALL")).toBe("ALL");
+    expect(parseStoreModeTripFocus("INVALID")).toBeNull();
+  });
+
+  it("upserts the trip focus for the user and family", async () => {
+    requireFamilyMembershipMock.mockResolvedValue({
+      family: { id: "family-1", name: "Solberg" },
+      role: "ADMIN",
+    });
+
+    const result = await updateStoreModeTripFocus({
+      familyId: "family-1",
+      tripFocus: "NEXT",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "UPDATED" });
+    expect(dbMock.userStorePreference.upsert).toHaveBeenCalledWith({
+      create: {
+        familyId: "family-1",
+        storeModeTripFocus: "NEXT",
+        userId: "user-1",
+      },
+      update: {
+        storeModeTripFocus: "NEXT",
+      },
+      where: {
+        userId_familyId: {
+          familyId: "family-1",
+          userId: "user-1",
+        },
+      },
+    });
+  });
+});

--- a/app/lib/store-mode-trip-focus-write.server.ts
+++ b/app/lib/store-mode-trip-focus-write.server.ts
@@ -1,0 +1,65 @@
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import {
+  STORE_MODE_TRIP_FOCUS_VALUES,
+  type StoreModeTripFocusValue,
+} from "./meal-plan-for-date.server";
+
+const validTripFocusValues = new Set<StoreModeTripFocusValue>(
+  STORE_MODE_TRIP_FOCUS_VALUES,
+);
+
+export function parseStoreModeTripFocus(
+  value: FormDataEntryValue | null,
+): StoreModeTripFocusValue | null {
+  const normalized = String(value ?? "").trim();
+
+  if (validTripFocusValues.has(normalized as StoreModeTripFocusValue)) {
+    return normalized as StoreModeTripFocusValue;
+  }
+
+  return null;
+}
+
+export async function updateStoreModeTripFocus({
+  familyId,
+  tripFocus,
+  userId,
+}: {
+  familyId: string;
+  tripFocus: StoreModeTripFocusValue;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  if (!validTripFocusValues.has(tripFocus)) {
+    return {
+      formError: "Ugyldig fokus for butikkmodus.",
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  await db.userStorePreference.upsert({
+    create: {
+      familyId,
+      storeModeTripFocus: tripFocus,
+      userId,
+    },
+    update: {
+      storeModeTripFocus: tripFocus,
+    },
+    where: {
+      userId_familyId: {
+        familyId,
+        userId,
+      },
+    },
+  });
+
+  return {
+    status: "UPDATED" as const,
+  };
+}

--- a/app/lib/store-mode-trip-focus.server.test.ts
+++ b/app/lib/store-mode-trip-focus.server.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock } = vi.hoisted(() => ({
+  dbMock: {
+    userStorePreference: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+import { getStoreModeTripFocus } from "./store-mode-trip-focus.server";
+
+describe("store-mode-trip-focus.server", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns CURRENT when no preference row exists", async () => {
+    dbMock.userStorePreference.findUnique.mockResolvedValue(null);
+
+    await expect(
+      getStoreModeTripFocus({
+        familyId: "family-1",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("CURRENT");
+  });
+
+  it("returns the saved trip focus", async () => {
+    dbMock.userStorePreference.findUnique.mockResolvedValue({
+      storeModeTripFocus: "ALL",
+    });
+
+    await expect(
+      getStoreModeTripFocus({
+        familyId: "family-1",
+        userId: "user-1",
+      }),
+    ).resolves.toBe("ALL");
+  });
+});

--- a/app/lib/store-mode-trip-focus.server.ts
+++ b/app/lib/store-mode-trip-focus.server.ts
@@ -1,0 +1,24 @@
+import { db } from "./db.server";
+import type { StoreModeTripFocusValue } from "./meal-plan-for-date.server";
+
+export async function getStoreModeTripFocus({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}): Promise<StoreModeTripFocusValue> {
+  const preference = await db.userStorePreference.findUnique({
+    select: {
+      storeModeTripFocus: true,
+    },
+    where: {
+      userId_familyId: {
+        familyId,
+        userId,
+      },
+    },
+  });
+
+  return preference?.storeModeTripFocus ?? "CURRENT";
+}

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -61,6 +61,13 @@ vi.mock("../lib/store-write.server", () => {
   };
 });
 
+vi.mock("../lib/store-mode-trip-focus-write.server", () => {
+  return {
+    parseStoreModeTripFocus: vi.fn(),
+    updateStoreModeTripFocus: vi.fn(),
+  };
+});
+
 import {
   createQuickFamilyShoppingItem,
   parseFamilyShoppingItemValues,
@@ -85,6 +92,10 @@ import {
   updateManualShoppingItem,
 } from "../lib/shopping-write.server";
 import { listIngredientCategories } from "../lib/store.server";
+import {
+  parseStoreModeTripFocus,
+  updateStoreModeTripFocus,
+} from "../lib/store-mode-trip-focus-write.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
 import { action, loader } from "./family-meal-plan-store-mode";
 
@@ -216,6 +227,9 @@ describe("family store mode route", () => {
         id: "store-1",
         name: "Meny",
       },
+      canFocusNext: true,
+      effectiveTripFocus: "CURRENT",
+      tripFocus: "CURRENT",
       stores: [
         {
           id: "store-1",
@@ -287,6 +301,9 @@ describe("family store mode route", () => {
         title: "Langhelg",
       },
     ]);
+    expect(result.tripFocus).toBe("CURRENT");
+    expect(result.effectiveTripFocus).toBe("CURRENT");
+    expect(result.canFocusNext).toBe(true);
     expect(result.dueSectionGroups[0]?.items[0]).toEqual(
       expect.objectContaining({
         firstDate: "2026-05-15",
@@ -337,6 +354,9 @@ describe("family store mode route", () => {
         id: "store-1",
         name: "Meny",
       },
+      canFocusNext: false,
+      effectiveTripFocus: "CURRENT",
+      tripFocus: "CURRENT",
       stores: [
         {
           id: "store-1",
@@ -1196,5 +1216,38 @@ describe("family store mode route", () => {
       "http://localhost/families/family-1/store-mode?notice=selected-store-updated",
     );
     expect(toggleShoppingItemChecked).not.toHaveBeenCalled();
+  });
+
+  it("redirects after updating store-mode trip focus", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(resolveStoreModeAnchorMealPlan).mockResolvedValue({
+      id: "meal-plan-1",
+    });
+    vi.mocked(parseStoreModeTripFocus).mockReturnValue("NEXT");
+    vi.mocked(updateStoreModeTripFocus).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "update-store-mode-trip-focus");
+    formData.set("tripFocus", "NEXT");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest(undefined, formData),
+    } as never);
+
+    expect(parseStoreModeTripFocus).toHaveBeenCalledWith("NEXT");
+    expect(updateStoreModeTripFocus).toHaveBeenCalledWith({
+      familyId: "family-1",
+      tripFocus: "NEXT",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/store-mode?notice=store-mode-trip-focus-updated",
+    );
   });
 });

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -74,6 +74,10 @@ import {
   updateManualShoppingItem,
 } from "../lib/shopping-write.server";
 import { listIngredientCategories } from "../lib/store.server";
+import {
+  parseStoreModeTripFocus,
+  updateStoreModeTripFocus,
+} from "../lib/store-mode-trip-focus-write.server";
 import { updateSelectedStorePreference } from "../lib/store-write.server";
 import {
   getStoreModeBannerClass,
@@ -85,6 +89,7 @@ import {
   storeModeLaterChipClass,
   storeModeMetaDateSelectClass,
   storeModeMetaStoreSelectClass,
+  storeModeMetaTripFocusSelectClass,
   storeModeMetaStripClass,
   storeModeMutedPanelClass,
   storeModePageClass,
@@ -109,7 +114,8 @@ type StoreModeNotice =
   | "active-shopping-date-updated"
   | "family-shopping-item-added"
   | "selected-store-updated"
-  | "shopping-item-check-state-updated";
+  | "shopping-item-check-state-updated"
+  | "store-mode-trip-focus-updated";
 
 type StoreModeIntent =
   | "quick-add-family-shopping-item"
@@ -120,7 +126,8 @@ type StoreModeIntent =
   | "toggle-family-shopping-item-checked"
   | "toggle-shopping-item-checked"
   | "update-active-shopping-date"
-  | "update-selected-store";
+  | "update-selected-store"
+  | "update-store-mode-trip-focus";
 
 interface StoreModeActionData {
   activeShoppingDateFieldErrors?: {
@@ -139,6 +146,10 @@ interface StoreModeActionData {
     selectedStoreId?: string;
   };
   selectedStoreValue?: string;
+  tripFocusFieldErrors?: {
+    tripFocus?: string;
+  };
+  tripFocusValue?: string;
 }
 
 interface FamilyMealPlanStoreModeRouteProps {
@@ -182,11 +193,13 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   return {
     activeShoppingDate: formatDateOnly(result.activeShoppingDate),
+    canFocusNext: result.canFocusNext,
     categories,
     dueSectionGroups: result.dueSectionGroups.map((section) => ({
       ...section,
       items: section.items.map(serializeProjectedShoppingItem),
     })),
+    effectiveTripFocus: result.effectiveTripFocus,
     family: result.family,
     includedMealPlans: result.includedMealPlans,
     laterItems: result.laterItems.map(serializeProjectedShoppingItem),
@@ -209,6 +222,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     selectableShoppingDates: result.selectableShoppingDates,
     shoppingHistory,
     stores: result.stores,
+    tripFocus: result.tripFocus,
     userRole: result.userRole,
     visibleDates: result.visibleDates,
   };
@@ -281,6 +295,44 @@ export async function action({ params, request }: Route.ActionArgs) {
     return buildFamilyStoreModeRedirect({
       familyId,
       notice: "selected-store-updated",
+      request,
+    });
+  }
+
+  if (intent === "update-store-mode-trip-focus") {
+    const tripFocus = parseStoreModeTripFocus(formData.get("tripFocus"));
+
+    if (!tripFocus) {
+      return {
+        formError: "Ugyldig fokus for butikkmodus.",
+        intent,
+        tripFocusFieldErrors: {
+          tripFocus: "Velg et gyldig fokus.",
+        },
+        tripFocusValue: String(formData.get("tripFocus") ?? ""),
+      } satisfies StoreModeActionData;
+    }
+
+    const result = await updateStoreModeTripFocus({
+      familyId,
+      tripFocus,
+      userId: user.id,
+    });
+
+    if (result.status === "VALIDATION_ERROR") {
+      return {
+        formError: result.formError,
+        intent,
+        tripFocusFieldErrors: {
+          tripFocus: result.formError,
+        },
+        tripFocusValue: tripFocus,
+      } satisfies StoreModeActionData;
+    }
+
+    return buildFamilyStoreModeRedirect({
+      familyId,
+      notice: "store-mode-trip-focus-updated",
       request,
     });
   }
@@ -614,6 +666,9 @@ export default function FamilyMealPlanStoreModeRoute({
   const isSavingShoppingDate =
     navigation.state === "submitting" &&
     pendingIntent === "update-active-shopping-date";
+  const isSavingTripFocus =
+    navigation.state === "submitting" &&
+    pendingIntent === "update-store-mode-trip-focus";
 
   useEffect(() => {
     setDueSectionGroups(
@@ -1014,6 +1069,16 @@ export default function FamilyMealPlanStoreModeRoute({
     actionData.activeShoppingDateValue
       ? actionData.activeShoppingDateValue
       : loaderData.activeShoppingDate;
+  const tripFocusValue =
+    actionData?.intent === "update-store-mode-trip-focus" &&
+    actionData.tripFocusValue
+      ? actionData.tripFocusValue
+      : loaderData.effectiveTripFocus;
+  const tripFocusSubtitle = getStoreModeTripFocusSubtitle({
+    effectiveTripFocus: loaderData.effectiveTripFocus,
+    includedMealPlans: loaderData.includedMealPlans,
+    mealPlanTitle: loaderData.mealPlan.title,
+  });
   const ingredientSearchPath = `/families/${loaderData.family.id}/shopping/ingredient-search`;
   const quantityFetcherError =
     quantityFetcher.data?.formError &&
@@ -1036,14 +1101,42 @@ export default function FamilyMealPlanStoreModeRoute({
         <section className={storeModeMetaStripClass}>
           <div className="min-w-0">
             <h1 className="truncate font-semibold text-stone-950">Butikkmodus</h1>
-            <p className="truncate text-xs text-stone-500">
-              Samlet fra {loaderData.includedMealPlans.length}{" "}
-              {loaderData.includedMealPlans.length === 1 ? "ukeplan" : "ukeplaner"}
-            </p>
+            <p className="truncate text-xs text-stone-500">{tripFocusSubtitle}</p>
           </div>
           <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
             ·
           </span>
+          <Form className="inline-flex min-w-0 flex-col gap-1" method="post">
+            <input
+              name="intent"
+              type="hidden"
+              value="update-store-mode-trip-focus"
+            />
+            <select
+              aria-busy={isSavingTripFocus}
+              aria-label="Velg handletur-fokus"
+              className={storeModeMetaTripFocusSelectClass}
+              defaultValue={tripFocusValue}
+              disabled={isSavingTripFocus}
+              key={tripFocusValue}
+              name="tripFocus"
+              onChange={(event) => {
+                submitSelectForm(event, tripFocusValue, submit);
+              }}
+            >
+              <option value="CURRENT">Denne uken</option>
+              <option disabled={!loaderData.canFocusNext} value="NEXT">
+                Neste uke
+              </option>
+              <option value="ALL">Alle åpne</option>
+            </select>
+            {actionData?.intent === "update-store-mode-trip-focus" &&
+            actionData.tripFocusFieldErrors?.tripFocus ? (
+              <p className="text-sm text-rose-600">
+                {actionData.tripFocusFieldErrors.tripFocus}
+              </p>
+            ) : null}
+          </Form>
           <Form className="inline-flex min-w-0 flex-col gap-1" method="post">
             <input name="intent" type="hidden" value="update-selected-store" />
             <select
@@ -1440,7 +1533,8 @@ function getStoreModeNotice(request: Request): StoreModeNotice | null {
     notice === "active-shopping-date-updated" ||
     notice === "family-shopping-item-added" ||
     notice === "selected-store-updated" ||
-    notice === "shopping-item-check-state-updated"
+    notice === "shopping-item-check-state-updated" ||
+    notice === "store-mode-trip-focus-updated"
   ) {
     return notice;
   }
@@ -1454,6 +1548,11 @@ function getStoreModeNoticeContent(notice: StoreModeNotice) {
       return {
         description: "Butikkvalget ditt ble lagret for denne familien.",
         title: "Butikkvalg lagret",
+      };
+    case "store-mode-trip-focus-updated":
+      return {
+        description: "Fokuset for handleturen ble oppdatert.",
+        title: "Fokus lagret",
       };
     case "active-shopping-date-updated":
       return {
@@ -1471,6 +1570,26 @@ function getStoreModeNoticeContent(notice: StoreModeNotice) {
         title: "Vare lagt til",
       };
   }
+}
+
+function getStoreModeTripFocusSubtitle({
+  effectiveTripFocus,
+  includedMealPlans,
+  mealPlanTitle,
+}: {
+  effectiveTripFocus: "CURRENT" | "NEXT" | "ALL";
+  includedMealPlans: Array<{ title: string }>;
+  mealPlanTitle: string;
+}) {
+  if (effectiveTripFocus === "ALL") {
+    return `Alle åpne ukeplaner (${includedMealPlans.length})`;
+  }
+
+  if (effectiveTripFocus === "NEXT") {
+    return `Neste uke · ${mealPlanTitle}`;
+  }
+
+  return `Denne uken · ${mealPlanTitle}`;
 }
 
 function buildFamilyStoreModeRedirect({

--- a/prisma/migrations/20260821090000_add_store_mode_trip_focus/migration.sql
+++ b/prisma/migrations/20260821090000_add_store_mode_trip_focus/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "StoreModeTripFocus" AS ENUM ('CURRENT', 'NEXT', 'ALL');
+
+-- AlterTable
+ALTER TABLE "UserStorePreference" ADD COLUMN "storeModeTripFocus" "StoreModeTripFocus" NOT NULL DEFAULT 'CURRENT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,12 @@ enum FamilyShoppingListMode {
   COMBINED
 }
 
+enum StoreModeTripFocus {
+  CURRENT
+  NEXT
+  ALL
+}
+
 enum MealPlanShareStatus {
   OPEN
   CLOSED
@@ -527,15 +533,16 @@ model StoreSection {
 }
 
 model UserStorePreference {
-  id              String   @id @default(cuid())
-  userId          String
-  familyId        String
-  selectedStoreId String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  family          Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
-  selectedStore   Store?   @relation("UserStorePreferenceSelectedStore", fields: [selectedStoreId], references: [id], onDelete: SetNull)
+  id                 String             @id @default(cuid())
+  userId             String
+  familyId           String
+  selectedStoreId    String?
+  storeModeTripFocus StoreModeTripFocus @default(CURRENT)
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
+  user               User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  family             Family             @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  selectedStore      Store?             @relation("UserStorePreferenceSelectedStore", fields: [selectedStoreId], references: [id], onDelete: SetNull)
 
   @@unique([userId, familyId])
   @@index([userId])


### PR DESCRIPTION
## Summary
- Add a persisted trip focus in Butikkmodus (Denne uken / Neste uke / Alle åpne) so shopping can stay on one meal plan plus family manuals
- Default is current week only, so planning next week no longer floods the aisle list mid-trip
- Neste uke supports Thursday shops while still calendar-inside this week; Alle åpne restores the previous multi-plan merge

## Related issue
Closes #213

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] Apply migration, open store mode with two open weeks — default hides next week
- [ ] Switch to Neste uke mid-week — only next plan (+ manuals)
- [ ] Alle åpne restores both weeks
- [ ] Handledato still works within the focused plan

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck