### PR TITLE
Trim MEALPLANNER_APP_URL in the weekend reminder workflow

### DIFF
--- a/.github/workflows/weekend-plan-reminders.yml
+++ b/.github/workflows/weekend-plan-reminders.yml
@@ -45,10 +45,33 @@ jobs:
             exit 1
           fi
 
-          url="${APP_URL%/}/internal/jobs/weekend-plan-reminders"
+          # GitHub secret paste often includes a trailing newline or wrapping quotes.
+          APP_URL="${APP_URL//$'\r'/}"
+          APP_URL="${APP_URL//$'\n'/}"
+          APP_URL="${APP_URL#"${APP_URL%%[![:space:]]*}"}"
+          APP_URL="${APP_URL%"${APP_URL##*[![:space:]]}"}"
+          APP_URL="${APP_URL#\"}"
+          APP_URL="${APP_URL%\"}"
+          APP_URL="${APP_URL#\'}"
+          APP_URL="${APP_URL%\'}"
+          APP_URL="${APP_URL#<}"
+          APP_URL="${APP_URL%>}"
+          APP_URL="${APP_URL%/}"
+
+          case "$APP_URL" in
+            https://*) ;;
+            *)
+              echo "MEALPLANNER_APP_URL must be an https origin with no path, e.g. https://mealplanner-xzvzow.fly.dev"
+              exit 1
+              ;;
+          esac
+
+          url="${APP_URL}/internal/jobs/weekend-plan-reminders"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force }}" = "true" ]; then
             url="${url}?force=true"
           fi
+
+          echo "POST ${url}"
 
           curl -fsS -X POST \
             -H "Authorization: Bearer ${CRON_SECRET}" \

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,21 +2,18 @@
 
 ## Current Objective
 
-Ship #225 — Thursday weekend-plan reminder emails. Branch `issue/225-weekend-plan-reminder` is validated and ready for PR.
+Ship #227 — trim `MEALPLANNER_APP_URL` in the weekend reminder GitHub Action so a trailing newline or quotes does not make curl reject the URL.
 
 ## Completed
 
-- Admins can set, change, or clear a family reminder email on the Familie tab
-- Thursday 12:00 Europe/Oslo job emails that address when Saturday or Sunday dinner is unplanned
-- Postgres claims the calendar week before send so extra machines or Action retries cannot duplicate mail
-- GitHub Action POSTs to a secret job route; `workflow_dispatch` can pass `force`
-- Operator set Fly `CRON_SECRET` and GitHub `CRON_SECRET` + `MEALPLANNER_APP_URL`
+- Workflow trims CR/LF/whitespace/quotes/angle brackets from the secret
+- Requires an `https://` origin and logs the sanitized POST URL
+- Docs say to paste origin only, no quotes or trailing slash
 
 ## Files To Read First
 
-- `app/lib/weekend-plan-reminder.server.ts` - window check, empty Sat/Sun, claim-then-send
-- `app/routes/family.tsx` - Helgevarsling form and `save-reminder-email` action
-- `.github/workflows/weekend-plan-reminders.yml` - Thursday UTC schedule and force dispatch
+- `.github/workflows/weekend-plan-reminders.yml` - URL sanitization before curl
+- `docs/deploy-fly.md` - secret format for `MEALPLANNER_APP_URL`
 
 ## Validation
 
@@ -28,9 +25,9 @@ Ship #225 — Thursday weekend-plan reminder emails. Branch `issue/225-weekend-p
 
 ## Open Items
 
-- Manual after merge: save a family email, leave Sat or Sun blank, `workflow_dispatch` with force, confirm one mail; run again same week — no second mail
-- Issue #225 closes on PR merge via `Closes #225`
+- Re-save GitHub secret `MEALPLANNER_APP_URL` as `https://mealplanner-xzvzow.fly.dev` (or the custom domain), no quotes or newline
+- After merge, re-run **Weekend plan reminders** with `force`
 
 ## Next Step
 
-Review and merge the pull request for #225.
+Review and merge the pull request for #227.

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -156,7 +156,7 @@ fly tokens create deploy -a mealplanner-xzvzow
 
 Add the token value as `FLY_API_TOKEN`.
 
-For Thursday weekend-plan reminders, also add repository secrets `CRON_SECRET` (same value as the Fly `CRON_SECRET` secret) and `MEALPLANNER_APP_URL` (e.g. `https://mealplanner-xzvzow.fly.dev`). The scheduled workflow [`.github/workflows/weekend-plan-reminders.yml`](../.github/workflows/weekend-plan-reminders.yml) POSTs to `/internal/jobs/weekend-plan-reminders`. Manual **Run workflow** can pass `force` to bypass the Thursday 12:00 Europe/Oslo window.
+For Thursday weekend-plan reminders, also add repository secrets `CRON_SECRET` (same value as the Fly `CRON_SECRET` secret) and `MEALPLANNER_APP_URL`. Paste the origin only, with no quotes, path, or trailing slash, e.g. `https://mealplanner-xzvzow.fly.dev`. The scheduled workflow [`.github/workflows/weekend-plan-reminders.yml`](../.github/workflows/weekend-plan-reminders.yml) POSTs to `/internal/jobs/weekend-plan-reminders`. Manual **Run workflow** can pass `force` to bypass the Thursday 12:00 Europe/Oslo window.
 
 Runtime secrets (`DATABASE_URL`, `SESSION_SECRET`, `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `CRON_SECRET`, etc.) stay on Fly via `fly secrets set`. `CRON_SECRET` is the exception that is **also** stored in GitHub so the reminder workflow can authenticate.
 


### PR DESCRIPTION
## Summary
- The smoke-test Action failed with `curl: (3) URL rejected: Malformed input` even though both secrets were set.
- That almost always means `MEALPLANNER_APP_URL` was pasted with a trailing newline or wrapping quotes.
- The workflow now trims those characters, requires an `https://` origin, and logs the sanitized POST URL.

## Related issue
Closes #227

## Test plan
- [ ] Re-save GitHub secret `MEALPLANNER_APP_URL` as `https://mealplanner-xzvzow.fly.dev` (or the custom domain) with no quotes or extra line
- [ ] After merge, run **Weekend plan reminders** with `force` and confirm the log shows `POST https://.../internal/jobs/weekend-plan-reminders?force=true`

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck