### PR TITLE
Autosave dinner assignments on draft meal plans

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,35 @@
 
 ## Current Objective
 
-Ship #221 ICS export fix — PR opened, awaiting merge.
+Ship #223 — autosave dinner assignments on draft meal plans. Branch `issue/223-autosave-draft-dinners` is validated and ready for PR.
 
 ## Completed
 
-- Normalized `\r\n` and `\r` to `\n` before ICS text escaping in `app/lib/calendar.server.ts`
-- Added tests that generated ICS lines contain no bare carriage returns
-- Validated, committed, pushed; PR with `Closes #221`
-- Merged `origin/main` (resolved `AGENT_HANDOFF.md` conflict)
+- Draft week dinners persist on pick, clear, reorder/Bytt med, and recipe-bank assign without pressing Lagre middager
+- Silent `autosave-meal-plan-entries` action returns JSON (no `meal-plan-entries-saved` notice)
+- Coalesced fetcher queue waits for idle so `updatedAt` versions do not 409 on rapid picks
+- Week editor no longer remounts or closes the open day after autosave
+- Notes and ansvarlig still use explicit Lagre; reset/auto-fill unchanged
 
 ## Files To Read First
 
-- `app/lib/calendar.server.ts` - ICS generation and `escapeText`
-- `app/lib/calendar.server.test.ts` - CRLF/CR description coverage
+- `app/lib/use-meal-plan-entries-autosave.ts` - dirty flag, coalesce, fetcher submit
+- `app/components/meal-plan-week-entries-form.tsx` - user vs server meal callbacks, no remount
+- `app/routes/family-meal-plan.tsx` - autosave intent, hook wiring, `assignRecipeToDate`
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 473 tests passed
+- `npm run test:run` — 519 tests passed
 - `npm run typecheck` — passed
+- Browser — not run
 
 ## Open Items
 
-- Re-export a week plan after merge/deploy and open the `.ics` in macOS Calendar
-- Issue #221 closes on PR merge via `Closes #221`
+- Manual: pick dinners on a draft plan, refresh; swap days; assign from recipe bank; freezer stock; notes still require Lagre
+- Issue #223 closes on PR merge via `Closes #223`
 
 ## Next Step
 
-Review/merge the open PR for #221.
+Review and merge the pull request for #223.

--- a/app/components/meal-plan-week-entries-form.tsx
+++ b/app/components/meal-plan-week-entries-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from "react";
 import { DndProvider, useDrag, useDrop } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { TouchBackend } from "react-dnd-touch-backend";
@@ -111,14 +111,17 @@ export function MealPlanWeekEntriesForm({
   entryValues,
   familyId,
   familyMembers,
+  formRef,
   freezerItems,
   isAutoFillingEntries,
+  isAutosaving,
   isResettingEntries,
   isSavingEntries,
   mealPlanId,
   mealSelectionsByDate,
   onActiveAssignDateChange,
   onMealSelectionsByDateChange,
+  onUserMealSelectionsChange,
   recentlyUsedRecipeIds,
   recipes,
   visibleDates,
@@ -131,14 +134,21 @@ export function MealPlanWeekEntriesForm({
   entryValues: Record<string, MealPlanEntryFormState>;
   familyId: string;
   familyMembers: MealPlanFamilyMemberOption[];
+  formRef?: RefObject<HTMLFormElement | null>;
   freezerItems: MealPlanFreezerOption[];
   isAutoFillingEntries: boolean;
+  isAutosaving?: boolean;
   isResettingEntries: boolean;
   isSavingEntries: boolean;
   mealPlanId: string;
   mealSelectionsByDate: Record<string, string>;
   onActiveAssignDateChange: (date: string | null) => void;
   onMealSelectionsByDateChange: (
+    value:
+      | Record<string, string>
+      | ((current: Record<string, string>) => Record<string, string>),
+  ) => void;
+  onUserMealSelectionsChange: (
     value:
       | Record<string, string>
       | ((current: Record<string, string>) => Record<string, string>),
@@ -167,15 +177,18 @@ export function MealPlanWeekEntriesForm({
   }, [mealSelectionsByDate]);
 
   useEffect(() => {
+    if (isAutosaving) {
+      return;
+    }
+
     onMealSelectionsByDateChange(
       buildMealSelectionsByDate(visibleDates, entryValues),
     );
-    setIsReorderMode(false);
-    onActiveAssignDateChange(null);
-    // Only reset when the server snapshot changes. Including entryValues/visibleDates
-    // would wipe in-progress drag swaps whenever parent re-renders with new object identity.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: snapshot-gated reset
-  }, [entriesSnapshot]);
+    // Sync meals from the server snapshot without closing the open day or
+    // reorder mode. Including entryValues/visibleDates would wipe in-progress
+    // drag swaps whenever the parent re-renders with new object identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: snapshot-gated sync
+  }, [entriesSnapshot, isAutosaving]);
 
   useEffect(() => {
     if (!isResettingEntries) {
@@ -201,7 +214,7 @@ export function MealPlanWeekEntriesForm({
   }, [isSavingEntries]);
 
   const applySwapOrMove = (fromDate: string, toDate: string) => {
-    onMealSelectionsByDateChange((current) =>
+    onUserMealSelectionsChange((current) =>
       swapOrMoveMealSelection(current, fromDate, toDate),
     );
   };
@@ -243,7 +256,7 @@ export function MealPlanWeekEntriesForm({
               mealSelection={mealSelectionsByDate[date] ?? ""}
               onActiveAssignDateChange={onActiveAssignDateChange}
               onMealSelectionChange={(value) => {
-                onMealSelectionsByDateChange((current) => ({
+                onUserMealSelectionsChange((current) => ({
                   ...current,
                   [date]: value,
                 }));
@@ -259,11 +272,14 @@ export function MealPlanWeekEntriesForm({
     </div>
   );
 
+  const isEntryMutationPending =
+    isSavingEntries || isResettingEntries || isAutoFillingEntries || Boolean(isAutosaving);
+
   return (
     <Form
-      key={entriesSnapshot}
       className="mt-4 min-w-0 space-y-3"
       method="post"
+      ref={formRef}
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <button
@@ -296,14 +312,14 @@ export function MealPlanWeekEntriesForm({
         <p className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
           {entryFormError}
         </p>
+      ) : isAutosaving ? (
+        <p className="text-sm text-slate-500">Lagrer…</p>
       ) : null}
 
       <div className="grid gap-3 sm:grid-cols-2">
         <button
           className="inline-flex w-full items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
-          disabled={
-            isSavingEntries || isResettingEntries || isAutoFillingEntries
-          }
+          disabled={isEntryMutationPending}
           name="intent"
           type="submit"
           value="save-meal-plan-entries"
@@ -312,9 +328,7 @@ export function MealPlanWeekEntriesForm({
         </button>
         <button
           className="inline-flex w-full items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 py-3 text-sm font-medium text-rose-800 transition hover:bg-rose-100 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
-          disabled={
-            isSavingEntries || isResettingEntries || isAutoFillingEntries
-          }
+          disabled={isEntryMutationPending}
           name="intent"
           type="submit"
           value="reset-meal-plan-entries"

--- a/app/lib/use-meal-plan-entries-autosave.test.ts
+++ b/app/lib/use-meal-plan-entries-autosave.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useMemo, useState, type RefObject } from "react";
+import type { FetcherWithComponents } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MEAL_PLAN_ENTRIES_AUTOSAVE_INTENT,
+  useMealPlanEntriesAutosave,
+  type MealPlanEntriesAutosaveData,
+} from "./use-meal-plan-entries-autosave";
+
+type AutosaveFetcherState = "idle" | "submitting" | "loading";
+
+function createEntriesForm() {
+  const form = document.createElement("form");
+  const dateInput = document.createElement("input");
+  dateInput.name = "entryDate";
+  dateInput.value = "2026-05-15";
+  const mealInput = document.createElement("input");
+  mealInput.name = "mealSelection:2026-05-15";
+  mealInput.value = "recipe:kylling-taco";
+  form.append(dateInput, mealInput);
+  document.body.append(form);
+
+  return form;
+}
+
+function useAutosaveTestHarness({
+  blocked = false,
+  formRef,
+  initialFetcherState = "idle" as AutosaveFetcherState,
+}: {
+  blocked?: boolean;
+  formRef: RefObject<HTMLFormElement | null>;
+  initialFetcherState?: AutosaveFetcherState;
+}) {
+  const [fetcherState, setFetcherState] =
+    useState<AutosaveFetcherState>(initialFetcherState);
+  const [fetcherData, setFetcherData] = useState<
+    MealPlanEntriesAutosaveData | undefined
+  >(undefined);
+  const [submit] = useState(() =>
+    vi.fn(async () => {
+      setFetcherState("submitting");
+    }),
+  );
+
+  const fetcher = useMemo(
+    () =>
+      ({
+        Form: () => null,
+        data: fetcherData,
+        load: vi.fn(),
+        state: fetcherState,
+        submit,
+      }) as unknown as FetcherWithComponents<MealPlanEntriesAutosaveData>,
+    [fetcherData, fetcherState, submit],
+  );
+
+  const autosave = useMealPlanEntriesAutosave({
+    blocked,
+    fetcher,
+    formRef,
+  });
+
+  return {
+    ...autosave,
+    setFetcherData,
+    setFetcherState,
+    submit,
+  };
+}
+
+describe("useMealPlanEntriesAutosave", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.clearAllMocks();
+  });
+
+  it("does not submit until autosave is scheduled", async () => {
+    const formRef = { current: createEntriesForm() };
+    const { result } = renderHook(() =>
+      useAutosaveTestHarness({ formRef }),
+    );
+
+    expect(result.current.submit).not.toHaveBeenCalled();
+    expect(result.current.isAutosaving).toBe(false);
+  });
+
+  it("submits the form with the autosave intent after a scheduled change", async () => {
+    const formRef = { current: createEntriesForm() };
+    const { result } = renderHook(() =>
+      useAutosaveTestHarness({ formRef }),
+    );
+
+    act(() => {
+      result.current.scheduleAutosave();
+    });
+
+    await waitFor(() => {
+      expect(result.current.submit).toHaveBeenCalledTimes(1);
+    });
+
+    const submittedCall = vi.mocked(result.current.submit).mock.calls.at(0) as
+      | [FormData]
+      | undefined;
+
+    expect(submittedCall?.[0]).toBeInstanceOf(FormData);
+    expect(submittedCall?.[0].get("intent")).toBe(
+      MEAL_PLAN_ENTRIES_AUTOSAVE_INTENT,
+    );
+    expect(submittedCall?.[0].get("mealSelection:2026-05-15")).toBe(
+      "recipe:kylling-taco",
+    );
+    expect(result.current.isAutosaving).toBe(true);
+  });
+
+  it("coalesces additional changes into one follow-up submit after the fetcher is idle", async () => {
+    const formRef = { current: createEntriesForm() };
+    const { result } = renderHook(() =>
+      useAutosaveTestHarness({ formRef }),
+    );
+
+    act(() => {
+      result.current.scheduleAutosave();
+    });
+
+    await waitFor(() => {
+      expect(result.current.submit).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.scheduleAutosave();
+    });
+
+    expect(result.current.submit).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.setFetcherData({
+        intent: MEAL_PLAN_ENTRIES_AUTOSAVE_INTENT,
+        ok: true,
+      });
+      result.current.setFetcherState("idle");
+    });
+
+    await waitFor(() => {
+      expect(result.current.submit).toHaveBeenCalledTimes(2);
+    });
+
+    const secondSubmitCall = vi.mocked(result.current.submit).mock.calls.at(
+      1,
+    ) as [FormData] | undefined;
+
+    expect(secondSubmitCall?.[0].get("intent")).toBe(
+      MEAL_PLAN_ENTRIES_AUTOSAVE_INTENT,
+    );
+  });
+
+  it("does not submit while reset or auto-fill is blocked", async () => {
+    const formRef = { current: createEntriesForm() };
+    const { result } = renderHook(() =>
+      useAutosaveTestHarness({ blocked: true, formRef }),
+    );
+
+    act(() => {
+      result.current.scheduleAutosave();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAutosaving).toBe(true);
+    });
+
+    expect(result.current.submit).not.toHaveBeenCalled();
+  });
+});

--- a/app/lib/use-meal-plan-entries-autosave.ts
+++ b/app/lib/use-meal-plan-entries-autosave.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import type { FetcherWithComponents } from "react-router";
+
+export const MEAL_PLAN_ENTRIES_AUTOSAVE_INTENT = "autosave-meal-plan-entries";
+
+export interface MealPlanEntriesAutosaveData {
+  entryFormError?: string;
+  intent?: string;
+  ok?: boolean;
+}
+
+export function useMealPlanEntriesAutosave({
+  blocked,
+  fetcher,
+  formRef,
+}: {
+  blocked: boolean;
+  fetcher: FetcherWithComponents<MealPlanEntriesAutosaveData>;
+  formRef: RefObject<HTMLFormElement | null>;
+}) {
+  const dirtyRef = useRef(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const fetcherRef = useRef(fetcher);
+  const formRefValue = formRef;
+
+  fetcherRef.current = fetcher;
+
+  const flushAutosave = useCallback(() => {
+    const currentFetcher = fetcherRef.current;
+
+    if (blocked || currentFetcher.state !== "idle" || !dirtyRef.current) {
+      return;
+    }
+
+    const form = formRefValue.current;
+
+    if (!form) {
+      return;
+    }
+
+    dirtyRef.current = false;
+    setIsDirty(false);
+
+    const formData = new FormData(form);
+    formData.set("intent", MEAL_PLAN_ENTRIES_AUTOSAVE_INTENT);
+    currentFetcher.submit(formData, { method: "post" });
+  }, [blocked, formRefValue]);
+
+  const scheduleAutosave = useCallback(() => {
+    dirtyRef.current = true;
+    setIsDirty(true);
+  }, []);
+
+  useEffect(() => {
+    flushAutosave();
+  }, [blocked, fetcher.state, flushAutosave, isDirty]);
+
+  return {
+    entryFormError:
+      fetcher.data?.intent === MEAL_PLAN_ENTRIES_AUTOSAVE_INTENT
+        ? fetcher.data.entryFormError
+        : undefined,
+    isAutosaving: fetcher.state !== "idle" || isDirty,
+    scheduleAutosave,
+  };
+}

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -367,6 +367,94 @@ describe("family meal plan route", () => {
     );
   });
 
+  it("returns JSON without a notice redirect after autosaving meal plan entries", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(saveMealPlanEntries).mockResolvedValue({
+      status: "UPDATED",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "autosave-meal-plan-entries");
+    formData.append("entryDate", "2026-05-15");
+    formData.set("mealSelection:2026-05-15", "recipe:kylling-taco");
+    formData.set("note:2026-05-15", "");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(saveMealPlanEntries).toHaveBeenCalledWith({
+      entries: [
+        {
+          date: "2026-05-15",
+          note: "",
+          freezerItemId: "",
+          recipeId: "kylling-taco",
+          responsibleUserId: "",
+        },
+      ],
+      entryVersions: {
+        "2026-05-15": "",
+      },
+      familyId: "family-1",
+      mealPlanId: "meal-plan-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      intent: "autosave-meal-plan-entries",
+      ok: true,
+    });
+  });
+
+  it("returns planner validation errors from autosave without redirecting", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(saveMealPlanEntries).mockResolvedValue({
+      formError: "En av dagene ligger utenfor den aktive perioden.",
+      status: "VALIDATION_ERROR",
+      values: [
+        {
+          date: "2026-05-15",
+          note: "",
+          freezerItemId: "",
+          recipeId: "kylling-taco",
+          responsibleUserId: "",
+        },
+      ],
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "autosave-meal-plan-entries");
+    formData.append("entryDate", "2026-05-15");
+    formData.set("mealSelection:2026-05-15", "recipe:kylling-taco");
+    formData.set("note:2026-05-15", "");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+      },
+      request: buildRequest("http://localhost/families/family-1/meal-plans/meal-plan-1", formData),
+    });
+
+    expect(result).toEqual({
+      entryFormError: "En av dagene ligger utenfor den aktive perioden.",
+      entryValues: {
+        "2026-05-15": {
+          note: "",
+          freezerItemId: "",
+          recipeId: "kylling-taco",
+          responsibleUserId: "",
+          updatedAt: "",
+        },
+      },
+      intent: "autosave-meal-plan-entries",
+    });
+  });
+
   it("clears all weekly meal fields when resetting entries", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(saveMealPlanEntries).mockResolvedValue({

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -2,10 +2,11 @@ import {
   Form,
   Link,
   isRouteErrorResponse,
+  useFetcher,
   useNavigation,
   type MetaFunction,
 } from "react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { MealPlanWeekEntriesForm } from "../components/meal-plan-week-entries-form";
 import { RecipePickerMedia } from "../components/recipe-picker-card";
@@ -30,6 +31,7 @@ import {
   formatShortDateLabel,
   parseMealSelection,
 } from "../lib/meal-plan-display";
+import { useMealPlanEntriesAutosave } from "../lib/use-meal-plan-entries-autosave";
 import {
   deriveRecipeTagOptions,
   filterRecipePickerList,
@@ -59,6 +61,7 @@ type MealPlanNotice =
 type MealPlanIntent =
   | "approve-meal-plan"
   | "auto-fill-meal-plan-entries"
+  | "autosave-meal-plan-entries"
   | "mark-comment-addressed"
   | "reopen-meal-plan"
   | "reset-meal-plan-entries"
@@ -98,6 +101,7 @@ interface MealPlanActionData {
   };
   formError?: string;
   intent?: MealPlanIntent;
+  ok?: boolean;
   shareFormError?: string;
   statusFormError?: string;
   values?: {
@@ -318,6 +322,7 @@ export async function action({
   }
 
   if (
+    intent === "autosave-meal-plan-entries" ||
     intent === "save-meal-plan-entries" ||
     intent === "reset-meal-plan-entries"
   ) {
@@ -354,6 +359,13 @@ export async function action({
         entryFormError: result.formError,
         entryValues: indexMealPlanEntryValues(result.values, entryVersions),
         intent,
+      } satisfies MealPlanActionData;
+    }
+
+    if (intent === "autosave-meal-plan-entries") {
+      return {
+        intent,
+        ok: true,
       } satisfies MealPlanActionData;
     }
 
@@ -540,6 +552,17 @@ export default function FamilyMealPlanRoute({
     isPending && pendingIntent === "save-meal-plan-entries";
   const isResettingEntries =
     isPending && pendingIntent === "reset-meal-plan-entries";
+  const autosaveFetcher = useFetcher<MealPlanActionData>();
+  const entriesFormRef = useRef<HTMLFormElement>(null);
+  const {
+    entryFormError: autosaveEntryFormError,
+    isAutosaving,
+    scheduleAutosave,
+  } = useMealPlanEntriesAutosave({
+    blocked: isResettingEntries || isAutoFillingEntries,
+    fetcher: autosaveFetcher,
+    formRef: entriesFormRef,
+  });
   const isUpdatingMetadata = isPending && pendingIntent === "update-meal-plan";
   const isSharingMealPlan = isPending && pendingIntent === "share-meal-plan";
   const isMarkingCommentAddressed =
@@ -604,12 +627,18 @@ export default function FamilyMealPlanRoute({
       : isReopeningMealPlan
         ? "Gjenåpner..."
         : "Gjenåpne som utkast";
-  const entryValues =
-    (actionData?.intent === "save-meal-plan-entries" ||
-      actionData?.intent === "reset-meal-plan-entries") &&
-    actionData.entryValues
-      ? actionData.entryValues
-      : loaderData.entriesByDate;
+  const failedEntryActionData =
+    autosaveFetcher.data?.intent === "autosave-meal-plan-entries" &&
+    autosaveFetcher.data.entryValues
+      ? autosaveFetcher.data
+      : (actionData?.intent === "save-meal-plan-entries" ||
+            actionData?.intent === "reset-meal-plan-entries") &&
+          actionData.entryValues
+        ? actionData
+        : null;
+  const entryValues = failedEntryActionData?.entryValues
+    ? failedEntryActionData.entryValues
+    : loaderData.entriesByDate;
   const displayEntryValues = isResettingEntries
     ? Object.fromEntries(
         loaderData.visibleDates.map((date) => {
@@ -648,12 +677,25 @@ export default function FamilyMealPlanRoute({
   const calendarExportDateSet = new Set(loaderData.calendarExportDates);
   const hasMealPlanCalendarExport = calendarExportDateSet.size > 0;
 
+  const handleUserMealSelectionsChange = useCallback(
+    (
+      value:
+        | Record<string, string>
+        | ((current: Record<string, string>) => Record<string, string>),
+    ) => {
+      setMealSelectionsByDate(value);
+      scheduleAutosave();
+    },
+    [scheduleAutosave],
+  );
+
   const assignRecipeToDate = (recipeId: string, date: string) => {
     setMealSelectionsByDate((current) => ({
       ...current,
       [date]: `recipe:${recipeId}`,
     }));
     setActiveAssignDate(date);
+    scheduleAutosave();
   };
 
   return (
@@ -854,24 +896,28 @@ export default function FamilyMealPlanRoute({
               calendarDownloadTarget={CALENDAR_DOWNLOAD_TARGET}
               calendarExportDateSet={calendarExportDateSet}
               entryFormError={
-                (actionData?.intent === "save-meal-plan-entries" ||
+                autosaveEntryFormError ||
+                ((actionData?.intent === "save-meal-plan-entries" ||
                   actionData?.intent === "reset-meal-plan-entries") &&
                 actionData.entryFormError
                   ? actionData.entryFormError
-                  : undefined
+                  : undefined)
               }
               entriesSnapshot={loaderData.entriesSnapshot}
               entryValues={displayEntryValues}
               familyId={loaderData.family.id}
               familyMembers={loaderData.familyMembers}
+              formRef={entriesFormRef}
               freezerItems={loaderData.freezerItems}
               isAutoFillingEntries={isAutoFillingEntries}
+              isAutosaving={isAutosaving}
               isResettingEntries={isResettingEntries}
               isSavingEntries={isSavingEntries}
               mealPlanId={loaderData.mealPlan.id}
               mealSelectionsByDate={mealSelectionsByDate}
               onActiveAssignDateChange={setActiveAssignDate}
               onMealSelectionsByDateChange={setMealSelectionsByDate}
+              onUserMealSelectionsChange={handleUserMealSelectionsChange}
               recentlyUsedRecipeIds={loaderData.recentlyUsedRecipeIds}
               recipes={loaderData.recipes}
               visibleDates={loaderData.visibleDates}
@@ -900,6 +946,7 @@ export default function FamilyMealPlanRoute({
                 disabled={
                   !canAutoFillEntries ||
                   isAutoFillingEntries ||
+                  isAutosaving ||
                   isSavingEntries ||
                   isResettingEntries
                 }


### PR DESCRIPTION
## Summary
- Draft week dinners now persist as soon as a meal is picked, cleared, reordered, or assigned from the recipe bank, so skipping Lagre middager no longer wipes the week.
- Autosave uses a coalesced background fetcher (`autosave-meal-plan-entries`) and does not flash the full-page saved notice.
- Notes and ansvarlig still use the explicit Lagre button; reset and auto-fill are unchanged.

## Related issue
Closes #223

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] Draft plan: pick dinners on several days, refresh — dinners remain
- [ ] Reorder or Bytt med two days, refresh — order remains
- [ ] Assign a recipe from the recipe bank, refresh
- [ ] Pick a freezer meal — stock updates without Lagre
- [ ] Type a note without Lagre, refresh — note is gone, meals remain
- [ ] Approved plans stay read-only

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck