### PR TITLE
Add iOS Shortcuts Påminn meg on recipes

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,35 @@
 
 ## Current Objective
 
-Ship #227 — trim `MEALPLANNER_APP_URL` in the weekend reminder GitHub Action so a trailing newline or quotes does not make curl reject the URL.
+Ship client-only iOS Shortcuts “Påminn meg” on recipe detail. Recipe reminder templates remain [#229](https://github.com/sndrem/mealplanner/issues/229).
 
 ## Completed
 
-- Workflow trims CR/LF/whitespace/quotes/angle brackets from the secret
-- Requires an `https://` origin and logs the sanitized POST URL
-- Docs say to paste origin only, no quotes or trailing slash
+- `app/lib/recipe-reminder.ts` — payload/URL helpers, presets, platform detection, `createRecipeReminder`
+- `RecipeReminderModal` — editable title, presets, custom date/time, Shortcut install help
+- **Påminn meg** on `FamilyRecipeEditorCard` for all viewers
+- Modal accepts optional `suggestions` for later #229 prefills (not persisted yet)
 
 ## Files To Read First
 
-- `.github/workflows/weekend-plan-reminders.yml` - URL sanitization before curl
-- `docs/deploy-fly.md` - secret format for `MEALPLANNER_APP_URL`
+- `app/lib/recipe-reminder.ts` — URL/payload construction and types
+- `app/components/recipe-reminder-modal.tsx` — mobile modal UX
+- `app/components/family-recipe-editor-card.tsx` — button placement
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 547 tests passed
+- `npm run test:run` — 562 tests passed
 - `npm run typecheck` — passed
-- Browser — not run
+- Browser / iPhone Safari — not run; needs a real device with Shortcut installed
 
 ## Open Items
 
-- Re-save GitHub secret `MEALPLANNER_APP_URL` as `https://mealplanner-xzvzow.fly.dev` (or the custom domain), no quotes or newline
-- After merge, re-run **Weekend plan reminders** with `force`
+- User must install Shortcut named exactly `Create Recipe Reminder` that parses the JSON text input
+- #229: store suggestions on recipes and show them on the meal plan
+- Optional: publish an iCloud Shortcut link in the help panel once one exists
 
 ## Next Step
 
-Review and merge the pull request for #227.
+Review and merge the PR; then manual check on iPhone Safari.

--- a/app/components/family-recipe-editor-card.tsx
+++ b/app/components/family-recipe-editor-card.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Form, useNavigation } from "react-router";
 
 import { RecipePickerMedia } from "./recipe-picker-card";
+import { RecipeReminderModal } from "./recipe-reminder-modal";
 import { compressRecipeCoverImage } from "../lib/recipe-cover-image";
 import type {
   FamilyRecipeFieldErrors,
@@ -26,6 +27,7 @@ interface DraftIngredientRow extends FamilyRecipeIngredientValues {
 interface FamilyRecipeEditorCardProps {
   canManageRecipes: boolean;
   categories: RecipeCategory[];
+  familyId: string;
   familyStores: RecipeStore[];
   initialEditing?: boolean;
   mealPlanEntryCount: number;
@@ -53,6 +55,7 @@ interface FamilyRecipeEditorCardProps {
 export function FamilyRecipeEditorCard({
   canManageRecipes,
   categories,
+  familyId,
   familyStores,
   initialEditing = false,
   mealPlanEntryCount,
@@ -86,6 +89,7 @@ export function FamilyRecipeEditorCard({
   const [ignoreSubmittedValues, setIgnoreSubmittedValues] = useState(false);
   const sourceValues =
     updateValues && !ignoreSubmittedValues ? updateValues : persistedValues;
+  const [isReminderModalOpen, setIsReminderModalOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(
     Boolean(updateValues) || initialEditing,
   );
@@ -278,14 +282,25 @@ export function FamilyRecipeEditorCard({
             ) : null}
           </div>
         </div>
-        {canManageRecipes && !isEditing ? (
-          <button
-            className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
-            onClick={() => setIsEditing(true)}
-            type="button"
-          >
-            Rediger oppskrift
-          </button>
+        {!isEditing ? (
+          <div className="flex shrink-0 flex-col gap-2 sm:items-end">
+            <button
+              className="inline-flex items-center justify-center rounded-2xl bg-emerald-50 px-5 py-3 text-sm font-medium text-emerald-800 ring-1 ring-emerald-200 transition hover:bg-emerald-100"
+              onClick={() => setIsReminderModalOpen(true)}
+              type="button"
+            >
+              Påminn meg
+            </button>
+            {canManageRecipes ? (
+              <button
+                className="inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+                onClick={() => setIsEditing(true)}
+                type="button"
+              >
+                Rediger oppskrift
+              </button>
+            ) : null}
+          </div>
         ) : null}
       </div>
 
@@ -365,6 +380,15 @@ export function FamilyRecipeEditorCard({
           familyStores={familyStores}
         />
       )}
+
+      {isReminderModalOpen ? (
+        <RecipeReminderModal
+          familyId={familyId}
+          onClose={() => setIsReminderModalOpen(false)}
+          recipeId={recipe.id}
+          recipeTitle={isUpdatingRecipe ? draftValues.title : recipe.title}
+        />
+      ) : null}
 
       {canManageRecipes && !isEditing ? (
         <div className="mt-4 space-y-3">

--- a/app/components/recipe-reminder-modal.test.tsx
+++ b/app/components/recipe-reminder-modal.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RecipeReminderModal } from "./recipe-reminder-modal";
+import { renderWithRouter } from "../test/render-with-router";
+
+const IPHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1";
+const ANDROID_UA = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36";
+
+function stubNavigator({
+  maxTouchPoints = 5,
+  platform = "iPhone",
+  userAgent = IPHONE_UA,
+}: {
+  maxTouchPoints?: number;
+  platform?: string;
+  userAgent?: string;
+} = {}) {
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: userAgent,
+  });
+  Object.defineProperty(window.navigator, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  Object.defineProperty(window.navigator, "maxTouchPoints", {
+    configurable: true,
+    value: maxTouchPoints,
+  });
+}
+
+describe("RecipeReminderModal", () => {
+  beforeEach(() => {
+    stubNavigator();
+    vi.stubGlobal("location", {
+      ...window.location,
+      assign: vi.fn(),
+      origin: "https://mealplanner.example",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults the reminder text to the recipe title and fills tomorrow-morning", () => {
+    renderWithRouter(
+      <RecipeReminderModal
+        familyId="family-1"
+        onClose={vi.fn()}
+        recipeId="recipe-1"
+        recipeTitle="Pizza"
+      />,
+    );
+
+    expect(screen.getByLabelText("Tekst")).toHaveValue("Pizza");
+    expect(
+      screen.getByRole("button", { name: "I morgen tidlig" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Dato")).toBeInTheDocument();
+    expect(screen.getByLabelText("Klokkeslett")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Opprett i Påminnelser" }),
+    ).toBeEnabled();
+  });
+
+  it("lets the user pick a suggestion as the reminder title", () => {
+    renderWithRouter(
+      <RecipeReminderModal
+        familyId="family-1"
+        onClose={vi.fn()}
+        recipeId="recipe-1"
+        recipeTitle="Pizza"
+        suggestions={[
+          { id: "dough", title: "Ta deigen ut av kjøleskapet" },
+          { id: "bake", title: "Sett ovnen på" },
+        ]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Ta deigen ut av kjøleskapet" }),
+    );
+    expect(screen.getByLabelText("Tekst")).toHaveValue(
+      "Ta deigen ut av kjøleskapet",
+    );
+  });
+
+  it("explains that the shortcut is required and disables create off iOS", () => {
+    stubNavigator({
+      maxTouchPoints: 0,
+      platform: "Linux x86_64",
+      userAgent: ANDROID_UA,
+    });
+
+    renderWithRouter(
+      <RecipeReminderModal
+        familyId="family-1"
+        onClose={vi.fn()}
+        recipeId="recipe-1"
+        recipeTitle="Pizza"
+      />,
+    );
+
+    expect(
+      screen.getByText(/fungerer i Safari på iPhone og iPad/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Opprett i Påminnelser" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText("Hvordan installere snarveien"),
+    ).toBeInTheDocument();
+  });
+
+  it("launches the shortcut URL with the edited title", () => {
+    renderWithRouter(
+      <RecipeReminderModal
+        familyId="family-1"
+        onClose={vi.fn()}
+        recipeId="recipe-1"
+        recipeTitle="Pizza"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Tekst"), {
+      target: { value: "Lag pizzadeig" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Opprett i Påminnelser" }),
+    );
+
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    const launchedUrl = vi.mocked(window.location.assign).mock.calls[0]?.[0];
+    expect(launchedUrl).toContain("shortcuts://run-shortcut?");
+    expect(launchedUrl).toContain("Create%20Recipe%20Reminder");
+    expect(decodeURIComponent(String(launchedUrl))).toContain("Lag pizzadeig");
+  });
+});

--- a/app/components/recipe-reminder-modal.tsx
+++ b/app/components/recipe-reminder-modal.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useId, useMemo, useState } from "react";
+
+import {
+  applyRecipeReminderPreset,
+  buildFamilyRecipeUrl,
+  canLaunchRecipeReminderShortcut,
+  createRecipeReminder,
+  formatLocalDateInput,
+  formatLocalTimeInput,
+  getRecipeReminderPlatformSupport,
+  parseLocalDateTime,
+  RECIPE_REMINDER_PRESETS,
+  RECIPE_REMINDER_SHORTCUT_NAME,
+  type RecipeReminderPresetId,
+  type RecipeReminderSuggestion,
+} from "../lib/recipe-reminder";
+
+export function RecipeReminderModal({
+  familyId,
+  onClose,
+  recipeId,
+  recipeTitle,
+  suggestions = [],
+}: {
+  familyId: string;
+  onClose: () => void;
+  recipeId: string;
+  recipeTitle: string;
+  suggestions?: RecipeReminderSuggestion[];
+}) {
+  const titleId = useId();
+  const defaultDueAt = useMemo(
+    () => applyRecipeReminderPreset("tomorrow-morning", new Date()),
+    [],
+  );
+  const [title, setTitle] = useState(recipeTitle);
+  const [selectedSuggestionId, setSelectedSuggestionId] = useState<
+    string | undefined
+  >();
+  const [presetId, setPresetId] = useState<RecipeReminderPresetId>(
+    "tomorrow-morning",
+  );
+  const [date, setDate] = useState(() => formatLocalDateInput(defaultDueAt));
+  const [time, setTime] = useState(() => formatLocalTimeInput(defaultDueAt));
+  const [formError, setFormError] = useState<string | null>(null);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [launchMayHaveFailed, setLaunchMayHaveFailed] = useState(false);
+  const [nameCopied, setNameCopied] = useState(false);
+
+  const platformSupport = getRecipeReminderPlatformSupport({
+    maxTouchPoints: navigator.maxTouchPoints,
+    platform: navigator.platform,
+    userAgent: navigator.userAgent,
+  });
+  const canLaunch = canLaunchRecipeReminderShortcut(platformSupport);
+  const dueAt = parseLocalDateTime(date, time);
+  const isPastDue = Boolean(dueAt && dueAt.getTime() < Date.now());
+  const canSubmit = canLaunch && title.trim().length > 0 && dueAt !== null;
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  function handlePresetClick(nextPresetId: RecipeReminderPresetId) {
+    setPresetId(nextPresetId);
+    setFormError(null);
+
+    if (nextPresetId === "custom") {
+      return;
+    }
+
+    const nextDueAt = applyRecipeReminderPreset(nextPresetId, new Date());
+    setDate(formatLocalDateInput(nextDueAt));
+    setTime(formatLocalTimeInput(nextDueAt));
+  }
+
+  function handleDateChange(value: string) {
+    setDate(value);
+    setPresetId("custom");
+    setFormError(null);
+  }
+
+  function handleTimeChange(value: string) {
+    setTime(value);
+    setPresetId("custom");
+    setFormError(null);
+  }
+
+  function handleSuggestionClick(suggestion: RecipeReminderSuggestion) {
+    setTitle(suggestion.title);
+    setSelectedSuggestionId(suggestion.id);
+    setFormError(null);
+  }
+
+  function handleCreate() {
+    if (!dueAt) {
+      setFormError("Velg en gyldig dato og et klokkeslett.");
+      return;
+    }
+
+    const result = createRecipeReminder({
+      dueAt,
+      recipeUrl: buildFamilyRecipeUrl({
+        familyId,
+        origin: window.location.origin,
+        recipeId,
+      }),
+      suggestionId: selectedSuggestionId,
+      title,
+    });
+
+    if (!result.ok) {
+      setFormError(getCreateErrorMessage(result.error));
+      return;
+    }
+
+    window.setTimeout(() => {
+      if (!document.hidden) {
+        setLaunchMayHaveFailed(true);
+        setHelpOpen(true);
+      }
+    }, 1500);
+  }
+
+  async function handleCopyShortcutName() {
+    try {
+      await navigator.clipboard.writeText(RECIPE_REMINDER_SHORTCUT_NAME);
+      setNameCopied(true);
+    } catch {
+      setNameCopied(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-slate-950/40 sm:items-center sm:p-4"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="w-full max-h-[90vh] overflow-y-auto rounded-t-3xl bg-white p-5 shadow-xl sm:max-w-md sm:rounded-3xl"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <h3 className="text-lg font-semibold text-slate-950" id={titleId}>
+          Påminn meg
+        </h3>
+        <p className="mt-1 text-sm leading-6 text-slate-600">
+          Opprett en påminnelse i Apple Påminnelser via snarveien «
+          {RECIPE_REMINDER_SHORTCUT_NAME}».
+        </p>
+
+        {platformSupport === "unsupported" ? (
+          <p className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm leading-6 text-amber-950">
+            Denne funksjonen fungerer i Safari på iPhone og iPad. Åpne
+            oppskriften der for å sende den til Påminnelser.
+          </p>
+        ) : null}
+
+        {platformSupport === "macos" ? (
+          <p className="mt-3 rounded-2xl border border-sky-200 bg-sky-50 px-3 py-3 text-sm leading-6 text-sky-950">
+            Dette er laget for iPhone. macOS kan åpne Snarveier, men opplevelsen
+            er best i Safari på iOS.
+          </p>
+        ) : null}
+
+        {suggestions.length > 0 ? (
+          <div className="mt-4">
+            <p className="text-xs font-medium text-slate-700">Foreslåtte påminnelser</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {suggestions.map((suggestion) => {
+                const selected =
+                  suggestion.id != null
+                    ? selectedSuggestionId === suggestion.id
+                    : title === suggestion.title;
+
+                return (
+                  <button
+                    className={
+                      selected
+                        ? "rounded-full bg-emerald-100 px-3 py-2 text-sm font-medium text-emerald-900 ring-1 ring-emerald-300"
+                        : "rounded-full bg-slate-100 px-3 py-2 text-sm font-medium text-slate-700 ring-1 ring-slate-200"
+                    }
+                    key={suggestion.id ?? suggestion.title}
+                    onClick={() => handleSuggestionClick(suggestion)}
+                    type="button"
+                  >
+                    {suggestion.title}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+
+        <label className="mt-4 block text-sm font-medium text-slate-700">
+          Tekst
+          <input
+            className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-base text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+            onChange={(event) => {
+              setTitle(event.target.value);
+              setSelectedSuggestionId(undefined);
+              setFormError(null);
+            }}
+            type="text"
+            value={title}
+          />
+        </label>
+
+        <div className="mt-4">
+          <p className="text-sm font-medium text-slate-700">Når</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {RECIPE_REMINDER_PRESETS.map((preset) => (
+              <button
+                aria-pressed={presetId === preset.id}
+                className={
+                  presetId === preset.id
+                    ? "rounded-full bg-emerald-100 px-3 py-2 text-sm font-medium text-emerald-900 ring-1 ring-emerald-300"
+                    : "rounded-full bg-slate-100 px-3 py-2 text-sm font-medium text-slate-700 ring-1 ring-slate-200"
+                }
+                key={preset.id}
+                onClick={() => handlePresetClick(preset.id)}
+                type="button"
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <label className="block text-sm font-medium text-slate-700">
+            Dato
+            <input
+              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+              onChange={(event) => handleDateChange(event.target.value)}
+              type="date"
+              value={date}
+            />
+          </label>
+          <label className="block text-sm font-medium text-slate-700">
+            Klokkeslett
+            <input
+              className="mt-2 w-full rounded-2xl border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100"
+              onChange={(event) => handleTimeChange(event.target.value)}
+              type="time"
+              value={time}
+            />
+          </label>
+        </div>
+
+        {isPastDue ? (
+          <p className="mt-3 text-sm leading-6 text-amber-800">
+            Tidspunktet er i fortiden. Påminnelsen kan likevel opprettes.
+          </p>
+        ) : null}
+
+        {formError ? (
+          <p className="mt-3 text-sm leading-6 text-rose-700">{formError}</p>
+        ) : null}
+
+        <details
+          className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3"
+          onToggle={(event) => setHelpOpen(event.currentTarget.open)}
+          open={helpOpen}
+        >
+          <summary className="cursor-pointer text-sm font-medium text-slate-800">
+            {launchMayHaveFailed
+              ? "Snarveien åpnet ikke"
+              : "Hvordan installere snarveien"}
+          </summary>
+          <div className="mt-2 space-y-2 text-sm leading-6 text-slate-600">
+            <p>
+              Webapper kan ikke opprette Apple-påminnelser direkte. Du trenger
+              snarveien <strong>{RECIPE_REMINDER_SHORTCUT_NAME}</strong> i appen
+              Snarveier. Navnet må være nøyaktig likt.
+            </p>
+            <ol className="list-decimal space-y-1 pl-5">
+              <li>Åpne Snarveier og lag en ny snarvei.</li>
+              <li>
+                Gi den navnet {RECIPE_REMINDER_SHORTCUT_NAME}.
+              </li>
+              <li>Legg til «Motta tekst» fra snarvei-inndata.</li>
+              <li>Legg til «Hent ordbok fra inndata».</li>
+              <li>
+                Legg til «Legg til ny påminnelse» med tittel fra `title`,
+                forfall fra `dueISO`, og URL/notater fra `url`.
+              </li>
+            </ol>
+            <button
+              className="rounded-xl bg-white px-3 py-2 text-sm font-medium text-slate-700 ring-1 ring-slate-200"
+              onClick={() => void handleCopyShortcutName()}
+              type="button"
+            >
+              {nameCopied ? "Navnet er kopiert" : "Kopier snarveinavn"}
+            </button>
+          </div>
+        </details>
+
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            className="rounded-2xl border border-slate-300 px-4 py-3 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+            onClick={onClose}
+            type="button"
+          >
+            Avbryt
+          </button>
+          <button
+            className="rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-300"
+            disabled={!canSubmit}
+            onClick={handleCreate}
+            type="button"
+          >
+            Opprett i Påminnelser
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getCreateErrorMessage(error: "EMPTY_TITLE" | "INVALID_DATE" | "INVALID_URL") {
+  switch (error) {
+    case "EMPTY_TITLE":
+      return "Skriv inn en tekst til påminnelsen.";
+    case "INVALID_DATE":
+      return "Velg en gyldig dato og et klokkeslett.";
+    case "INVALID_URL":
+      return "Kunne ikke lage en lenke tilbake til oppskriften.";
+  }
+}

--- a/app/lib/recipe-reminder.test.ts
+++ b/app/lib/recipe-reminder.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyRecipeReminderPreset,
+  buildFamilyRecipeUrl,
+  buildRecipeReminderPayload,
+  buildRecipeReminderShortcutUrl,
+  canLaunchRecipeReminderShortcut,
+  createRecipeReminder,
+  formatLocalDateInput,
+  formatLocalTimeInput,
+  getRecipeReminderPlatformSupport,
+  parseLocalDateTime,
+  parseRecipeReminderShortcutUrl,
+  RECIPE_REMINDER_SHORTCUT_NAME,
+} from "./recipe-reminder";
+
+const recipeUrl = "https://mealplanner.example/families/family-1/recipes/recipe-1";
+
+describe("recipe-reminder", () => {
+  it("builds a family recipe URL from origin and ids", () => {
+    expect(
+      buildFamilyRecipeUrl({
+        familyId: "family-1",
+        origin: "https://mealplanner.example/",
+        recipeId: "recipe-1",
+      }),
+    ).toBe(recipeUrl);
+  });
+
+  it("encodes spaces as %20 in the shortcut name, not as plus", () => {
+    const payload = buildRecipeReminderPayload({
+      dueAt: new Date(2026, 7, 27, 8, 0, 0),
+      recipeUrl,
+      title: "Pizza",
+    });
+
+    expect(payload).not.toBeTypeOf("string");
+    if (typeof payload === "string") {
+      return;
+    }
+
+    const url = buildRecipeReminderShortcutUrl(payload);
+
+    expect(url).toContain("name=Create%20Recipe%20Reminder");
+    expect(url).not.toContain("name=Create+Recipe+Reminder");
+    expect(url.startsWith("shortcuts://run-shortcut?")).toBe(true);
+    expect(url).toContain("input=text");
+  });
+
+  it("round-trips titles with Norwegian characters, ampersands, quotes, and emoji", () => {
+    const title = 'Ta deigen ut av kjøleskapet & "start" 🍕';
+    const payload = buildRecipeReminderPayload({
+      dueAt: new Date(2026, 7, 27, 8, 0, 0),
+      recipeUrl,
+      title,
+    });
+
+    expect(payload).not.toBeTypeOf("string");
+    if (typeof payload === "string") {
+      return;
+    }
+
+    const parsed = parseRecipeReminderShortcutUrl(
+      buildRecipeReminderShortcutUrl(payload),
+    );
+
+    expect(parsed?.title).toBe(title);
+    expect(parsed?.url).toBe(recipeUrl);
+  });
+
+  it("preserves recipe URLs that already contain query parameters", () => {
+    const urlWithQuery =
+      "https://mealplanner.example/families/family-1/recipes/recipe-1?ref=plan&day=2026-08-27";
+    const payload = buildRecipeReminderPayload({
+      dueAt: new Date(2026, 7, 27, 8, 0, 0),
+      recipeUrl: urlWithQuery,
+      title: "Pizza",
+    });
+
+    expect(payload).not.toBeTypeOf("string");
+    if (typeof payload === "string") {
+      return;
+    }
+
+    const parsed = parseRecipeReminderShortcutUrl(
+      buildRecipeReminderShortcutUrl(payload),
+    );
+
+    expect(parsed?.url).toBe(urlWithQuery);
+    expect(parsed?.notes).toBe(urlWithQuery);
+    expect(parsed?.dueISO).toBe("2026-08-27T08:00:00");
+    expect(parsed?.dueISO.endsWith("Z")).toBe(false);
+  });
+
+  it("includes suggestionId when a saved suggestion is used", () => {
+    const payload = buildRecipeReminderPayload({
+      dueAt: new Date(2026, 7, 27, 8, 0, 0),
+      recipeUrl,
+      suggestionId: "suggestion-dough",
+      title: "Ta deigen ut av kjøleskapet",
+    });
+
+    expect(payload).not.toBeTypeOf("string");
+    if (typeof payload === "string") {
+      return;
+    }
+
+    expect(payload.suggestionId).toBe("suggestion-dough");
+    expect(
+      parseRecipeReminderShortcutUrl(buildRecipeReminderShortcutUrl(payload))
+        ?.suggestionId,
+    ).toBe("suggestion-dough");
+  });
+
+  it("rejects empty titles, invalid dates, and non-http URLs", () => {
+    expect(
+      buildRecipeReminderPayload({
+        dueAt: new Date(2026, 7, 27, 8, 0, 0),
+        recipeUrl,
+        title: "   ",
+      }),
+    ).toBe("EMPTY_TITLE");
+    expect(
+      buildRecipeReminderPayload({
+        dueAt: new Date("invalid"),
+        recipeUrl,
+        title: "Pizza",
+      }),
+    ).toBe("INVALID_DATE");
+    expect(
+      buildRecipeReminderPayload({
+        dueAt: new Date(2026, 7, 27, 8, 0, 0),
+        recipeUrl: "shortcuts://not-a-recipe",
+        title: "Pizza",
+      }),
+    ).toBe("INVALID_URL");
+  });
+
+  it("creates a reminder by constructing the URL then launching it", () => {
+    const openUrl = vi.fn();
+    const result = createRecipeReminder(
+      {
+        dueAt: new Date(2026, 7, 27, 8, 0, 0),
+        recipeUrl,
+        title: "Lag pizzadeig",
+      },
+      { openUrl },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(openUrl).toHaveBeenCalledTimes(1);
+    expect(openUrl).toHaveBeenCalledWith(result.url);
+    expect(parseRecipeReminderShortcutUrl(result.url)?.title).toBe(
+      "Lag pizzadeig",
+    );
+    expect(RECIPE_REMINDER_SHORTCUT_NAME).toBe("Create Recipe Reminder");
+  });
+
+  it("does not launch when validation fails", () => {
+    const openUrl = vi.fn();
+    const result = createRecipeReminder(
+      {
+        dueAt: new Date(2026, 7, 27, 8, 0, 0),
+        recipeUrl,
+        title: "",
+      },
+      { openUrl },
+    );
+
+    expect(result).toEqual({ error: "EMPTY_TITLE", ok: false });
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+
+  it("applies tomorrow-morning in local time", () => {
+    const now = new Date(2026, 7, 26, 14, 30, 0);
+    const dueAt = applyRecipeReminderPreset("tomorrow-morning", now);
+
+    expect(formatLocalDateInput(dueAt)).toBe("2026-08-27");
+    expect(formatLocalTimeInput(dueAt)).toBe("08:00");
+  });
+
+  it("parses local date and time fields without using UTC", () => {
+    const dueAt = parseLocalDateTime("2026-08-27", "08:00");
+
+    expect(dueAt).not.toBeNull();
+    expect(dueAt?.getFullYear()).toBe(2026);
+    expect(dueAt?.getMonth()).toBe(7);
+    expect(dueAt?.getDate()).toBe(27);
+    expect(dueAt?.getHours()).toBe(8);
+    expect(dueAt?.getMinutes()).toBe(0);
+    expect(parseLocalDateTime("27.08.2026", "8:00")).toBeNull();
+  });
+
+  it("detects iOS, iPadOS, macOS, and unsupported platforms", () => {
+    expect(
+      getRecipeReminderPlatformSupport({
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15",
+      }),
+    ).toBe("ios");
+    expect(
+      getRecipeReminderPlatformSupport({
+        maxTouchPoints: 5,
+        platform: "MacIntel",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+      }),
+    ).toBe("ios");
+    expect(
+      getRecipeReminderPlatformSupport({
+        maxTouchPoints: 0,
+        platform: "MacIntel",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+      }),
+    ).toBe("macos");
+    expect(
+      getRecipeReminderPlatformSupport({
+        userAgent: "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36",
+      }),
+    ).toBe("unsupported");
+    expect(canLaunchRecipeReminderShortcut("ios")).toBe(true);
+    expect(canLaunchRecipeReminderShortcut("macos")).toBe(true);
+    expect(canLaunchRecipeReminderShortcut("unsupported")).toBe(false);
+  });
+});

--- a/app/lib/recipe-reminder.ts
+++ b/app/lib/recipe-reminder.ts
@@ -1,0 +1,270 @@
+export const RECIPE_REMINDER_SHORTCUT_NAME = "Create Recipe Reminder";
+
+export interface RecipeReminderSuggestion {
+  id?: string;
+  title: string;
+}
+
+export interface RecipeReminderInput {
+  dueAt: Date;
+  recipeUrl: string;
+  suggestionId?: string;
+  title: string;
+}
+
+export interface RecipeReminderPayload {
+  dueDate: string;
+  dueISO: string;
+  dueTime: string;
+  notes: string;
+  suggestionId?: string;
+  title: string;
+  url: string;
+}
+
+export type CreateRecipeReminderError =
+  | "EMPTY_TITLE"
+  | "INVALID_DATE"
+  | "INVALID_URL";
+
+export type CreateRecipeReminderResult =
+  | { ok: true; payload: RecipeReminderPayload; url: string }
+  | { error: CreateRecipeReminderError; ok: false };
+
+export type RecipeReminderPlatformSupport = "ios" | "macos" | "unsupported";
+
+export type RecipeReminderPresetId =
+  | "custom"
+  | "tomorrow-afternoon"
+  | "tomorrow-evening"
+  | "tomorrow-morning";
+
+export interface RecipeReminderPreset {
+  dayOffset?: number;
+  hour?: number;
+  id: RecipeReminderPresetId;
+  label: string;
+  minute?: number;
+}
+
+export const RECIPE_REMINDER_PRESETS: readonly RecipeReminderPreset[] = [
+  {
+    dayOffset: 1,
+    hour: 8,
+    id: "tomorrow-morning",
+    label: "I morgen tidlig",
+    minute: 0,
+  },
+  {
+    dayOffset: 1,
+    hour: 15,
+    id: "tomorrow-afternoon",
+    label: "I morgen ettermiddag",
+    minute: 0,
+  },
+  {
+    dayOffset: 1,
+    hour: 18,
+    id: "tomorrow-evening",
+    label: "I morgen kveld",
+    minute: 0,
+  },
+  {
+    id: "custom",
+    label: "Velg tid selv",
+  },
+];
+
+export function buildFamilyRecipeUrl({
+  familyId,
+  origin,
+  recipeId,
+}: {
+  familyId: string;
+  origin: string;
+  recipeId: string;
+}) {
+  const base = origin.replace(/\/+$/, "");
+
+  return `${base}/families/${encodeURIComponent(familyId)}/recipes/${encodeURIComponent(recipeId)}`;
+}
+
+export function getRecipeReminderPlatformSupport(input: {
+  maxTouchPoints?: number;
+  platform?: string;
+  userAgent: string;
+}): RecipeReminderPlatformSupport {
+  if (/iPad|iPhone|iPod/i.test(input.userAgent)) {
+    return "ios";
+  }
+
+  if (input.platform === "MacIntel" && (input.maxTouchPoints ?? 0) > 1) {
+    return "ios";
+  }
+
+  if (/Macintosh|Mac OS X/i.test(input.userAgent)) {
+    return "macos";
+  }
+
+  return "unsupported";
+}
+
+export function canLaunchRecipeReminderShortcut(
+  support: RecipeReminderPlatformSupport,
+) {
+  return support === "ios" || support === "macos";
+}
+
+export function formatLocalDateInput(date: Date) {
+  return [
+    date.getFullYear().toString().padStart(4, "0"),
+    (date.getMonth() + 1).toString().padStart(2, "0"),
+    date.getDate().toString().padStart(2, "0"),
+  ].join("-");
+}
+
+export function formatLocalTimeInput(date: Date) {
+  return [
+    date.getHours().toString().padStart(2, "0"),
+    date.getMinutes().toString().padStart(2, "0"),
+  ].join(":");
+}
+
+export function parseLocalDateTime(date: string, time: string) {
+  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  const timeMatch = /^(\d{2}):(\d{2})$/.exec(time);
+
+  if (!dateMatch || !timeMatch) {
+    return null;
+  }
+
+  const result = new Date(
+    Number(dateMatch[1]),
+    Number(dateMatch[2]) - 1,
+    Number(dateMatch[3]),
+    Number(timeMatch[1]),
+    Number(timeMatch[2]),
+    0,
+    0,
+  );
+
+  if (Number.isNaN(result.getTime())) {
+    return null;
+  }
+
+  return result;
+}
+
+export function applyRecipeReminderPreset(
+  presetId: Exclude<RecipeReminderPresetId, "custom">,
+  now: Date,
+) {
+  const preset = RECIPE_REMINDER_PRESETS.find((item) => item.id === presetId);
+
+  if (!preset || preset.dayOffset == null || preset.hour == null || preset.minute == null) {
+    throw new Error(`Unknown reminder preset: ${presetId}`);
+  }
+
+  return new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + preset.dayOffset,
+    preset.hour,
+    preset.minute,
+    0,
+    0,
+  );
+}
+
+export function buildRecipeReminderPayload(
+  input: RecipeReminderInput,
+): RecipeReminderPayload | CreateRecipeReminderError {
+  const title = input.title.trim();
+
+  if (!title) {
+    return "EMPTY_TITLE";
+  }
+
+  if (Number.isNaN(input.dueAt.getTime())) {
+    return "INVALID_DATE";
+  }
+
+  if (!isHttpUrl(input.recipeUrl)) {
+    return "INVALID_URL";
+  }
+
+  const dueDate = formatLocalDateInput(input.dueAt);
+  const dueTime = formatLocalTimeInput(input.dueAt);
+  const payload: RecipeReminderPayload = {
+    dueDate,
+    dueISO: `${dueDate}T${dueTime}:00`,
+    dueTime,
+    notes: input.recipeUrl,
+    title,
+    url: input.recipeUrl,
+  };
+
+  if (input.suggestionId) {
+    payload.suggestionId = input.suggestionId;
+  }
+
+  return payload;
+}
+
+export function buildRecipeReminderShortcutUrl(payload: RecipeReminderPayload) {
+  const text = JSON.stringify(payload);
+
+  return `shortcuts://run-shortcut?name=${encodeURIComponent(RECIPE_REMINDER_SHORTCUT_NAME)}&input=text&text=${encodeURIComponent(text)}`;
+}
+
+export function parseRecipeReminderShortcutUrl(url: string) {
+  if (!url.startsWith("shortcuts://run-shortcut?")) {
+    return null;
+  }
+
+  const query = url.slice("shortcuts://run-shortcut?".length);
+  const params = new URLSearchParams(query);
+  const name = params.get("name");
+  const input = params.get("input");
+  const text = params.get("text");
+
+  if (name !== RECIPE_REMINDER_SHORTCUT_NAME || input !== "text" || !text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as RecipeReminderPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function createRecipeReminder(
+  input: RecipeReminderInput,
+  options?: { openUrl?: (url: string) => void },
+): CreateRecipeReminderResult {
+  const payload = buildRecipeReminderPayload(input);
+
+  if (typeof payload === "string") {
+    return { error: payload, ok: false };
+  }
+
+  const url = buildRecipeReminderShortcutUrl(payload);
+  const openUrl = options?.openUrl ?? openShortcutUrl;
+  openUrl(url);
+
+  return { ok: true, payload, url };
+}
+
+export function openShortcutUrl(url: string) {
+  window.location.assign(url);
+}
+
+function isHttpUrl(value: string) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/app/routes/family-recipe.tsx
+++ b/app/routes/family-recipe.tsx
@@ -249,6 +249,7 @@ export default function FamilyRecipeRoute({
         <FamilyRecipeEditorCard
           canManageRecipes={canManageRecipes}
           categories={loaderData.categories}
+          familyId={loaderData.family.id}
           familyStores={loaderData.familyStores}
           initialEditing={loaderData.startInEditMode}
           mealPlanEntryCount={loaderData.mealPlanEntryCount}


### PR DESCRIPTION
## Summary
- Adds a **Påminn meg** button on recipe detail that opens a mobile-friendly modal (editable title, time presets, custom date/time).
- Launches a `shortcuts://` URL with a single URL-encoded JSON payload so a user-installed Shortcut can create an Apple Reminder with title, due time, and recipe link.
- Structures types so future recipe reminder suggestions (#229) can prefill the modal without rewriting the Shortcut bridge.

## Related issue
Follow-up (not closed by this PR): #229 — store reminder suggestions on recipes and show them on the meal plan.

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] On iPhone Safari: open a recipe → Påminn meg → pick a preset → Opprett i Påminnelser
- [ ] Confirm Shortcut named exactly `Create Recipe Reminder` receives JSON and creates the reminder
- [ ] On Android/desktop: unsupported message and disabled create (or macOS note)
- [ ] Help panel: copy Shortcut name; expand after failed launch if page stays visible

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck