### PR TITLE
Stack recipe reminder date and time fields on mobile

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,35 +2,32 @@
 
 ## Current Objective
 
-Ship recipe reminder suggestions on recipes and the meal plan ([#229](https://github.com/sndrem/mealplanner/issues/229)).
+Ship the mobile layout fix for Dato and Klokkeslett in the recipe reminder modal ([#233](https://github.com/sndrem/mealplanner/issues/233)).
 
 ## Completed
 
-- Persisted `RecipeReminderSuggestion` rows (title, optional note, optional display-only timing)
-- Recipe editor: add/edit/reorder/remove suggestions; read view opens Påminn meg with prefill
-- Meal plan: collapsed **Påminnelse** chip and expanded suggestion rows open the Shortcut modal
-- Day cards use a controlled expand header so the chip works when the day is closed
+- Date/time fields use `grid gap-3 sm:grid-cols-2` so they stack on mobile and sit side by side from `sm`
+- Modal test asserts the layout classes
+- Branch `issue/233-stack-reminder-datetime-mobile` cut from current `origin/main`
 
 ## Files To Read First
 
-- `app/components/meal-plan-week-entries-form.tsx` — meal-plan chips and modal trigger
-- `app/components/family-recipe-editor-card.tsx` — recipe editor suggestions UI
-- `app/lib/recipe-write.server.ts` — parse/save suggestions
-- `prisma/schema.prisma` — `RecipeReminderSuggestion` model
+- `app/components/recipe-reminder-modal.tsx` — date/time grid layout
+- `app/components/recipe-reminder-modal.test.tsx` — layout class assertion
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 570 tests passed
+- `npm run test:run` — 571 tests passed
 - `npm run typecheck` — passed
-- Browser / iPhone Safari Shortcut launch — not fully verified in this session
+- Browser / iOS Safari visual check — not run (no browser tools in this session)
 
 ## Open Items
 
-- Manual: collapsed meal-plan **Påminnelse** → modal → **Opprett i Påminnelser** on iPhone
-- Timing remains display-only (no due-date computation from meal-plan dates)
+- Manual: open **Påminn meg** on a phone-width viewport and confirm Dato/Klokkeslett stack without overlap
+- Manual: confirm `sm`+ still shows two columns
 
 ## Next Step
 
-Review and merge the PR for #229.
+Review and merge the PR for #233.

--- a/app/components/recipe-reminder-modal.test.tsx
+++ b/app/components/recipe-reminder-modal.test.tsx
@@ -61,8 +61,12 @@ describe("RecipeReminderModal", () => {
     expect(
       screen.getByRole("button", { name: "I morgen tidlig" }),
     ).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByLabelText("Dato")).toBeInTheDocument();
-    expect(screen.getByLabelText("Klokkeslett")).toBeInTheDocument();
+    const dateField = screen.getByLabelText("Dato");
+    const timeField = screen.getByLabelText("Klokkeslett");
+    const datetimeLayout = dateField.closest("div");
+    expect(datetimeLayout).toContainElement(timeField);
+    expect(datetimeLayout).toHaveClass("grid", "gap-3", "sm:grid-cols-2");
+    expect(datetimeLayout).not.toHaveClass("grid-cols-2");
     expect(
       screen.getByRole("button", { name: "Opprett i Påminnelser" }),
     ).toBeEnabled();

--- a/app/components/recipe-reminder-modal.tsx
+++ b/app/components/recipe-reminder-modal.tsx
@@ -242,7 +242,7 @@ export function RecipeReminderModal({
           </div>
         </div>
 
-        <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
           <label className="block text-sm font-medium text-slate-700">
             Dato
             <input


### PR DESCRIPTION
## Summary
- Dato and Klokkeslett in the Påminn meg modal now stack on small screens so native date/time inputs no longer overlap.
- From `sm` and up they still sit side by side, matching other forms in the app.

## Related issue
Closes #233

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Open **Påminn meg** on a phone-width viewport and confirm Dato/Klokkeslett stack without overlap
- [ ] Confirm `sm`+ still shows two columns

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck