### PR TITLE
Share a curated shopping list via guest URL

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,35 @@
 
 ## Current Objective
 
-Ship #213 store-mode trip focus — PR opened, awaiting merge.
+Ship #217 guest shopping-list share — PR opening from `issue/217-share-shopping-list-url`.
 
 ## Completed
 
-- Trip focus control in Butikkmodus: Denne uken / Neste uke / Alle åpne
-- Persisted on `UserStorePreference.storeModeTripFocus` (default CURRENT)
-- Store-mode list filters by focus; family manuals always included
-- Validated, committed, pushed; PR with `Closes #213`
+- Store-mode **Del liste** curation (checked items excluded by default) creates an unlisted guest URL
+- Public `/s/:token` page with Rema 1000 default store, client store switch, localStorage checkoff
+- `ShoppingListShare` snapshot (hashed token + JSON); checks do not write the family list
+- `StoreModeShoppingItemCard` `readOnly` mode
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx`
-- `app/lib/shopping.server.ts`
-- `app/lib/meal-plan-for-date.server.ts`
-- `prisma/migrations/20260821090000_add_store_mode_trip_focus/migration.sql`
+- `app/lib/shopping-share.server.ts` — create/load snapshot
+- `app/routes/family-store-mode-share.tsx` — curation + copy link
+- `app/routes/shopping-list-share.tsx` — unauthenticated guest view
+- `prisma/migrations/20260821140000_add_shopping_list_share/migration.sql`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 472 tests passed
+- `npm run test:run` — 500 tests passed
 - `npm run typecheck` — passed
 
 ## Open Items
 
 - Apply migration on deploy (`prisma migrate deploy`)
-- Manual smoke after deploy: CURRENT hides next week; NEXT mid-week; Alle åpne
-- Issue #213 closes on PR merge via `Closes #213`
+- Manual smoke: store mode → curate → copy → incognito `/s/:token` → Rema order → switch store → check → reload
+- Issue #217 closes on PR merge via `Closes #217`
 
 ## Next Step
 
-Review/merge the open PR for #213.
+Review/merge the open PR for #217.

--- a/app/components/store-mode-shopping-item-card.test.tsx
+++ b/app/components/store-mode-shopping-item-card.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { StoreModeShoppingItemCard } from "./store-mode-shopping-item-card";
+import { renderWithRouter } from "../test/render-with-router";
+
+const familyItem = {
+  category: { id: "cat-dairy", name: "Meieri" },
+  checked: false,
+  collaborationVersion: "2026-05-01T12:00:00.000Z",
+  name: "Melk",
+  note: "Tine lettmelk",
+  preferredStore: null,
+  quantity: "1 l",
+  quantityLabel: "1 l",
+  sourceKey: "family-milk",
+  sourceType: "FAMILY" as const,
+};
+
+describe("StoreModeShoppingItemCard", () => {
+  it("hides edit and quick-add controls in read-only mode but still toggles", () => {
+    const onToggle = vi.fn();
+
+    renderWithRouter(
+      <StoreModeShoppingItemCard
+        item={familyItem}
+        layout="grid"
+        onToggle={onToggle}
+        readOnly
+        selectedStoreId="store-1"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Hurtiglegg til" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Sett mengde")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Endre seksjon")).not.toBeInTheDocument();
+    expect(screen.getByText("1 l")).toBeInTheDocument();
+    expect(screen.getByText("Tine lettmelk")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Marker Melk som handlet" }),
+    );
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows quick-add when not read-only", () => {
+    renderWithRouter(
+      <StoreModeShoppingItemCard
+        categories={[{ displayName: "Meieri", familyId: null, id: "cat-dairy" }]}
+        item={familyItem}
+        layout="grid"
+        onToggle={vi.fn()}
+        selectedStoreId="store-1"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Hurtiglegg til" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/store-mode-shopping-item-card.tsx
+++ b/app/components/store-mode-shopping-item-card.tsx
@@ -77,7 +77,7 @@ export type StoreModeCategoryUpdateRequest =
     };
 
 interface StoreModeShoppingItemCardProps {
-  categories: StoreCategory[];
+  categories?: StoreCategory[];
   categoryError?: string | null;
   isRecentlyAdded?: boolean;
   isSavingCategory?: boolean;
@@ -96,6 +96,7 @@ interface StoreModeShoppingItemCardProps {
     sourceType: "FAMILY" | "GENERATED";
   }) => void;
   onToggle: () => void;
+  readOnly?: boolean;
   selectedStoreId: string | undefined;
 }
 
@@ -103,7 +104,7 @@ const badgeClass = "rounded-full px-2 py-0.5 text-[11px] font-medium leading-4";
 const NOTE_SAVE_DEBOUNCE_MS = 450;
 
 export function StoreModeShoppingItemCard({
-  categories,
+  categories = [],
   categoryError = null,
   isRecentlyAdded = false,
   isSavingCategory = false,
@@ -113,6 +114,7 @@ export function StoreModeShoppingItemCard({
   onUpdateCategory,
   onUpdateQuantity,
   onToggle,
+  readOnly = false,
   selectedStoreId,
 }: StoreModeShoppingItemCardProps) {
   const quantityBadge = formatGeneratedQuantityBadge(item);
@@ -124,7 +126,8 @@ export function StoreModeShoppingItemCard({
   const [noteDraft, setNoteDraft] = useState(item.note ?? "");
   const quantityInputRef = useRef<HTMLInputElement>(null);
   const showCategoryEdit =
-    item.sourceType === "FAMILY" || item.sourceType === "MANUAL";
+    !readOnly &&
+    (item.sourceType === "FAMILY" || item.sourceType === "MANUAL");
   const savedNote = item.note ?? "";
   const hasNote = Boolean(noteDraft.trim());
   const isNoteDirty = noteDraft.trim() !== savedNote.trim();
@@ -256,7 +259,8 @@ export function StoreModeShoppingItemCard({
     ? "text-sm font-semibold leading-5 text-stone-500 line-through decoration-stone-400"
     : "text-sm font-semibold leading-5 text-stone-950";
   const showQuantityEdit =
-    item.sourceType === "FAMILY" || item.sourceType === "GENERATED";
+    !readOnly &&
+    (item.sourceType === "FAMILY" || item.sourceType === "GENERATED");
 
   useEffect(() => {
     if (!isQuantityModalOpen) {
@@ -332,7 +336,7 @@ export function StoreModeShoppingItemCard({
                 Foretrekker {item.preferredStore.name}
               </span>
             ) : null}
-            {hasNote ? (
+            {hasNote && !readOnly ? (
               <button
                 aria-expanded={isDetailsOpen}
                 aria-label={
@@ -347,13 +351,19 @@ export function StoreModeShoppingItemCard({
                 }}
                 type="button"
               >
-                <StoreModeNoteIcon className="h-3 w-3" />
+                <StoreModeNoteIcon className="h-3.5 w-3.5" />
                 Notat
               </button>
             ) : null}
           </span>
+          {readOnly && item.note ? (
+            <p className="mt-1 break-words text-xs leading-4 text-stone-600">
+              {item.note}
+            </p>
+          ) : null}
         </div>
 
+        {readOnly ? null : (
         <details
           className="group mt-auto flex w-7 min-w-7 flex-col-reverse items-stretch self-start pointer-events-auto open:w-1/2 open:min-w-[50%] open:max-w-full"
           onToggle={(event) => {
@@ -439,6 +449,7 @@ export function StoreModeShoppingItemCard({
             ) : null}
           </div>
         </details>
+        )}
       </div>
 
       {isQuantityModalOpen &&

--- a/app/lib/shopping-section-groups.test.ts
+++ b/app/lib/shopping-section-groups.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  groupSharedShoppingItemsByStore,
+  resolveDefaultSharedStoreId,
+} from "./shopping-section-groups";
+
+const produceSection = {
+  categoryId: "cat-produce",
+  displayName: "Frukt og grønt",
+  sortOrder: 1,
+};
+
+const dairySection = {
+  categoryId: "cat-dairy",
+  displayName: "Meieri",
+  sortOrder: 0,
+};
+
+const items = [
+  {
+    categoryId: "cat-produce",
+    categoryName: "Frukt og grønt",
+    id: "GENERATED:paprika",
+    name: "Paprika",
+    note: null,
+    quantityLabel: "2 stk",
+  },
+  {
+    categoryId: "cat-dairy",
+    categoryName: "Meieri",
+    id: "FAMILY:milk",
+    name: "Melk",
+    note: null,
+    quantityLabel: "1 l",
+  },
+];
+
+describe("shopping-section-groups", () => {
+  it("resolves Rema 1000 as the default store when present", () => {
+    expect(
+      resolveDefaultSharedStoreId([
+        { id: "kiwi", name: "Kiwi" },
+        { id: "rema", name: "Rema 1000" },
+      ]),
+    ).toBe("rema");
+  });
+
+  it("falls back to the first store when Rema 1000 is missing", () => {
+    expect(
+      resolveDefaultSharedStoreId([
+        { id: "meny", name: "Meny" },
+        { id: "kiwi", name: "Kiwi" },
+      ]),
+    ).toBe("meny");
+  });
+
+  it("returns null when there are no stores", () => {
+    expect(resolveDefaultSharedStoreId([])).toBeNull();
+  });
+
+  it("groups items by the selected store section order", () => {
+    const groups = groupSharedShoppingItemsByStore({
+      items,
+      selectedStoreId: "rema",
+      stores: [
+        {
+          id: "rema",
+          name: "Rema 1000",
+          sections: [produceSection, dairySection],
+        },
+      ],
+    });
+
+    expect(groups.map((group) => group.displayName)).toEqual([
+      "Meieri",
+      "Frukt og grønt",
+    ]);
+    expect(groups[0]?.items.map((item) => item.name)).toEqual(["Melk"]);
+    expect(groups[1]?.items.map((item) => item.name)).toEqual(["Paprika"]);
+  });
+
+  it("falls back to category name when the store has no matching section", () => {
+    const groups = groupSharedShoppingItemsByStore({
+      items,
+      selectedStoreId: "unknown",
+      stores: [],
+    });
+
+    expect(groups.map((group) => group.displayName).sort()).toEqual([
+      "Frukt og grønt",
+      "Meieri",
+    ]);
+  });
+});

--- a/app/lib/shopping-section-groups.ts
+++ b/app/lib/shopping-section-groups.ts
@@ -1,0 +1,105 @@
+export const DEFAULT_SHARED_STORE_NAME = "Rema 1000";
+
+export interface SharedShoppingSnapshotItem {
+  categoryId: string;
+  categoryName: string;
+  id: string;
+  name: string;
+  note: string | null;
+  quantityLabel: string | null;
+}
+
+export interface SharedShoppingSnapshotStoreSection {
+  categoryId: string;
+  displayName: string;
+  sortOrder: number;
+}
+
+export interface SharedShoppingSnapshotStore {
+  id: string;
+  name: string;
+  sections: SharedShoppingSnapshotStoreSection[];
+}
+
+export interface SharedShoppingSnapshot {
+  items: SharedShoppingSnapshotItem[];
+  stores: SharedShoppingSnapshotStore[];
+}
+
+export interface SharedShoppingSectionGroup {
+  category: {
+    id: string;
+    name: string;
+  };
+  displayName: string;
+  items: SharedShoppingSnapshotItem[];
+}
+
+export function resolveDefaultSharedStoreId(
+  stores: Array<{ id: string; name: string }>,
+): string | null {
+  if (stores.length === 0) {
+    return null;
+  }
+
+  const rematch = stores.find(
+    (store) =>
+      store.name.trim().toLocaleLowerCase("nb") ===
+      DEFAULT_SHARED_STORE_NAME.toLocaleLowerCase("nb"),
+  );
+
+  return rematch?.id ?? stores[0]?.id ?? null;
+}
+
+export function groupSharedShoppingItemsByStore({
+  items,
+  selectedStoreId,
+  stores,
+}: {
+  items: SharedShoppingSnapshotItem[];
+  selectedStoreId: string | null;
+  stores: SharedShoppingSnapshotStore[];
+}): SharedShoppingSectionGroup[] {
+  const selectedStore =
+    stores.find((store) => store.id === selectedStoreId) ?? null;
+  const sectionsByCategoryId = new Map(
+    (selectedStore?.sections ?? []).map((section) => [section.categoryId, section]),
+  );
+  const groups = new Map<
+    string,
+    SharedShoppingSectionGroup & { sortOrder: number }
+  >();
+
+  for (const item of items) {
+    const section = sectionsByCategoryId.get(item.categoryId);
+    const displayName = section?.displayName ?? item.categoryName;
+    const sortOrder = section?.sortOrder ?? Number.MAX_SAFE_INTEGER;
+    const groupKey = `${item.categoryId}:${displayName}`;
+    const existing = groups.get(groupKey);
+
+    if (existing) {
+      existing.items.push(item);
+      continue;
+    }
+
+    groups.set(groupKey, {
+      category: {
+        id: item.categoryId,
+        name: item.categoryName,
+      },
+      displayName,
+      items: [item],
+      sortOrder,
+    });
+  }
+
+  return [...groups.values()]
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) {
+        return left.sortOrder - right.sortOrder;
+      }
+
+      return left.displayName.localeCompare(right.displayName, "nb");
+    })
+    .map(({ sortOrder: _sortOrder, ...group }) => group);
+}

--- a/app/lib/shopping-share-client.test.ts
+++ b/app/lib/shopping-share-client.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildShoppingShareChecksStorageKey,
+  buildShoppingShareStoreStorageKey,
+  readShoppingShareCheckedIds,
+  readShoppingShareSelectedStoreId,
+  writeShoppingShareCheckedIds,
+  writeShoppingShareSelectedStoreId,
+} from "./shopping-share-client";
+
+const token = "share-token-1";
+const checksKey = buildShoppingShareChecksStorageKey(token);
+const storeKey = buildShoppingShareStoreStorageKey(token);
+
+describe("shopping-share-client", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("builds isolated storage keys per token", () => {
+    expect(buildShoppingShareChecksStorageKey("a")).not.toBe(
+      buildShoppingShareChecksStorageKey("b"),
+    );
+    expect(buildShoppingShareStoreStorageKey("a")).not.toBe(
+      buildShoppingShareStoreStorageKey("b"),
+    );
+  });
+
+  it("persists and reads checked ids", () => {
+    writeShoppingShareCheckedIds(checksKey, ["FAMILY:milk", "GENERATED:eggs"]);
+
+    expect(readShoppingShareCheckedIds(checksKey)).toEqual([
+      "FAMILY:milk",
+      "GENERATED:eggs",
+    ]);
+  });
+
+  it("clears storage when the checked list is empty", () => {
+    writeShoppingShareCheckedIds(checksKey, ["FAMILY:milk"]);
+    writeShoppingShareCheckedIds(checksKey, []);
+
+    expect(window.localStorage.getItem(checksKey)).toBeNull();
+    expect(readShoppingShareCheckedIds(checksKey)).toEqual([]);
+  });
+
+  it("returns an empty list for corrupt checked JSON", () => {
+    window.localStorage.setItem(checksKey, "{not-json");
+
+    expect(readShoppingShareCheckedIds(checksKey)).toEqual([]);
+  });
+
+  it("persists and reads the selected store", () => {
+    writeShoppingShareSelectedStoreId(storeKey, "store-rema");
+
+    expect(readShoppingShareSelectedStoreId(storeKey)).toBe("store-rema");
+  });
+
+  it("returns null for a missing selected store", () => {
+    expect(readShoppingShareSelectedStoreId(storeKey)).toBeNull();
+  });
+});

--- a/app/lib/shopping-share-client.ts
+++ b/app/lib/shopping-share-client.ts
@@ -1,0 +1,89 @@
+const SHARE_CHECKS_KEY_PREFIX = "mealplanner:shopping-share-checks:v1";
+const SHARE_STORE_KEY_PREFIX = "mealplanner:shopping-share-store:v1";
+
+export function buildShoppingShareChecksStorageKey(token: string) {
+  return `${SHARE_CHECKS_KEY_PREFIX}:${token}`;
+}
+
+export function buildShoppingShareStoreStorageKey(token: string) {
+  return `${SHARE_STORE_KEY_PREFIX}:${token}`;
+}
+
+export function readShoppingShareCheckedIds(storageKey: string): string[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+
+    if (!raw) {
+      return [];
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter((value): value is string => typeof value === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function writeShoppingShareCheckedIds(
+  storageKey: string,
+  checkedIds: string[],
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (checkedIds.length === 0) {
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+
+    window.localStorage.setItem(storageKey, JSON.stringify(checkedIds));
+  } catch {
+    // Private mode or quota exceeded — in-session state still works.
+  }
+}
+
+export function readShoppingShareSelectedStoreId(
+  storageKey: string,
+): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+
+    if (!raw || raw.trim().length === 0) {
+      return null;
+    }
+
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function writeShoppingShareSelectedStoreId(
+  storageKey: string,
+  storeId: string,
+) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(storageKey, storeId);
+  } catch {
+    // Private mode or quota exceeded — in-session state still works.
+  }
+}

--- a/app/lib/shopping-share.server.test.ts
+++ b/app/lib/shopping-share.server.test.ts
@@ -1,0 +1,272 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  dbMock,
+  getFamilyStoreModeDataMock,
+  listScopedStoresMock,
+  loadFamilyShoppingItemsMock,
+  randomBytesMock,
+  requireFamilyMembershipMock,
+} = vi.hoisted(() => {
+  return {
+    dbMock: {
+      shoppingListShare: {
+        create: vi.fn(),
+        findUnique: vi.fn(),
+      },
+    },
+    getFamilyStoreModeDataMock: vi.fn(),
+    listScopedStoresMock: vi.fn(),
+    loadFamilyShoppingItemsMock: vi.fn(),
+    randomBytesMock: vi.fn(),
+    requireFamilyMembershipMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyMembership: requireFamilyMembershipMock,
+}));
+
+vi.mock("./shopping.server", () => ({
+  getFamilyStoreModeData: getFamilyStoreModeDataMock,
+  loadFamilyShoppingItems: loadFamilyShoppingItemsMock,
+}));
+
+vi.mock("./store.server", () => ({
+  listScopedStores: listScopedStoresMock,
+}));
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+
+  return {
+    ...actual,
+    randomBytes: randomBytesMock,
+  };
+});
+
+import {
+  createShoppingListShare,
+  getShoppingListShareByToken,
+  getShoppingShareCurationData,
+  hashShoppingListShareToken,
+} from "./shopping-share.server";
+
+const RAW_TOKEN = "a".repeat(64);
+const TOKEN_HASH = createHash("sha256").update(RAW_TOKEN).digest("hex");
+
+const pendingItem = {
+  category: { id: "cat-produce", name: "Frukt og grønt" },
+  checked: false,
+  collaborationVersion: "",
+  mealPlanId: "meal-plan-1",
+  mealPlanTitle: "Langhelg",
+  name: "Paprika",
+  note: null,
+  preferredStore: { id: "store-1", name: "Meny" },
+  quantityLabel: "1 stk",
+  section: { displayName: "Frukt og grønt", sortOrder: 1 },
+  sourceKey: "entry-1:ingredient-1",
+  sourceType: "GENERATED" as const,
+  amount: "1",
+  firstDate: new Date("2026-05-15T00:00:00.000Z"),
+  lastDate: new Date("2026-05-15T00:00:00.000Z"),
+  occurrenceCount: 1,
+  occurrences: [],
+  postponedUntilDate: null,
+  preferredStoreConflict: false,
+  quantity: null,
+  recipeCount: 1,
+  unit: "stk",
+};
+
+const checkedGeneratedItem = {
+  ...pendingItem,
+  checked: true,
+  name: "Løk",
+  sourceKey: "entry-1:ingredient-2",
+};
+
+const membership = {
+  family: { id: "family-1", joinCode: "ABC123", name: "Solberg" },
+  familyId: "family-1",
+  role: "ADMIN",
+  userId: "user-1",
+};
+
+function mockStoreModeData() {
+  getFamilyStoreModeDataMock.mockResolvedValue({
+    dueSectionGroups: [
+      {
+        category: { id: "cat-produce", name: "Frukt og grønt" },
+        displayName: "Frukt og grønt",
+        items: [pendingItem, checkedGeneratedItem],
+      },
+    ],
+    family: { id: "family-1", name: "Solberg" },
+  });
+}
+
+describe("shopping-share.server", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires family membership and excludes checked items from pending curation", async () => {
+    requireFamilyMembershipMock.mockResolvedValue(membership);
+    mockStoreModeData();
+    loadFamilyShoppingItemsMock.mockResolvedValue([
+      {
+        category: { displayName: "Meieri", id: "cat-dairy" },
+        checked: true,
+        id: "family-milk",
+        name: "Melk",
+        note: null,
+        quantity: "1 l",
+      },
+    ]);
+
+    const result = await getShoppingShareCurationData({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyMembershipMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result?.pendingItems.map((item) => item.name)).toEqual(["Paprika"]);
+    expect(result?.alreadyCheckedItems.map((item) => item.name)).toEqual([
+      "Løk",
+      "Melk",
+    ]);
+  });
+
+  it("creates a snapshot of selected items and hashed token", async () => {
+    requireFamilyMembershipMock.mockResolvedValue(membership);
+    mockStoreModeData();
+    loadFamilyShoppingItemsMock.mockResolvedValue([]);
+    listScopedStoresMock.mockResolvedValue([
+      {
+        id: "store-rema",
+        name: "Rema 1000",
+        sections: [
+          {
+            categoryId: "cat-produce",
+            displayName: "Frukt og grønt",
+            sortOrder: 1,
+          },
+        ],
+      },
+    ]);
+    randomBytesMock.mockReturnValue(Buffer.from(RAW_TOKEN, "hex"));
+    dbMock.shoppingListShare.create.mockResolvedValue({ id: "share-1" });
+
+    const result = await createShoppingListShare({
+      familyId: "family-1",
+      selectedKeys: ["GENERATED:entry-1:ingredient-1"],
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "OK", token: RAW_TOKEN });
+    expect(dbMock.shoppingListShare.create).toHaveBeenCalledWith({
+      data: {
+        createdByUserId: "user-1",
+        familyId: "family-1",
+        snapshot: {
+          items: [
+            {
+              categoryId: "cat-produce",
+              categoryName: "Frukt og grønt",
+              id: "GENERATED:entry-1:ingredient-1",
+              name: "Paprika",
+              note: null,
+              quantityLabel: "1 stk",
+            },
+          ],
+          stores: [
+            {
+              id: "store-rema",
+              name: "Rema 1000",
+              sections: [
+                {
+                  categoryId: "cat-produce",
+                  displayName: "Frukt og grønt",
+                  sortOrder: 1,
+                },
+              ],
+            },
+          ],
+        },
+        tokenHash: TOKEN_HASH,
+      },
+    });
+  });
+
+  it("rejects creating a share with no selected items", async () => {
+    requireFamilyMembershipMock.mockResolvedValue(membership);
+
+    const result = await createShoppingListShare({
+      familyId: "family-1",
+      selectedKeys: [],
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      formError: "Velg minst én vare å dele.",
+      status: "VALIDATION_ERROR",
+    });
+    expect(dbMock.shoppingListShare.create).not.toHaveBeenCalled();
+  });
+
+  it("loads a share by hashed token", async () => {
+    dbMock.shoppingListShare.findUnique.mockResolvedValue({
+      snapshot: {
+        items: [
+          {
+            categoryId: "cat-1",
+            categoryName: "Meieri",
+            id: "FAMILY:milk",
+            name: "Melk",
+            note: null,
+            quantityLabel: "1 l",
+          },
+        ],
+        stores: [],
+      },
+    });
+
+    const result = await getShoppingListShareByToken(RAW_TOKEN);
+
+    expect(dbMock.shoppingListShare.findUnique).toHaveBeenCalledWith({
+      select: { snapshot: true },
+      where: { tokenHash: TOKEN_HASH },
+    });
+    expect(result?.snapshot.items[0]?.name).toBe("Melk");
+  });
+
+  it("returns null for an unknown token", async () => {
+    dbMock.shoppingListShare.findUnique.mockResolvedValue(null);
+
+    await expect(getShoppingListShareByToken("missing")).resolves.toBeNull();
+  });
+
+  it("returns null when the stored snapshot is invalid", async () => {
+    dbMock.shoppingListShare.findUnique.mockResolvedValue({
+      snapshot: { nope: true },
+    });
+
+    await expect(getShoppingListShareByToken(RAW_TOKEN)).resolves.toBeNull();
+  });
+});
+
+describe("hashShoppingListShareToken", () => {
+  it("hashes with sha256 hex", () => {
+    expect(hashShoppingListShareToken(RAW_TOKEN)).toBe(TOKEN_HASH);
+  });
+});

--- a/app/lib/shopping-share.server.ts
+++ b/app/lib/shopping-share.server.ts
@@ -1,0 +1,286 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { Prisma } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyMembership } from "./family.server";
+import type { SharedShoppingSnapshot } from "./shopping-section-groups";
+import {
+  buildShoppingShareItemSelectionKey,
+  parseShoppingListShareSnapshot,
+} from "./shopping-share";
+import {
+  getFamilyStoreModeData,
+  loadFamilyShoppingItems,
+  type ProjectedShoppingItem,
+} from "./shopping.server";
+import { listScopedStores } from "./store.server";
+
+export interface ShoppingShareCurationItem {
+  category: {
+    id: string;
+    name: string;
+  };
+  checked: boolean;
+  name: string;
+  note: string | null;
+  quantityLabel: string | null;
+  sourceKey: string;
+  sourceType: "FAMILY" | "GENERATED" | "MANUAL";
+}
+
+export interface ShoppingShareCurationData {
+  alreadyCheckedItems: ShoppingShareCurationItem[];
+  family: {
+    id: string;
+    name: string;
+  };
+  pendingItems: ShoppingShareCurationItem[];
+}
+
+export type CreateShoppingListShareResult =
+  | { formError: string; status: "VALIDATION_ERROR" }
+  | { status: "NOT_FOUND" }
+  | { status: "OK"; token: string };
+
+export function hashShoppingListShareToken(rawToken: string) {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+export function createShoppingListShareRawToken() {
+  return randomBytes(32).toString("hex");
+}
+
+export async function getShoppingShareCurationData({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}): Promise<ShoppingShareCurationData | null> {
+  const membership = await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+  const storeModeData = await getFamilyStoreModeData({
+    familyId,
+    userId,
+  });
+
+  if (!storeModeData) {
+    return null;
+  }
+
+  const dueItems = flattenDueItems(storeModeData.dueSectionGroups);
+  const checkedFamilyItems = await loadFamilyShoppingItems({
+    checked: true,
+    familyId,
+  });
+  const items = mergeCurationItems(dueItems, checkedFamilyItems);
+
+  return {
+    alreadyCheckedItems: items.filter((item) => item.checked),
+    family: {
+      id: membership.family.id,
+      name: membership.family.name,
+    },
+    pendingItems: items.filter((item) => !item.checked),
+  };
+}
+
+export async function createShoppingListShare({
+  familyId,
+  selectedKeys,
+  userId,
+}: {
+  familyId: string;
+  selectedKeys: string[];
+  userId: string;
+}): Promise<CreateShoppingListShareResult> {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const uniqueSelectedKeys = [...new Set(selectedKeys.filter((key) => key.length > 0))];
+
+  if (uniqueSelectedKeys.length === 0) {
+    return {
+      formError: "Velg minst én vare å dele.",
+      status: "VALIDATION_ERROR",
+    };
+  }
+
+  const storeModeData = await getFamilyStoreModeData({
+    familyId,
+    userId,
+  });
+
+  if (!storeModeData) {
+    return { status: "NOT_FOUND" };
+  }
+
+  const dueItems = flattenDueItems(storeModeData.dueSectionGroups);
+  const checkedFamilyItems = await loadFamilyShoppingItems({
+    checked: true,
+    familyId,
+  });
+  const candidates = mergeCurationItems(dueItems, checkedFamilyItems);
+  const selectedKeySet = new Set(uniqueSelectedKeys);
+  const selectedItems = candidates.filter((item) =>
+    selectedKeySet.has(
+      buildShoppingShareItemSelectionKey({
+        sourceKey: item.sourceKey,
+        sourceType: item.sourceType,
+      }),
+    ),
+  );
+
+  if (selectedItems.length === 0) {
+    return {
+      formError: "Velg minst én vare å dele.",
+      status: "VALIDATION_ERROR",
+    };
+  }
+
+  const stores = await listScopedStores(familyId);
+  const snapshot: SharedShoppingSnapshot = {
+    items: selectedItems.map((item) => ({
+      categoryId: item.category.id,
+      categoryName: item.category.name,
+      id: buildShoppingShareItemSelectionKey({
+        sourceKey: item.sourceKey,
+        sourceType: item.sourceType,
+      }),
+      name: item.name,
+      note: item.note,
+      quantityLabel: item.quantityLabel,
+    })),
+    stores: stores.map((store) => ({
+      id: store.id,
+      name: store.name,
+      sections: store.sections.map((section) => ({
+        categoryId: section.categoryId,
+        displayName: section.displayName,
+        sortOrder: section.sortOrder,
+      })),
+    })),
+  };
+  const token = createShoppingListShareRawToken();
+
+  await db.shoppingListShare.create({
+    data: {
+      createdByUserId: userId,
+      familyId,
+      snapshot: snapshot as unknown as Prisma.InputJsonValue,
+      tokenHash: hashShoppingListShareToken(token),
+    },
+  });
+
+  return {
+    status: "OK",
+    token,
+  };
+}
+
+export async function getShoppingListShareByToken(token: string) {
+  const trimmedToken = token.trim();
+
+  if (!trimmedToken) {
+    return null;
+  }
+
+  const share = await db.shoppingListShare.findUnique({
+    select: {
+      snapshot: true,
+    },
+    where: {
+      tokenHash: hashShoppingListShareToken(trimmedToken),
+    },
+  });
+
+  if (!share) {
+    return null;
+  }
+
+  const snapshot = parseShoppingListShareSnapshot(share.snapshot);
+
+  return snapshot ? { snapshot } : null;
+}
+
+function flattenDueItems(
+  dueSectionGroups: Array<{ items: ProjectedShoppingItem[] }>,
+) {
+  return dueSectionGroups.flatMap((section) => section.items);
+}
+
+function mergeCurationItems(
+  dueItems: ProjectedShoppingItem[],
+  checkedFamilyItems: Array<{
+    category: { displayName: string; id: string };
+    checked: boolean;
+    id: string;
+    name: string;
+    note: string | null;
+    quantity: string | null;
+  }>,
+): ShoppingShareCurationItem[] {
+  const dueKeys = new Set(
+    dueItems.map((item) =>
+      buildShoppingShareItemSelectionKey({
+        sourceKey: item.sourceKey,
+        sourceType: item.sourceType,
+      }),
+    ),
+  );
+  const extraFamilyItems = checkedFamilyItems
+    .filter(
+      (item) =>
+        !dueKeys.has(
+          buildShoppingShareItemSelectionKey({
+            sourceKey: item.id,
+            sourceType: "FAMILY",
+          }),
+        ),
+    )
+    .map(mapFamilyRowToCurationItem);
+
+  return [...dueItems.map(mapProjectedItemToCurationItem), ...extraFamilyItems];
+}
+
+function mapProjectedItemToCurationItem(
+  item: ProjectedShoppingItem,
+): ShoppingShareCurationItem {
+  return {
+    category: item.category,
+    checked: item.checked,
+    name: item.name,
+    note: item.note,
+    quantityLabel: item.quantityLabel,
+    sourceKey: item.sourceKey,
+    sourceType: item.sourceType,
+  };
+}
+
+function mapFamilyRowToCurationItem(item: {
+  category: { displayName: string; id: string };
+  checked: boolean;
+  id: string;
+  name: string;
+  note: string | null;
+  quantity: string | null;
+}): ShoppingShareCurationItem {
+  const quantityLabel = item.quantity?.trim() || null;
+
+  return {
+    category: {
+      id: item.category.id,
+      name: item.category.displayName,
+    },
+    checked: item.checked,
+    name: item.name,
+    note: item.note,
+    quantityLabel,
+    sourceKey: item.id,
+    sourceType: "FAMILY",
+  };
+}

--- a/app/lib/shopping-share.test.ts
+++ b/app/lib/shopping-share.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildShoppingShareItemSelectionKey,
+  parseShoppingListShareSnapshot,
+  parseShoppingShareItemSelectionKey,
+} from "./shopping-share";
+
+describe("shopping-share", () => {
+  it("builds and parses selection keys", () => {
+    const key = buildShoppingShareItemSelectionKey({
+      sourceKey: "item-1",
+      sourceType: "FAMILY",
+    });
+
+    expect(key).toBe("FAMILY:item-1");
+    expect(parseShoppingShareItemSelectionKey(key)).toEqual({
+      sourceKey: "item-1",
+      sourceType: "FAMILY",
+    });
+  });
+
+  it("parses a valid snapshot", () => {
+    const snapshot = parseShoppingListShareSnapshot({
+      items: [
+        {
+          categoryId: "cat-1",
+          categoryName: "Meieri",
+          id: "FAMILY:item-1",
+          name: "Melk",
+          note: null,
+          quantityLabel: "1 l",
+        },
+      ],
+      stores: [
+        {
+          id: "store-1",
+          name: "Rema 1000",
+          sections: [
+            {
+              categoryId: "cat-1",
+              displayName: "Meieri",
+              sortOrder: 0,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(snapshot?.items).toHaveLength(1);
+    expect(snapshot?.stores[0]?.name).toBe("Rema 1000");
+  });
+
+  it("rejects an invalid snapshot", () => {
+    expect(parseShoppingListShareSnapshot({ items: "nope" })).toBeNull();
+    expect(parseShoppingListShareSnapshot(null)).toBeNull();
+  });
+});

--- a/app/lib/shopping-share.ts
+++ b/app/lib/shopping-share.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+import type { SharedShoppingSnapshot } from "./shopping-section-groups";
+
+const sharedShoppingSnapshotItemSchema = z.object({
+  categoryId: z.string().min(1),
+  categoryName: z.string().min(1),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  note: z.string().nullable(),
+  quantityLabel: z.string().nullable(),
+});
+
+const sharedShoppingSnapshotStoreSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  sections: z.array(
+    z.object({
+      categoryId: z.string().min(1),
+      displayName: z.string().min(1),
+      sortOrder: z.number().int(),
+    }),
+  ),
+});
+
+export const shoppingListShareSnapshotSchema = z.object({
+  items: z.array(sharedShoppingSnapshotItemSchema),
+  stores: z.array(sharedShoppingSnapshotStoreSchema),
+});
+
+export function parseShoppingListShareSnapshot(
+  value: unknown,
+): SharedShoppingSnapshot | null {
+  const parsed = shoppingListShareSnapshotSchema.safeParse(value);
+
+  return parsed.success ? parsed.data : null;
+}
+
+export function buildShoppingShareItemSelectionKey({
+  sourceKey,
+  sourceType,
+}: {
+  sourceKey: string;
+  sourceType: string;
+}) {
+  return `${sourceType}:${sourceKey}`;
+}
+
+export function parseShoppingShareItemSelectionKey(value: string) {
+  const separatorIndex = value.indexOf(":");
+
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return null;
+  }
+
+  return {
+    sourceKey: value.slice(separatorIndex + 1),
+    sourceType: value.slice(0, separatorIndex),
+  };
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -8,6 +8,7 @@ export default [
   route("forgot-password", "routes/forgot-password.tsx"),
   route("reset-password", "routes/reset-password.tsx"),
   route("api/generate-recipe-description", "routes/api.generate-recipe-description.ts"),
+  route("s/:token", "routes/shopping-list-share.tsx"),
   layout("routes/app-layout.tsx", [
     route("app", "routes/app.tsx"),
     route("families/:familyId", "routes/family.tsx"),
@@ -40,6 +41,10 @@ export default [
       "routes/family-meal-plan-store-mode-redirect.ts",
     ),
     route("families/:familyId/store-mode", "routes/family-meal-plan-store-mode.tsx"),
+    route(
+      "families/:familyId/store-mode/share",
+      "routes/family-store-mode-share.tsx",
+    ),
     route("families/:familyId/shopping", "routes/family-shopping.tsx"),
     route(
       "families/:familyId/shopping/ingredient-search",

--- a/app/routes/family-meal-plan-store-mode.tsx
+++ b/app/routes/family-meal-plan-store-mode.tsx
@@ -1215,6 +1215,12 @@ export default function FamilyMealPlanStoreModeRoute({
             </Link>
             <Link
               className="text-stone-600 underline-offset-2 hover:text-stone-950 hover:underline"
+              to={`/families/${loaderData.family.id}/store-mode/share`}
+            >
+              Del liste
+            </Link>
+            <Link
+              className="text-stone-600 underline-offset-2 hover:text-stone-950 hover:underline"
               to={`/families/${loaderData.family.id}/stores`}
             >
               Butikker

--- a/app/routes/family-store-mode-share.test.ts
+++ b/app/routes/family-store-mode-share.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/shopping-share.server", () => ({
+  createShoppingListShare: vi.fn(),
+  getShoppingShareCurationData: vi.fn(),
+}));
+
+import { requireUser } from "../lib/auth.server";
+import {
+  createShoppingListShare,
+  getShoppingShareCurationData,
+} from "../lib/shopping-share.server";
+import { action, loader } from "./family-store-mode-share";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+const curation = {
+  alreadyCheckedItems: [
+    {
+      category: { id: "cat-dairy", name: "Meieri" },
+      checked: true,
+      name: "Melk",
+      note: null,
+      quantityLabel: "1 l",
+      sourceKey: "family-milk",
+      sourceType: "FAMILY" as const,
+    },
+  ],
+  family: { id: "family-1", name: "Solberg" },
+  pendingItems: [
+    {
+      category: { id: "cat-produce", name: "Frukt og grønt" },
+      checked: false,
+      name: "Paprika",
+      note: null,
+      quantityLabel: "1 stk",
+      sourceKey: "entry-1:ingredient-1",
+      sourceType: "GENERATED" as const,
+    },
+  ],
+};
+
+describe("family store mode share route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads pending items selected by default and checked items separately", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getShoppingShareCurationData).mockResolvedValue(curation);
+
+    const result = await loader({
+      params: { familyId: "family-1" },
+      request: new Request("http://localhost/families/family-1/store-mode/share"),
+    } as never);
+
+    expect(result.pendingItems).toHaveLength(1);
+    expect(result.alreadyCheckedItems[0]?.checked).toBe(true);
+  });
+
+  it("creates a share and returns an absolute guest URL", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createShoppingListShare).mockResolvedValue({
+      status: "OK",
+      token: "share-token",
+    });
+
+    const formData = new FormData();
+    formData.append("item", "GENERATED:entry-1:ingredient-1");
+
+    const result = await action({
+      params: { familyId: "family-1" },
+      request: new Request(
+        "http://localhost/families/family-1/store-mode/share",
+        { body: formData, method: "POST" },
+      ),
+    } as never);
+
+    expect(createShoppingListShare).toHaveBeenCalledWith({
+      familyId: "family-1",
+      selectedKeys: ["GENERATED:entry-1:ingredient-1"],
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      shareUrl: "http://localhost/s/share-token",
+    });
+  });
+
+  it("returns a validation error when creation is rejected", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createShoppingListShare).mockResolvedValue({
+      formError: "Velg minst én vare å dele.",
+      status: "VALIDATION_ERROR",
+    });
+
+    const result = await action({
+      params: { familyId: "family-1" },
+      request: new Request(
+        "http://localhost/families/family-1/store-mode/share",
+        { body: new FormData(), method: "POST" },
+      ),
+    } as never);
+
+    expect(result).toEqual({
+      formError: "Velg minst én vare å dele.",
+    });
+  });
+});

--- a/app/routes/family-store-mode-share.tsx
+++ b/app/routes/family-store-mode-share.tsx
@@ -1,0 +1,359 @@
+import { useEffect, useState } from "react";
+import {
+  Form,
+  Link,
+  isRouteErrorResponse,
+  redirect,
+  useNavigation,
+  type MetaFunction,
+} from "react-router";
+
+import { requireUser } from "../lib/auth.server";
+import {
+  createShoppingListShare,
+  getShoppingShareCurationData,
+  type ShoppingShareCurationItem,
+} from "../lib/shopping-share.server";
+import { buildShoppingShareItemSelectionKey } from "../lib/shopping-share";
+import {
+  storeModePageClass,
+  storeModeSectionCardClass,
+  storeModeSurfaceCardClass,
+} from "../lib/store-mode-theme";
+import type { Route } from "./+types/family-store-mode-share";
+
+interface ShareActionData {
+  formError?: string;
+  shareUrl?: string;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Del handleliste | Mealplanner" },
+    {
+      name: "description",
+      content: "Velg varer og lag en lenke du kan sende til butikken.",
+    },
+  ];
+};
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const curation = await getShoppingShareCurationData({
+    familyId,
+    userId: user.id,
+  });
+
+  if (!curation) {
+    throw redirect(`/families/${familyId}/meal-plans`);
+  }
+
+  return curation;
+}
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const formData = await request.formData();
+  const selectedKeys = formData
+    .getAll("item")
+    .map((value) => String(value).trim())
+    .filter((value) => value.length > 0);
+  const result = await createShoppingListShare({
+    familyId,
+    selectedKeys,
+    userId: user.id,
+  });
+
+  if (result.status === "NOT_FOUND") {
+    throw redirect(`/families/${familyId}/meal-plans`);
+  }
+
+  if (result.status === "VALIDATION_ERROR") {
+    return {
+      formError: result.formError,
+    } satisfies ShareActionData;
+  }
+
+  const origin = new URL(request.url).origin;
+
+  return {
+    shareUrl: `${origin}/s/${result.token}`,
+  } satisfies ShareActionData;
+}
+
+export default function FamilyStoreModeShareRoute({
+  actionData,
+  loaderData,
+}: Route.ComponentProps) {
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+
+  return (
+    <main className={storeModePageClass}>
+      <div className="mx-auto flex max-w-2xl flex-col gap-5">
+        <section className={`${storeModeSurfaceCardClass} p-6`}>
+          <p className="text-sm text-stone-500">
+            <Link
+              className="underline-offset-2 hover:text-stone-950 hover:underline"
+              to={`/families/${loaderData.family.id}/store-mode`}
+            >
+              Butikkmodus
+            </Link>
+            {" · "}
+            Del liste
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-stone-950">
+            Del handleliste
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-stone-600">
+            Fjern varer du ikke vil ha med. Allerede kryssede varer er utelatt
+            som standard. Når du oppretter lenken, fryses listen slik den er nå.
+          </p>
+        </section>
+
+        {actionData?.shareUrl ? (
+          <ShareUrlResult shareUrl={actionData.shareUrl} />
+        ) : null}
+
+        {actionData?.formError ? (
+          <p className="rounded-[28px] border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900">
+            {actionData.formError}
+          </p>
+        ) : null}
+
+        <Form className="grid gap-4" method="post">
+          <CurationSection
+            defaultSelected
+            emptyText="Ingen varer å handle akkurat nå."
+            items={loaderData.pendingItems}
+            title="Varer å handle"
+          />
+          {loaderData.alreadyCheckedItems.length > 0 ? (
+            <details className={storeModeSectionCardClass}>
+              <summary className="cursor-pointer list-none text-lg font-semibold tracking-tight text-stone-950 marker:content-none [&::-webkit-details-marker]:hidden">
+                Allerede krysset av
+                <span className="ml-2 text-sm font-medium text-stone-500">
+                  {loaderData.alreadyCheckedItems.length} varer
+                </span>
+              </summary>
+              <p className="mt-2 text-sm leading-6 text-stone-600">
+                Disse er ikke med på lenken med mindre du huker dem av.
+              </p>
+              <ul className="mt-4 grid gap-2">
+                {loaderData.alreadyCheckedItems.map((item) => (
+                  <CurationItemRow
+                    defaultSelected={false}
+                    item={item}
+                    key={buildShoppingShareItemSelectionKey({
+                      sourceKey: item.sourceKey,
+                      sourceType: item.sourceType,
+                    })}
+                  />
+                ))}
+              </ul>
+            </details>
+          ) : null}
+          <button
+            className="inline-flex min-h-11 items-center justify-center rounded-2xl bg-stone-900 px-5 py-3 text-sm font-medium text-white transition hover:bg-stone-800 disabled:cursor-wait disabled:opacity-70"
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? "Oppretter lenke..." : "Opprett lenke"}
+          </button>
+        </Form>
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi klarte ikke å laste deling av handlelisten.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke listen" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className={`${storeModePageClass} py-16`}>
+      <div className={`mx-auto max-w-2xl ${storeModeSurfaceCardClass} p-8`}>
+        <h1 className="text-2xl font-semibold text-stone-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-stone-600">{message}</p>
+        <Link
+          className="mt-6 inline-flex rounded-2xl bg-stone-900 px-5 py-3 text-sm font-medium text-white"
+          to="/app"
+        >
+          Til appen
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function CurationSection({
+  defaultSelected,
+  emptyText,
+  items,
+  title,
+}: {
+  defaultSelected: boolean;
+  emptyText: string;
+  items: ShoppingShareCurationItem[];
+  title: string;
+}) {
+  return (
+    <section className={storeModeSectionCardClass}>
+      <h2 className="text-lg font-semibold tracking-tight text-stone-950">
+        {title}
+      </h2>
+      {items.length === 0 ? (
+        <p className="mt-3 text-sm leading-6 text-stone-600">{emptyText}</p>
+      ) : (
+        <ul className="mt-4 grid gap-2">
+          {items.map((item) => (
+            <CurationItemRow
+              defaultSelected={defaultSelected}
+              item={item}
+              key={buildShoppingShareItemSelectionKey({
+                sourceKey: item.sourceKey,
+                sourceType: item.sourceType,
+              })}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function CurationItemRow({
+  defaultSelected,
+  item,
+}: {
+  defaultSelected: boolean;
+  item: ShoppingShareCurationItem;
+}) {
+  const selectionKey = buildShoppingShareItemSelectionKey({
+    sourceKey: item.sourceKey,
+    sourceType: item.sourceType,
+  });
+
+  return (
+    <li>
+      <label className="flex min-h-11 cursor-pointer items-start gap-3 rounded-2xl border border-stone-200 bg-stone-50 px-3 py-2.5">
+        <input
+          className="mt-1 size-4 shrink-0 accent-stone-900"
+          defaultChecked={defaultSelected}
+          name="item"
+          type="checkbox"
+          value={selectionKey}
+        />
+        <span className="min-w-0">
+          <span className="block text-sm font-semibold text-stone-950">
+            {item.name}
+          </span>
+          <span className="mt-0.5 block text-xs text-stone-500">
+            {[item.quantityLabel, item.category.name].filter(Boolean).join(" · ")}
+          </span>
+          {item.note ? (
+            <span className="mt-1 block text-xs text-stone-600">{item.note}</span>
+          ) : null}
+        </span>
+      </label>
+    </li>
+  );
+}
+
+function ShareUrlResult({ shareUrl }: { shareUrl: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
+    "idle",
+  );
+  const [canShare, setCanShare] = useState(false);
+
+  useEffect(() => {
+    setCanShare(typeof navigator.share === "function");
+  }, []);
+
+  return (
+    <section className={`${storeModeSurfaceCardClass} p-6`}>
+      <h2 className="text-lg font-semibold tracking-tight text-stone-950">
+        Lenken er klar
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-stone-600">
+        Send denne til den som skal handle. Listen oppdateres ikke hvis du
+        endrer handlelisten senere.
+      </p>
+      <label className="mt-4 block text-sm font-medium text-stone-700">
+        Delt lenke
+        <input
+          className="mt-1 w-full rounded-2xl border border-stone-300 bg-white px-4 py-3 text-base text-stone-900 outline-none focus:border-store-accent focus:ring-4 focus:ring-store-accent-light/60"
+          readOnly
+          value={shareUrl}
+        />
+      </label>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          className="inline-flex min-h-11 items-center justify-center rounded-2xl bg-stone-900 px-4 py-2 text-sm font-medium text-white"
+          onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(shareUrl);
+              setCopyState("copied");
+            } catch {
+              setCopyState("failed");
+            }
+          }}
+          type="button"
+        >
+          {copyState === "copied" ? "Kopiert" : "Kopier lenke"}
+        </button>
+        {canShare ? (
+          <button
+            className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-stone-300 bg-white px-4 py-2 text-sm font-medium text-stone-900"
+            onClick={() => {
+              void navigator.share({
+                text: "Handleliste",
+                title: "Handleliste",
+                url: shareUrl,
+              });
+            }}
+            type="button"
+          >
+            Del
+          </button>
+        ) : null}
+        <Link
+          className="inline-flex min-h-11 items-center justify-center rounded-2xl border border-stone-300 bg-white px-4 py-2 text-sm font-medium text-stone-900"
+          rel="noreferrer"
+          target="_blank"
+          to={new URL(shareUrl).pathname}
+        >
+          Åpne listen
+        </Link>
+      </div>
+      {copyState === "failed" ? (
+        <p className="mt-2 text-sm text-rose-700">
+          Kunne ikke kopiere. Marker lenken og kopier manuelt.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}

--- a/app/routes/shopping-list-share.test.ts
+++ b/app/routes/shopping-list-share.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/shopping-share.server", () => ({
+  getShoppingListShareByToken: vi.fn(),
+}));
+
+import { getShoppingListShareByToken } from "../lib/shopping-share.server";
+import { loader } from "./shopping-list-share";
+
+describe("shopping list share route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads a snapshot without requiring a session", async () => {
+    vi.mocked(getShoppingListShareByToken).mockResolvedValue({
+      snapshot: {
+        items: [
+          {
+            categoryId: "cat-1",
+            categoryName: "Meieri",
+            id: "FAMILY:milk",
+            name: "Melk",
+            note: null,
+            quantityLabel: "1 l",
+          },
+        ],
+        stores: [
+          {
+            id: "store-rema",
+            name: "Rema 1000",
+            sections: [],
+          },
+        ],
+      },
+    });
+
+    const result = await loader({
+      params: { token: "share-token" },
+      request: new Request("http://localhost/s/share-token"),
+    } as never);
+
+    expect(getShoppingListShareByToken).toHaveBeenCalledWith("share-token");
+    expect(result.snapshot.items[0]?.name).toBe("Melk");
+    expect(result.token).toBe("share-token");
+  });
+
+  it("returns 404 for an unknown token", async () => {
+    vi.mocked(getShoppingListShareByToken).mockResolvedValue(null);
+
+    await expect(
+      loader({
+        params: { token: "missing" },
+        request: new Request("http://localhost/s/missing"),
+      } as never),
+    ).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/app/routes/shopping-list-share.tsx
+++ b/app/routes/shopping-list-share.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useState } from "react";
+import { isRouteErrorResponse, type MetaFunction } from "react-router";
+
+import { StoreModeShoppingItemCard } from "../components/store-mode-shopping-item-card";
+import {
+  groupSharedShoppingItemsByStore,
+  resolveDefaultSharedStoreId,
+  type SharedShoppingSnapshotItem,
+} from "../lib/shopping-section-groups";
+import {
+  buildShoppingShareChecksStorageKey,
+  buildShoppingShareStoreStorageKey,
+  readShoppingShareCheckedIds,
+  readShoppingShareSelectedStoreId,
+  writeShoppingShareCheckedIds,
+  writeShoppingShareSelectedStoreId,
+} from "../lib/shopping-share-client";
+import { getShoppingListShareByToken } from "../lib/shopping-share.server";
+import {
+  partitionStoreModeSections,
+  sortStoreModeItemsByName,
+} from "../lib/shopping-store-mode-client";
+import {
+  storeModeAccentBarClass,
+  storeModeCountChipClass,
+  storeModeHandletFoldClass,
+  storeModeMetaStoreSelectClass,
+  storeModeMetaStripClass,
+  storeModePageClass,
+  storeModeProgressDotClass,
+  storeModeProgressPillClass,
+  storeModeSectionCardClass,
+  storeModeSurfaceCardClass,
+} from "../lib/store-mode-theme";
+import type { Route } from "./+types/shopping-list-share";
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Handleliste | Mealplanner" },
+    {
+      name: "description",
+      content: "Delt handleliste du kan krysse av i butikken.",
+    },
+  ];
+};
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const token = requireRouteParam(params.token, "Fant ikke listen.");
+  const share = await getShoppingListShareByToken(token);
+
+  if (!share) {
+    throw new Response("Fant ikke listen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return {
+    snapshot: share.snapshot,
+    token,
+  };
+}
+
+export default function ShoppingListShareRoute({
+  loaderData,
+}: Route.ComponentProps) {
+  const { snapshot, token } = loaderData;
+  const checksStorageKey = buildShoppingShareChecksStorageKey(token);
+  const storeStorageKey = buildShoppingShareStoreStorageKey(token);
+  const defaultStoreId = resolveDefaultSharedStoreId(snapshot.stores);
+  const [selectedStoreId, setSelectedStoreId] = useState(defaultStoreId);
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    const storedStoreId = readShoppingShareSelectedStoreId(storeStorageKey);
+    const matchingStore = snapshot.stores.some(
+      (store) => store.id === storedStoreId,
+    );
+
+    if (storedStoreId && matchingStore) {
+      setSelectedStoreId(storedStoreId);
+    }
+
+    setCheckedIds(new Set(readShoppingShareCheckedIds(checksStorageKey)));
+  }, [checksStorageKey, snapshot.stores, storeStorageKey]);
+
+  const sectionGroups = useMemo(
+    () =>
+      groupSharedShoppingItemsByStore({
+        items: snapshot.items,
+        selectedStoreId,
+        stores: snapshot.stores,
+      }).map((section) => ({
+        ...section,
+        items: section.items.map((item) => ({
+          ...item,
+          checked: checkedIds.has(item.id),
+        })),
+      })),
+    [checkedIds, selectedStoreId, snapshot.items, snapshot.stores],
+  );
+  const { activeSections } = partitionStoreModeSections(sectionGroups, true);
+  const checkedCount = checkedIds.size;
+  const totalCount = snapshot.items.length;
+
+  function handleToggle(itemId: string) {
+    setCheckedIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(itemId)) {
+        next.delete(itemId);
+      } else {
+        next.add(itemId);
+      }
+
+      writeShoppingShareCheckedIds(checksStorageKey, [...next]);
+      return next;
+    });
+  }
+
+  return (
+    <main className={storeModePageClass.replace("pb-36", "pb-8")}>
+      <div className="mx-auto flex max-w-4xl flex-col gap-5">
+        <section className={storeModeMetaStripClass}>
+          <div className="min-w-0">
+            <h1 className="truncate font-semibold text-stone-950">
+              Handleliste
+            </h1>
+            <p className="truncate text-xs text-stone-500">Delt liste</p>
+          </div>
+          {snapshot.stores.length > 0 ? (
+            <>
+              <span className="hidden text-stone-300 sm:inline" aria-hidden="true">
+                ·
+              </span>
+              <label className="inline-flex min-w-0 flex-col gap-1">
+                <span className="sr-only">Velg butikk</span>
+                <select
+                  aria-label="Velg butikk"
+                  className={storeModeMetaStoreSelectClass}
+                  onChange={(event) => {
+                    const nextStoreId = event.currentTarget.value;
+                    setSelectedStoreId(nextStoreId);
+                    writeShoppingShareSelectedStoreId(storeStorageKey, nextStoreId);
+                  }}
+                  value={selectedStoreId ?? ""}
+                >
+                  {snapshot.stores.map((store) => (
+                    <option key={store.id} value={store.id}>
+                      {store.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </>
+          ) : null}
+          <span className={storeModeProgressPillClass}>
+            <span aria-hidden="true" className={storeModeProgressDotClass} />
+            {checkedCount}/{totalCount}
+          </span>
+        </section>
+
+        {activeSections.length > 0 ? (
+          <section className="grid gap-4">
+            <h2 className="text-lg font-semibold tracking-tight text-stone-950">
+              Varer å handle
+            </h2>
+            {activeSections.map((section) => (
+              <details
+                key={`${selectedStoreId ?? "no-store"}:${section.category.id}:${section.displayName}`}
+                className={storeModeSectionCardClass}
+                open
+              >
+                <div aria-hidden="true" className={storeModeAccentBarClass} />
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 marker:content-none focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-store-accent [&::-webkit-details-marker]:hidden">
+                  <span className="text-lg font-semibold tracking-tight text-stone-950">
+                    {section.displayName}
+                  </span>
+                  <span className={storeModeCountChipClass}>
+                    {section.items.length > 0
+                      ? `${section.items.length} varer`
+                      : `${section.boughtItems.length} handlet`}
+                  </span>
+                </summary>
+                {section.items.length > 0 ? (
+                  <GuestItemGrid
+                    items={section.items}
+                    onToggle={handleToggle}
+                    selectedStoreId={selectedStoreId ?? undefined}
+                  />
+                ) : null}
+                {section.boughtItems.length > 0 ? (
+                  <details
+                    className={`${storeModeHandletFoldClass}${section.items.length > 0 ? " mt-4" : " mt-3"}`}
+                  >
+                    <summary className="flex cursor-pointer list-none items-center justify-between gap-3 marker:content-none [&::-webkit-details-marker]:hidden">
+                      <span className="text-sm font-semibold text-stone-700">
+                        Handlet
+                      </span>
+                      <span className={storeModeCountChipClass}>
+                        {section.boughtItems.length} varer
+                      </span>
+                    </summary>
+                    <GuestItemGrid
+                      items={section.boughtItems}
+                      onToggle={handleToggle}
+                      selectedStoreId={selectedStoreId ?? undefined}
+                    />
+                  </details>
+                ) : null}
+              </details>
+            ))}
+          </section>
+        ) : (
+          <section className={`${storeModeSurfaceCardClass} p-6`}>
+            <p className="text-sm leading-6 text-stone-600">
+              Denne listen er tom.
+            </p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: unknown }) {
+  let title = "Noe gikk galt";
+  let message = "Vi klarte ikke å laste den delte handlelisten.";
+
+  if (isRouteErrorResponse(error)) {
+    title = error.status === 404 ? "Fant ikke listen" : title;
+    message =
+      typeof error.data === "string" && error.data.length > 0
+        ? error.data
+        : error.statusText || message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return (
+    <main className={`${storeModePageClass.replace("pb-36", "pb-8")} py-16`}>
+      <div className={`mx-auto max-w-2xl ${storeModeSurfaceCardClass} p-8`}>
+        <h1 className="text-2xl font-semibold text-stone-950">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-stone-600">{message}</p>
+      </div>
+    </main>
+  );
+}
+
+function GuestItemGrid({
+  items,
+  onToggle,
+  selectedStoreId,
+}: {
+  items: Array<SharedShoppingSnapshotItem & { checked: boolean }>;
+  onToggle: (itemId: string) => void;
+  selectedStoreId: string | undefined;
+}) {
+  const sortedItems = sortStoreModeItemsByName(
+    items.map((item) => ({ ...item, sourceKey: item.id })),
+  );
+
+  return (
+    <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 [&>*]:min-w-0">
+      {sortedItems.map((item) => (
+        <StoreModeShoppingItemCard
+          key={item.id}
+          item={{
+            category: {
+              id: item.categoryId,
+              name: item.categoryName,
+            },
+            checked: item.checked,
+            collaborationVersion: "",
+            name: item.name,
+            note: item.note,
+            preferredStore: null,
+            quantity: item.quantityLabel,
+            quantityLabel: item.quantityLabel,
+            sourceKey: item.id,
+            sourceType: "FAMILY",
+          }}
+          layout="grid"
+          onToggle={() => onToggle(item.id)}
+          readOnly
+          selectedStoreId={selectedStoreId}
+        />
+      ))}
+    </div>
+  );
+}
+
+function requireRouteParam(value: string | undefined, message: string) {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}

--- a/prisma/migrations/20260821140000_add_shopping_list_share/migration.sql
+++ b/prisma/migrations/20260821140000_add_shopping_list_share/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "ShoppingListShare" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "createdByUserId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "snapshot" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ShoppingListShare_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ShoppingListShare_tokenHash_key" ON "ShoppingListShare"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "ShoppingListShare_familyId_createdAt_idx" ON "ShoppingListShare"("familyId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ShoppingListShare_createdByUserId_idx" ON "ShoppingListShare"("createdByUserId");
+
+-- AddForeignKey
+ALTER TABLE "ShoppingListShare" ADD CONSTRAINT "ShoppingListShare_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShoppingListShare" ADD CONSTRAINT "ShoppingListShare_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model User {
   responsibleMealPlanEntries      MealPlanEntry[]        @relation("MealPlanEntryResponsible")
   shoppingItemCheckEvents         ShoppingItemCheckEvent[] @relation("ShoppingItemCheckEventActor")
   passwordResetTokens             PasswordResetToken[]
+  createdShoppingListShares       ShoppingListShare[]      @relation("ShoppingListShareCreatedBy")
 
   @@index([displayName])
 }
@@ -131,6 +132,7 @@ model Family {
   shoppingCatalogItems FamilyShoppingCatalogItem[]
   shoppingItemCheckEvents ShoppingItemCheckEvent[]
   ingredientCategories    IngredientCategory[]
+  shoppingListShares      ShoppingListShare[]
 
   @@index([createdByUserId])
   @@index([name])
@@ -548,6 +550,21 @@ model UserStorePreference {
   @@index([userId])
   @@index([familyId])
   @@index([selectedStoreId])
+}
+
+model ShoppingListShare {
+  id              String   @id @default(cuid())
+  familyId        String
+  createdByUserId String
+  tokenHash       String   @unique
+  snapshot        Json
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  family          Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  createdByUser   User     @relation("ShoppingListShareCreatedBy", fields: [createdByUserId], references: [id], onDelete: Cascade)
+
+  @@index([familyId, createdAt])
+  @@index([createdByUserId])
 }
 
 model UserFamilyShoppingPreference {


### PR DESCRIPTION
## Summary
- From store mode, curate which items to include (already-checked items excluded by default) and create an unlisted guest link.
- Recipients open `/s/:token` without logging in, pick a store (default Rema 1000), and check items off in localStorage without changing the family list.
- Snapshot is frozen at share time; the URL token is stored hashed.

## Related issue
Closes #217

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] Apply migration (`prisma migrate deploy`) then from store mode: Del liste → deselect items → Opprett lenke
- [ ] Open the URL in a private window (no login): Rema 1000 aisle order, switch store, check items, reload (checks persist)
- [ ] Confirm family store-mode check state is unchanged

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck