### PR TITLE
Fix ICS week export for multiline recipe descriptions

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,33 @@
 
 ## Current Objective
 
-Ship #213 store-mode trip focus — PR opened, awaiting merge.
+Ship #221 ICS export fix — PR opening from `fix/ics-export-crlf-descriptions`.
 
 ## Completed
 
-- Trip focus control in Butikkmodus: Denne uken / Neste uke / Alle åpne
-- Persisted on `UserStorePreference.storeModeTripFocus` (default CURRENT)
-- Store-mode list filters by focus; family manuals always included
-- Validated, committed, pushed; PR with `Closes #213`
+- Normalized `\r\n` and `\r` to `\n` before ICS text escaping in `app/lib/calendar.server.ts`
+- Added tests that generated ICS lines contain no bare carriage returns
+- Local validation passed; issue #221 created
 
 ## Files To Read First
 
-- `app/routes/family-meal-plan-store-mode.tsx`
-- `app/lib/shopping.server.ts`
-- `app/lib/meal-plan-for-date.server.ts`
-- `prisma/migrations/20260821090000_add_store_mode_trip_focus/migration.sql`
+- `app/lib/calendar.server.ts` - ICS generation and `escapeText`
+- `app/lib/calendar.server.test.ts` - CRLF/CR description coverage
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 472 tests passed
+- `npm run test:run` — 473 tests passed
 - `npm run typecheck` — passed
+- Not verified yet in Calendar.app with a fresh download after deploy
 
 ## Open Items
 
-- Apply migration on deploy (`prisma migrate deploy`)
-- Manual smoke after deploy: CURRENT hides next week; NEXT mid-week; Alle åpne
-- Issue #213 closes on PR merge via `Closes #213`
+- Re-export a week plan after merge/deploy and open the `.ics` in macOS Calendar; meals with multiline recipe steps should import with the rest
+- Empty days (no recipe/freezer item) are still omitted by design
+- Issue #221 closes on PR merge via `Closes #221`
 
 ## Next Step
 
-Review/merge the open PR for #213.
+Review/merge the open PR for #221.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,13 +2,13 @@
 
 ## Current Objective
 
-Ship #221 ICS export fix — PR opening from `fix/ics-export-crlf-descriptions`.
+Ship #221 ICS export fix — PR opened, awaiting merge.
 
 ## Completed
 
 - Normalized `\r\n` and `\r` to `\n` before ICS text escaping in `app/lib/calendar.server.ts`
 - Added tests that generated ICS lines contain no bare carriage returns
-- Local validation passed; issue #221 created
+- Validated, committed, pushed; PR with `Closes #221`
 
 ## Files To Read First
 
@@ -21,12 +21,10 @@ Ship #221 ICS export fix — PR opening from `fix/ics-export-crlf-descriptions`.
 - `npm run lint` — passed
 - `npm run test:run` — 473 tests passed
 - `npm run typecheck` — passed
-- Not verified yet in Calendar.app with a fresh download after deploy
 
 ## Open Items
 
-- Re-export a week plan after merge/deploy and open the `.ics` in macOS Calendar; meals with multiline recipe steps should import with the rest
-- Empty days (no recipe/freezer item) are still omitted by design
+- Re-export a week plan after merge/deploy and open the `.ics` in macOS Calendar
 - Issue #221 closes on PR merge via `Closes #221`
 
 ## Next Step

--- a/app/lib/calendar.server.test.ts
+++ b/app/lib/calendar.server.test.ts
@@ -71,6 +71,34 @@ describe("calendar.server", () => {
     expect(content).toContain("UID:meal-plan-1\\\\2026-05-15");
     expect(content).toContain("DTSTART;TZID=Europe/Oslo:20260515T160000");
     expect(content).toContain("DTEND;TZID=Europe/Oslo:20260515T170000");
+    expectIcsLinesHaveNoBareCarriageReturns(content);
+  });
+
+  it("escapes CRLF and CR recipe descriptions without breaking ICS line endings", () => {
+    const content = createCalendarFile("Mealplanner - Uke 35", [
+      {
+        date: "2026-08-25",
+        description:
+          "Planlagt for tirsdag 25. august 2026 i Uke 35. 1. Salt og pepre kyllingfilter av lårfilet\r\n2. Sleng i poteter, gulrøtter, champignon og løk\r\n3. Ha i kyllingkraft",
+        title: "Middag: Kremet kyllinggryte med sopp i Crock pot",
+        uid: "meal-plan-1-2026-08-25@mealplanner",
+      },
+      {
+        date: "2026-08-26",
+        description: "Planlagt for onsdag 26. august 2026 i Uke 35. Steg 1\rSteg 2",
+        title: "Middag: Bakt laksepasta",
+        uid: "meal-plan-1-2026-08-26@mealplanner",
+      },
+    ]);
+
+    expect(content).toContain(
+      "DESCRIPTION:Planlagt for tirsdag 25. august 2026 i Uke 35. 1. Salt og pepre kyllingfilter av lårfilet\\n2. Sleng i poteter\\, gulrøtter\\, champignon og løk\\n3. Ha i kyllingkraft",
+    );
+    expect(content).toContain(
+      "DESCRIPTION:Planlagt for onsdag 26. august 2026 i Uke 35. Steg 1\\nSteg 2",
+    );
+    expect(content.match(/BEGIN:VEVENT/g)).toHaveLength(2);
+    expectIcsLinesHaveNoBareCarriageReturns(content);
   });
 
   it("exports recipe-backed and freezer-backed meal-plan dinners", async () => {
@@ -82,7 +110,7 @@ describe("calendar.server", () => {
           freezerItem: null,
           freezerItemId: null,
           recipe: {
-            description: null,
+            description: "Steg 1\r\nSteg 2",
             title: "Taco fredag",
           },
           recipeId: "recipe-1",
@@ -125,6 +153,8 @@ describe("calendar.server", () => {
     expect(result.content).toContain("SUMMARY:Middag: Taco fredag");
     expect(result.content).toContain("SUMMARY:Middag: Chili fra fryseren");
     expect(result.content).toContain("Tina i micro");
+    expect(result.content).toContain("Steg 1\\nSteg 2");
+    expectIcsLinesHaveNoBareCarriageReturns(result.content);
   });
 
   it("exports a single day as a timed dinner calendar file", async () => {
@@ -184,3 +214,9 @@ describe("calendar.server", () => {
     });
   });
 });
+
+function expectIcsLinesHaveNoBareCarriageReturns(content: string) {
+  for (const line of content.split("\r\n")) {
+    expect(line).not.toMatch(/[\r\n]/);
+  }
+}

--- a/app/lib/calendar.server.ts
+++ b/app/lib/calendar.server.ts
@@ -331,6 +331,8 @@ function formatDateTimeStamp(value: Date) {
 
 function escapeText(value: string) {
   return value
+    .replaceAll("\r\n", "\n")
+    .replaceAll("\r", "\n")
     .replaceAll("\\", "\\\\")
     .replaceAll(";", "\\;")
     .replaceAll(",", "\\,")


### PR DESCRIPTION
## Summary
- Normalize `\r\n` and `\r` in recipe text before ICS escaping so Apple Calendar imports every planned dinner
- Bare carriage returns inside `DESCRIPTION` previously broke event parsing and skipped later weekday meals

## Related issue
Closes #221

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] After deploy: export a week plan that includes recipes with numbered/multiline steps
- [ ] Open the `.ics` in macOS Calendar and confirm all planned dinners appear

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck