### PR TITLE
Close linked issues after auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,11 +14,110 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Merge associated pull requests
         uses: actions/github-script@v7
         with:
           script: |
+            // GITHUB_TOKEN squash-merges do not run GitHub's closing-keyword
+            // handling, so linked issues stay open unless we close them here.
+            const CLOSING_ISSUE_RE =
+              /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)/gi;
+
+            function issueNumbersFromText(text) {
+              const numbers = new Set();
+              if (!text) {
+                return numbers;
+              }
+              for (const match of text.matchAll(CLOSING_ISSUE_RE)) {
+                numbers.add(Number(match[1]));
+              }
+              return numbers;
+            }
+
+            async function linkedIssueNumbers(pull) {
+              const numbers = issueNumbersFromText(
+                `${pull.title}\n${pull.body ?? ''}`
+              );
+              try {
+                const data = await github.graphql(
+                  `query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        closingIssuesReferences(first: 50) {
+                          nodes { number }
+                        }
+                      }
+                    }
+                  }`,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    number: pull.number,
+                  }
+                );
+                for (const node of data.repository.pullRequest
+                  .closingIssuesReferences.nodes ?? []) {
+                  numbers.add(node.number);
+                }
+              } catch (error) {
+                core.warning(
+                  `Could not load closing issue refs for PR #${pull.number}: ${error.message}`
+                );
+              }
+              return [...numbers];
+            }
+
+            async function closeLinkedIssues(pull) {
+              const issueNumbers = await linkedIssueNumbers(pull);
+              if (issueNumbers.length === 0) {
+                core.info(`PR #${pull.number} has no linked issues to close.`);
+                return;
+              }
+
+              for (const issueNumber of issueNumbers) {
+                if (issueNumber === pull.number) {
+                  continue;
+                }
+                try {
+                  const { data: issue } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                  });
+                  if (issue.pull_request) {
+                    core.info(`#${issueNumber} is a pull request, skipping close.`);
+                    continue;
+                  }
+                  if (issue.state === 'closed') {
+                    core.info(`Issue #${issueNumber} is already closed.`);
+                    continue;
+                  }
+
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    state: 'closed',
+                    state_reason: 'completed',
+                  });
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `Automatically closed after #${pull.number} was squash-merged.`,
+                  });
+                  core.info(`Closed issue #${issueNumber}.`);
+                } catch (error) {
+                  // Do not fail the job: Fly deploy triggers on Auto-merge success.
+                  core.warning(
+                    `Failed to close issue #${issueNumber} for PR #${pull.number}: ${error.message}`
+                  );
+                }
+              }
+            }
+
             const pullRequests = context.payload.workflow_run.pull_requests;
             if (!pullRequests || pullRequests.length === 0) {
               core.info('No pull requests associated with this workflow run.');
@@ -57,6 +156,7 @@ jobs:
                   merge_method: 'squash',
                 });
                 core.info(`PR #${pr.number} merged successfully.`);
+                await closeLinkedIssues(pull);
               } catch (error) {
                 core.setFailed(`Failed to merge PR #${pr.number}: ${error.message}`);
               }

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,18 +2,19 @@
 
 ## Current Objective
 
-Ship the mobile layout fix for Dato and Klokkeslett in the recipe reminder modal ([#233](https://github.com/sndrem/mealplanner/issues/233)).
+Fix auto-merge so linked issues close after a squash merge ([#234](https://github.com/sndrem/mealplanner/issues/234)).
 
 ## Completed
 
-- Date/time fields use `grid gap-3 sm:grid-cols-2` so they stack on mobile and sit side by side from `sm`
-- Modal test asserts the layout classes
-- Branch `issue/233-stack-reminder-datetime-mobile` cut from current `origin/main`
+- Confirmed `GITHUB_TOKEN` API squash-merges skip GitHub's `Closes #N` handling (same limitation as missing `push` events)
+- Auto-merge workflow now closes linked issues after a successful merge (GraphQL `closingIssuesReferences` plus closing keywords in the PR title/body)
+- Issue-close failures warn instead of failing the job so Fly deploy still runs
+- Branch cut from current `origin/main` after `git pull --ff-only`
 
 ## Files To Read First
 
-- `app/components/recipe-reminder-modal.tsx` — date/time grid layout
-- `app/components/recipe-reminder-modal.test.tsx` — layout class assertion
+- `.github/workflows/auto-merge.yml` — merge + explicit issue close
+- `docs/deploy-fly.md` — GITHUB_TOKEN merge limitations
 
 ## Validation
 
@@ -21,13 +22,12 @@ Ship the mobile layout fix for Dato and Klokkeslett in the recipe reminder modal
 - `npm run lint` — passed
 - `npm run test:run` — 571 tests passed
 - `npm run typecheck` — passed
-- Browser / iOS Safari visual check — not run (no browser tools in this session)
 
 ## Open Items
 
-- Manual: open **Påminn meg** on a phone-width viewport and confirm Dato/Klokkeslett stack without overlap
-- Manual: confirm `sm`+ still shows two columns
+- This PR's own merge still uses the old workflow on `main`, so #234 may need a manual close after merge
+- Manual: next auto-merged PR with `Closes #<n>` should close via `github-actions[bot]`
 
 ## Next Step
 
-Review and merge the PR for #233.
+Review and merge the PR for #234.

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -144,7 +144,7 @@ Routine production releases use [`.github/workflows/fly-deploy.yml`](../.github/
 | `workflow_run` (`Auto-merge PR` completed) | After auto-merge squash-merges a PR — needed because GITHUB_TOKEN merges do not fire `push` |
 | `workflow_dispatch` | Manually from **Actions → Deploy to Fly.io → Run workflow** (must run on the `main` branch) |
 
-Pull request branches do not trigger this workflow.
+Pull request branches do not trigger this workflow. The same GITHUB_TOKEN merge path also skips GitHub's `Closes #N` handling; [`.github/workflows/auto-merge.yml`](../.github/workflows/auto-merge.yml) closes linked issues after a successful squash merge.
 
 ### GitHub secret (one-time setup)
 


### PR DESCRIPTION
## Summary
- Auto-merge squash-merges with `GITHUB_TOKEN`, which skips GitHub's `Closes #N` handling (same limitation as missing `push` events).
- After a successful merge, the workflow now closes linked issues from GraphQL `closingIssuesReferences` and closing keywords in the PR title/body.
- Issue-close failures warn instead of failing the job, so Fly deploy still runs.

## Related issue
Closes #234

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] After this lands on `main`, open a follow-up PR with `Closes #<n>` and confirm `github-actions[bot]` closes the issue

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck