### PR TITLE
Subscribe to family dinners as a live iCal calendar

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,32 +2,34 @@
 
 ## Current Objective
 
-Fix auto-merge so linked issues close after a squash merge ([#234](https://github.com/sndrem/mealplanner/issues/234)).
+Ship the family iCal subscription feed ([#239](https://github.com/sndrem/mealplanner/issues/239)): commit, push, and open a PR.
 
 ## Completed
 
-- Confirmed `GITHUB_TOKEN` API squash-merges skip GitHub's `Closes #N` handling (same limitation as missing `push` events)
-- Auto-merge workflow now closes linked issues after a successful merge (GraphQL `closingIssuesReferences` plus closing keywords in the PR title/body)
-- Issue-close failures warn instead of failing the job so Fly deploy still runs
+- Family-level live iCal feed at `GET /c/:token/calendar.ics` behind a hashed token
+- ADMIN Familie-tab card to create, copy HTTPS + webcal URLs, rotate, and revoke
+- Existing cookie-gated week/day `.ics` downloads unchanged
 - Branch cut from current `origin/main` after `git pull --ff-only`
 
 ## Files To Read First
 
-- `.github/workflows/auto-merge.yml` — merge + explicit issue close
-- `docs/deploy-fly.md` — GITHUB_TOKEN merge limitations
+- `app/lib/calendar-subscription.server.ts` — token CRUD and 14-day feed query
+- `app/routes/calendar-subscription.ts` — public unauthenticated ICS route
+- `app/components/family-calendar-subscription-card.tsx` — subscribe UI
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 571 tests passed
+- `npm run test:run` — 590 tests passed
 - `npm run typecheck` — passed
+- Browser subscribe flow (iPhone `webcal://`, Google From URL) — not run
 
 ## Open Items
 
-- This PR's own merge still uses the old workflow on `main`, so #234 may need a manual close after merge
-- Manual: next auto-merged PR with `Closes #<n>` should close via `github-actions[bot]`
+- Apply migration `20260901140000_add_calendar_subscription` on deploy/local DB
+- Manual after merge: subscribe from iPhone and Google Calendar; refresh is not instant
 
 ## Next Step
 
-Review and merge the PR for #234.
+Merge the PR for #239 and confirm the migration runs in the usual deploy path.

--- a/app/components/family-calendar-subscription-card.tsx
+++ b/app/components/family-calendar-subscription-card.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { Form } from "react-router";
+
+export function FamilyCalendarSubscriptionCard({
+  hasCalendarSubscription,
+  httpsUrl,
+  isCreating,
+  isRevoking,
+  isRotating,
+  webcalUrl,
+}: {
+  hasCalendarSubscription: boolean;
+  httpsUrl?: string;
+  isCreating: boolean;
+  isRevoking: boolean;
+  isRotating: boolean;
+  webcalUrl?: string;
+}) {
+  const showUrls = Boolean(httpsUrl && webcalUrl);
+
+  return (
+    <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold text-slate-950">
+          Abonner i kalenderen
+        </h2>
+        <p className="text-sm leading-6 text-slate-600">
+          Legg til familiens middager i Apple Kalender eller Google Kalender.
+          Lenken er hemmelig — ikke del den offentlig. Kalendere henter
+          oppdateringer selv, ofte først etter noen timer.
+        </p>
+      </div>
+
+      {showUrls && httpsUrl && webcalUrl ? (
+        <CalendarSubscriptionUrlResult
+          httpsUrl={httpsUrl}
+          webcalUrl={webcalUrl}
+        />
+      ) : null}
+
+      {!hasCalendarSubscription ? (
+        <Form className="mt-6" method="post">
+          <input
+            name="intent"
+            type="hidden"
+            value="create-calendar-subscription"
+          />
+          <button
+            className="inline-flex w-fit items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+            type="submit"
+          >
+            {isCreating ? "Oppretter..." : "Opprett abonnement"}
+          </button>
+        </Form>
+      ) : (
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Form
+            method="post"
+            onSubmit={(event) => {
+              if (
+                !window.confirm(
+                  "Bytter du lenke, slutter eksisterende kalendere å oppdatere. Fortsette?",
+                )
+              ) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <input
+              name="intent"
+              type="hidden"
+              value="rotate-calendar-subscription"
+            />
+            <button
+              className="inline-flex w-fit items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+              type="submit"
+            >
+              {isRotating ? "Bytter lenke..." : "Bytt lenke"}
+            </button>
+          </Form>
+          <Form
+            method="post"
+            onSubmit={(event) => {
+              if (
+                !window.confirm(
+                  "Opphever du abonnementet, slutter kalendere å hente middager. Fortsette?",
+                )
+              ) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <input
+              name="intent"
+              type="hidden"
+              value="revoke-calendar-subscription"
+            />
+            <button
+              className="inline-flex w-fit items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700"
+              type="submit"
+            >
+              {isRevoking ? "Opphever..." : "Opphev"}
+            </button>
+          </Form>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CalendarSubscriptionUrlResult({
+  httpsUrl,
+  webcalUrl,
+}: {
+  httpsUrl: string;
+  webcalUrl: string;
+}) {
+  return (
+    <div className="mt-6 grid gap-4">
+      <p className="text-sm font-medium text-slate-950">Lenken er klar</p>
+      <p className="text-sm leading-6 text-slate-600">
+        Kopier HTTPS-lenken til Google Kalender, eller åpne webcal-lenken på
+        iPhone. Bytt lenke senere hvis den kommer på avveie — da må enhetene
+        abonnere på nytt.
+      </p>
+      <CopyableCalendarUrl
+        label="HTTPS (Google Kalender)"
+        url={httpsUrl}
+      />
+      <CopyableCalendarUrl label="webcal (iPhone)" url={webcalUrl} />
+    </div>
+  );
+}
+
+function CopyableCalendarUrl({
+  label,
+  url,
+}: {
+  label: string;
+  url: string;
+}) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
+    "idle",
+  );
+
+  return (
+    <label className="block text-sm font-medium text-slate-700">
+      {label}
+      <input
+        className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-950 outline-none transition focus:border-slate-400"
+        readOnly
+        value={url}
+      />
+      <button
+        className="mt-2 inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+        onClick={async () => {
+          try {
+            await navigator.clipboard.writeText(url);
+            setCopyState("copied");
+          } catch {
+            setCopyState("failed");
+          }
+        }}
+        type="button"
+      >
+        {copyState === "copied" ? "Kopiert" : "Kopier lenke"}
+      </button>
+      {copyState === "failed" ? (
+        <p className="mt-2 text-sm text-rose-700">
+          Kunne ikke kopiere. Marker lenken og kopier manuelt.
+        </p>
+      ) : null}
+    </label>
+  );
+}

--- a/app/lib/calendar-subscription.server.test.ts
+++ b/app/lib/calendar-subscription.server.test.ts
@@ -1,0 +1,360 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  dbMock,
+  randomBytesMock,
+  requireFamilyAdminMock,
+} = vi.hoisted(() => {
+  const calendarSubscription = {
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+    findUnique: vi.fn(),
+  };
+
+  return {
+    dbMock: {
+      $transaction: vi.fn(),
+      calendarSubscription,
+      mealPlan: {
+        findMany: vi.fn(),
+      },
+    },
+    randomBytesMock: vi.fn(),
+    requireFamilyAdminMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyAdmin: requireFamilyAdminMock,
+  requireFamilyMembership: vi.fn(),
+}));
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+
+  return {
+    ...actual,
+    randomBytes: randomBytesMock,
+  };
+});
+
+import {
+  buildCalendarSubscriptionUrls,
+  createOrRotateFamilyCalendarSubscription,
+  getFamilyCalendarFeedByToken,
+  getFamilyCalendarSubscriptionStatus,
+  hashCalendarSubscriptionToken,
+  revokeFamilyCalendarSubscription,
+} from "./calendar-subscription.server";
+
+const RAW_TOKEN = "a".repeat(64);
+const TOKEN_HASH = createHash("sha256").update(RAW_TOKEN).digest("hex");
+const PREVIOUS_TOKEN_HASH = createHash("sha256").update("b".repeat(64)).digest("hex");
+
+const mockAdmin = {
+  family: {
+    id: "family-1",
+    joinCode: "ABC123",
+    name: "Solberg",
+  },
+  familyId: "family-1",
+  id: "membership-1",
+  role: "ADMIN",
+  userId: "user-1",
+};
+
+function dinnerEntry({
+  date,
+  recipeTitle,
+  updatedAt = new Date("2026-05-13T18:00:00.000Z"),
+}: {
+  date: string;
+  recipeTitle: string;
+  updatedAt?: Date;
+}) {
+  return {
+    date: new Date(`${date}T00:00:00.000Z`),
+    freezerItem: null,
+    freezerItemId: null,
+    recipe: {
+      description: `${recipeTitle} beskrivelse`,
+      title: recipeTitle,
+    },
+    recipeId: `recipe-${recipeTitle}`,
+    updatedAt,
+  };
+}
+
+describe("calendar-subscription.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T09:30:45.000Z"));
+    requireFamilyAdminMock.mockResolvedValue(mockAdmin);
+    randomBytesMock.mockReturnValue(Buffer.from(RAW_TOKEN, "hex"));
+    dbMock.$transaction.mockImplementation(async (callback: (tx: typeof dbMock) => unknown) => {
+      return callback(dbMock);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hashes subscription tokens with SHA-256", () => {
+    expect(hashCalendarSubscriptionToken(RAW_TOKEN)).toBe(TOKEN_HASH);
+  });
+
+  it("builds https and webcal subscribe URLs", () => {
+    expect(
+      buildCalendarSubscriptionUrls({
+        origin: "https://mealplanner.example/",
+        token: RAW_TOKEN,
+      }),
+    ).toEqual({
+      httpsUrl: `https://mealplanner.example/c/${RAW_TOKEN}/calendar.ics`,
+      webcalUrl: `webcal://mealplanner.example/c/${RAW_TOKEN}/calendar.ics`,
+    });
+  });
+
+  it("stores a hashed token and returns the raw token once", async () => {
+    dbMock.calendarSubscription.deleteMany.mockResolvedValue({ count: 0 });
+    dbMock.calendarSubscription.create.mockResolvedValue({ id: "sub-1" });
+
+    const result = await createOrRotateFamilyCalendarSubscription({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyAdminMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ token: RAW_TOKEN });
+    expect(dbMock.calendarSubscription.deleteMany).toHaveBeenCalledWith({
+      where: { familyId: "family-1" },
+    });
+    expect(dbMock.calendarSubscription.create).toHaveBeenCalledWith({
+      data: {
+        createdByUserId: "user-1",
+        familyId: "family-1",
+        tokenHash: TOKEN_HASH,
+      },
+    });
+  });
+
+  it("replaces an existing token hash on rotate", async () => {
+    dbMock.calendarSubscription.deleteMany.mockResolvedValue({ count: 1 });
+    dbMock.calendarSubscription.create.mockResolvedValue({ id: "sub-2" });
+
+    await createOrRotateFamilyCalendarSubscription({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.calendarSubscription.deleteMany).toHaveBeenCalled();
+    expect(dbMock.calendarSubscription.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        tokenHash: TOKEN_HASH,
+      }),
+    });
+    expect(TOKEN_HASH).not.toBe(PREVIOUS_TOKEN_HASH);
+  });
+
+  it("revokes the family subscription", async () => {
+    dbMock.calendarSubscription.deleteMany.mockResolvedValue({ count: 1 });
+
+    await revokeFamilyCalendarSubscription({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyAdminMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(dbMock.calendarSubscription.deleteMany).toHaveBeenCalledWith({
+      where: { familyId: "family-1" },
+    });
+  });
+
+  it("reports whether a subscription exists", async () => {
+    dbMock.calendarSubscription.findUnique.mockResolvedValue({ id: "sub-1" });
+
+    await expect(
+      getFamilyCalendarSubscriptionStatus({ familyId: "family-1" }),
+    ).resolves.toEqual({ exists: true });
+
+    dbMock.calendarSubscription.findUnique.mockResolvedValue(null);
+
+    await expect(
+      getFamilyCalendarSubscriptionStatus({ familyId: "family-1" }),
+    ).resolves.toEqual({ exists: false });
+  });
+
+  it("returns null for an unknown feed token", async () => {
+    dbMock.calendarSubscription.findUnique.mockResolvedValue(null);
+
+    await expect(getFamilyCalendarFeedByToken("missing")).resolves.toBeNull();
+  });
+
+  it("returns an empty calendar when nothing is planned", async () => {
+    dbMock.calendarSubscription.findUnique.mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+    });
+    dbMock.mealPlan.findMany.mockResolvedValue([]);
+
+    const result = await getFamilyCalendarFeedByToken(RAW_TOKEN);
+
+    expect(result).not.toBeNull();
+    expect(result?.content).toContain("X-WR-CALNAME:Mealplanner - Solberg");
+    expect(result?.content).toContain("REFRESH-INTERVAL;VALUE=DURATION:PT1H");
+    expect(result?.content).not.toContain("BEGIN:VEVENT");
+    expect(result?.content).toContain("BEGIN:VTIMEZONE");
+  });
+
+  it("emits dinners from current and next week using the newest covering plan", async () => {
+    dbMock.calendarSubscription.findUnique.mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+    });
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        endDate: new Date("2026-05-17T00:00:00.000Z"),
+        entries: [
+          dinnerEntry({
+            date: "2026-05-15",
+            recipeTitle: "Pizza",
+            updatedAt: new Date("2026-05-14T08:00:00.000Z"),
+          }),
+        ],
+        id: "meal-plan-new",
+        startDate: new Date("2026-05-11T00:00:00.000Z"),
+        title: "Uke 20 ny",
+      },
+      {
+        endDate: new Date("2026-05-17T00:00:00.000Z"),
+        entries: [
+          dinnerEntry({
+            date: "2026-05-15",
+            recipeTitle: "Taco",
+          }),
+        ],
+        id: "meal-plan-old",
+        startDate: new Date("2026-05-11T00:00:00.000Z"),
+        title: "Uke 20 gammel",
+      },
+      {
+        endDate: new Date("2026-05-24T00:00:00.000Z"),
+        entries: [
+          dinnerEntry({
+            date: "2026-05-20",
+            recipeTitle: "Lapskaus",
+          }),
+        ],
+        id: "meal-plan-next",
+        startDate: new Date("2026-05-18T00:00:00.000Z"),
+        title: "Uke 21",
+      },
+    ]);
+
+    const result = await getFamilyCalendarFeedByToken(RAW_TOKEN);
+
+    expect(dbMock.calendarSubscription.findUnique).toHaveBeenCalledWith({
+      select: {
+        family: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        familyId: true,
+      },
+      where: {
+        tokenHash: TOKEN_HASH,
+      },
+    });
+    expect(dbMock.mealPlan.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          endDate: {
+            gte: new Date("2026-05-11T00:00:00.000Z"),
+          },
+          familyId: "family-1",
+          startDate: {
+            lte: new Date("2026-05-24T00:00:00.000Z"),
+          },
+        },
+      }),
+    );
+    expect(result?.content).toContain("SUMMARY:Middag: Pizza");
+    expect(result?.content).not.toContain("SUMMARY:Middag: Taco");
+    expect(result?.content).toContain("SUMMARY:Middag: Lapskaus");
+    expect(result?.content).toContain("UID:meal-plan-new-2026-05-15@mealplanner");
+    expect(result?.content).toContain("UID:meal-plan-next-2026-05-20@mealplanner");
+    expect(result?.content).toContain("LAST-MODIFIED:20260514T080000Z");
+    expect(result?.content).toContain("DTSTAMP:20260514T080000Z");
+  });
+
+  it("keeps the same UID when a dinner recipe is swapped", async () => {
+    dbMock.calendarSubscription.findUnique.mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      familyId: "family-1",
+    });
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        endDate: new Date("2026-05-17T00:00:00.000Z"),
+        entries: [
+          dinnerEntry({
+            date: "2026-05-15",
+            recipeTitle: "Taco",
+            updatedAt: new Date("2026-05-12T10:00:00.000Z"),
+          }),
+        ],
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-11T00:00:00.000Z"),
+        title: "Uke 20",
+      },
+    ]);
+
+    const first = await getFamilyCalendarFeedByToken(RAW_TOKEN);
+
+    dbMock.mealPlan.findMany.mockResolvedValue([
+      {
+        endDate: new Date("2026-05-17T00:00:00.000Z"),
+        entries: [
+          dinnerEntry({
+            date: "2026-05-15",
+            recipeTitle: "Fiskekaker",
+            updatedAt: new Date("2026-05-14T08:00:00.000Z"),
+          }),
+        ],
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-11T00:00:00.000Z"),
+        title: "Uke 20",
+      },
+    ]);
+
+    const second = await getFamilyCalendarFeedByToken(RAW_TOKEN);
+
+    expect(first?.content).toContain("UID:meal-plan-1-2026-05-15@mealplanner");
+    expect(second?.content).toContain("UID:meal-plan-1-2026-05-15@mealplanner");
+    expect(second?.content).toContain("SUMMARY:Middag: Fiskekaker");
+    expect(first?.content).toContain("SUMMARY:Middag: Taco");
+  });
+});

--- a/app/lib/calendar-subscription.server.ts
+++ b/app/lib/calendar-subscription.server.ts
@@ -1,0 +1,253 @@
+import { createHash, randomBytes } from "node:crypto";
+import { MealType } from "@prisma/client";
+
+import {
+  createCalendarFile,
+  createMealPlanCalendarEvent,
+  getCalendarMealDetails,
+  getFamilyCalendarName,
+} from "./calendar.server";
+import { db } from "./db.server";
+import { requireFamilyAdmin } from "./family.server";
+import { formatDateOnly } from "./meal-plan-dates";
+import {
+  getCalendarWeekBounds,
+  getCalendarWeekDates,
+  getNextCalendarWeekBounds,
+} from "./meal-plan-week";
+
+export function hashCalendarSubscriptionToken(rawToken: string) {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+export function createCalendarSubscriptionRawToken() {
+  return randomBytes(32).toString("hex");
+}
+
+export function buildCalendarSubscriptionUrls({
+  origin,
+  token,
+}: {
+  origin: string;
+  token: string;
+}) {
+  const path = `/c/${encodeURIComponent(token)}/calendar.ics`;
+  const normalizedOrigin = origin.replace(/\/+$/, "");
+  const host = new URL(normalizedOrigin).host;
+
+  return {
+    httpsUrl: `${normalizedOrigin}${path}`,
+    webcalUrl: `webcal://${host}${path}`,
+  };
+}
+
+export async function getFamilyCalendarSubscriptionStatus({
+  familyId,
+}: {
+  familyId: string;
+}) {
+  const subscription = await db.calendarSubscription.findUnique({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  return {
+    exists: Boolean(subscription),
+  };
+}
+
+export async function createOrRotateFamilyCalendarSubscription({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const token = createCalendarSubscriptionRawToken();
+  const tokenHash = hashCalendarSubscriptionToken(token);
+
+  await db.$transaction(async (tx) => {
+    await tx.calendarSubscription.deleteMany({
+      where: {
+        familyId,
+      },
+    });
+    await tx.calendarSubscription.create({
+      data: {
+        createdByUserId: userId,
+        familyId,
+        tokenHash,
+      },
+    });
+  });
+
+  return {
+    token,
+  };
+}
+
+export async function revokeFamilyCalendarSubscription({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  await db.calendarSubscription.deleteMany({
+    where: {
+      familyId,
+    },
+  });
+}
+
+export async function getFamilyCalendarFeedByToken(
+  token: string,
+  referenceDate = new Date(),
+) {
+  const trimmedToken = token.trim();
+
+  if (!trimmedToken) {
+    return null;
+  }
+
+  const subscription = await db.calendarSubscription.findUnique({
+    select: {
+      family: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      familyId: true,
+    },
+    where: {
+      tokenHash: hashCalendarSubscriptionToken(trimmedToken),
+    },
+  });
+
+  if (!subscription) {
+    return null;
+  }
+
+  const events = await getFamilyCalendarEvents({
+    familyId: subscription.familyId,
+    referenceDate,
+  });
+
+  return {
+    content: createCalendarFile(
+      getFamilyCalendarName(subscription.family.name),
+      events,
+      new Date(),
+      {
+        includeRefreshInterval: true,
+        useEventTimestamps: true,
+      },
+    ),
+  };
+}
+
+async function getFamilyCalendarEvents({
+  familyId,
+  referenceDate,
+}: {
+  familyId: string;
+  referenceDate: Date;
+}) {
+  const currentWeek = getCalendarWeekBounds(referenceDate);
+  const nextWeek = getNextCalendarWeekBounds(referenceDate);
+  const windowStart = currentWeek.weekStart;
+  const windowEnd = nextWeek.weekEnd;
+  const windowStartDate = new Date(`${windowStart}T00:00:00.000Z`);
+  const windowEndDate = new Date(`${windowEnd}T00:00:00.000Z`);
+  const dates = [
+    ...getCalendarWeekDates(currentWeek),
+    ...getCalendarWeekDates(nextWeek),
+  ];
+
+  const mealPlans = await db.mealPlan.findMany({
+    orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
+    select: {
+      endDate: true,
+      entries: {
+        select: {
+          date: true,
+          freezerItem: {
+            select: {
+              label: true,
+              note: true,
+            },
+          },
+          freezerItemId: true,
+          recipe: {
+            select: {
+              description: true,
+              title: true,
+            },
+          },
+          recipeId: true,
+          updatedAt: true,
+        },
+        where: {
+          date: {
+            gte: windowStartDate,
+            lte: windowEndDate,
+          },
+          mealType: MealType.DINNER,
+        },
+      },
+      id: true,
+      startDate: true,
+      title: true,
+    },
+    where: {
+      endDate: {
+        gte: windowStartDate,
+      },
+      familyId,
+      startDate: {
+        lte: windowEndDate,
+      },
+    },
+  });
+
+  return dates.flatMap((date) => {
+    const coveringPlan = mealPlans.find(
+      (plan) =>
+        formatDateOnly(plan.startDate) <= date && formatDateOnly(plan.endDate) >= date,
+    );
+    const entry = coveringPlan?.entries.find(
+      (mealPlanEntry) => formatDateOnly(mealPlanEntry.date) === date,
+    );
+    const meal = entry ? getCalendarMealDetails(entry) : null;
+
+    if (!coveringPlan || !entry || !meal) {
+      return [];
+    }
+
+    return [
+      createMealPlanCalendarEvent({
+        date,
+        description: meal.description,
+        lastModified: entry.updatedAt,
+        mealPlanId: coveringPlan.id,
+        mealPlanTitle: coveringPlan.title,
+        title: meal.title,
+      }),
+    ];
+  });
+}

--- a/app/lib/calendar.server.test.ts
+++ b/app/lib/calendar.server.test.ts
@@ -71,6 +71,47 @@ describe("calendar.server", () => {
     expect(content).toContain("UID:meal-plan-1\\\\2026-05-15");
     expect(content).toContain("DTSTART;TZID=Europe/Oslo:20260515T160000");
     expect(content).toContain("DTEND;TZID=Europe/Oslo:20260515T170000");
+    expect(content).toContain("BEGIN:VTIMEZONE");
+    expect(content).toContain("TZID:Europe/Oslo");
+    expect(content).not.toContain("REFRESH-INTERVAL");
+    expectIcsLinesHaveNoBareCarriageReturns(content);
+  });
+
+  it("omits a blank event block for an empty calendar and can emit feed headers", () => {
+    const content = createCalendarFile("Mealplanner - Solberg", [], new Date(), {
+      includeRefreshInterval: true,
+    });
+
+    expect(content).toContain("BEGIN:VCALENDAR");
+    expect(content).toContain("END:VCALENDAR");
+    expect(content).toContain("REFRESH-INTERVAL;VALUE=DURATION:PT1H");
+    expect(content).toContain("X-PUBLISHED-TTL:PT1H");
+    expect(content).not.toContain("BEGIN:VEVENT");
+    expect(content).not.toMatch(/\r\n\r\nEND:VCALENDAR/);
+    expectIcsLinesHaveNoBareCarriageReturns(content);
+  });
+
+  it("uses event timestamps for feed DTSTAMP and LAST-MODIFIED", () => {
+    const content = createCalendarFile(
+      "Mealplanner - Solberg",
+      [
+        {
+          date: "2026-05-15",
+          description: "Taco",
+          lastModified: new Date("2026-05-13T18:00:00.000Z"),
+          title: "Middag: Taco",
+          uid: "meal-plan-1-2026-05-15@mealplanner",
+        },
+      ],
+      new Date(),
+      {
+        useEventTimestamps: true,
+      },
+    );
+
+    expect(content).toContain("DTSTAMP:20260513T180000Z");
+    expect(content).toContain("LAST-MODIFIED:20260513T180000Z");
+    expect(content).not.toContain("DTSTAMP:20260514T093045Z");
     expectIcsLinesHaveNoBareCarriageReturns(content);
   });
 
@@ -114,6 +155,7 @@ describe("calendar.server", () => {
             title: "Taco fredag",
           },
           recipeId: "recipe-1",
+          updatedAt: new Date("2026-05-14T08:00:00.000Z"),
         },
         {
           date: new Date("2026-05-16T00:00:00.000Z"),
@@ -124,6 +166,7 @@ describe("calendar.server", () => {
           freezerItemId: "freezer-1",
           recipe: null,
           recipeId: null,
+          updatedAt: new Date("2026-05-14T08:00:00.000Z"),
         },
         {
           date: new Date("2026-05-17T00:00:00.000Z"),
@@ -131,6 +174,7 @@ describe("calendar.server", () => {
           freezerItemId: null,
           recipe: null,
           recipeId: "",
+          updatedAt: new Date("2026-05-14T08:00:00.000Z"),
         },
       ],
       id: "meal-plan-1",
@@ -190,6 +234,27 @@ describe("calendar.server", () => {
     expect(result.content).toContain("DTSTART;TZID=Europe/Oslo:20260516T160000");
     expect(result.content).toContain("DTEND;TZID=Europe/Oslo:20260516T170000");
     expect(result.content).toContain("Rask middagsfavoritt.");
+  });
+
+  it("rejects an empty meal-plan export before creating a file", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-18T00:00:00.000Z"),
+      entries: [],
+      id: "meal-plan-1",
+      startDate: new Date("2026-05-15T00:00:00.000Z"),
+      title: "Langhelg",
+    });
+
+    await expect(
+      getMealPlanCalendarExport({
+        familyId: "family-1",
+        mealPlanId: "meal-plan-1",
+        userId: "user-1",
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
   });
 
   it("rejects invalid day exports before creating a file", async () => {

--- a/app/lib/calendar.server.ts
+++ b/app/lib/calendar.server.ts
@@ -27,6 +27,7 @@ const mealPlanCalendarSelect = Prisma.validator<Prisma.MealPlanSelect>()({
         },
       },
       recipeId: true,
+      updatedAt: true,
     },
     where: {
       mealType: MealType.DINNER,
@@ -40,9 +41,49 @@ const mealPlanCalendarSelect = Prisma.validator<Prisma.MealPlanSelect>()({
 export interface CalendarEventInput {
   date: string;
   description: string;
+  lastModified?: Date;
   title: string;
   uid: string;
 }
+
+export interface CreateCalendarFileOptions {
+  includeRefreshInterval?: boolean;
+  useEventTimestamps?: boolean;
+}
+
+export interface CalendarMealEntry {
+  freezerItem: {
+    label: string;
+    note: string | null;
+  } | null;
+  freezerItemId: string | null;
+  recipe: {
+    description: string | null;
+    title: string;
+  } | null;
+  recipeId: string | null;
+}
+
+const EUROPE_OSLO_VTIMEZONE = [
+  "BEGIN:VTIMEZONE",
+  `TZID:${CALENDAR_TIME_ZONE}`,
+  `X-LIC-LOCATION:${CALENDAR_TIME_ZONE}`,
+  "BEGIN:DAYLIGHT",
+  "TZOFFSETFROM:+0100",
+  "TZOFFSETTO:+0200",
+  "TZNAME:CEST",
+  "DTSTART:19700329T020000",
+  "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU",
+  "END:DAYLIGHT",
+  "BEGIN:STANDARD",
+  "TZOFFSETFROM:+0200",
+  "TZOFFSETTO:+0100",
+  "TZNAME:CET",
+  "DTSTART:19701025T030000",
+  "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU",
+  "END:STANDARD",
+  "END:VTIMEZONE",
+].join("\r\n");
 
 interface MealPlanCalendarExportInput {
   familyId: string;
@@ -110,20 +151,36 @@ export function createCalendarFile(
   calendarName: string,
   events: CalendarEventInput[],
   stamp = new Date(),
+  options: CreateCalendarFileOptions = {},
 ): string {
-  const eventContent = events.map((event) => createCalendarEvent(event, stamp)).join("\r\n");
-
-  return [
+  const eventContent = events
+    .map((event) => createCalendarEvent(event, stamp, options.useEventTimestamps))
+    .join("\r\n");
+  const lines = [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",
     "PRODID:-//Mealplanner//NO",
     "CALSCALE:GREGORIAN",
     "METHOD:PUBLISH",
+  ];
+
+  if (options.includeRefreshInterval) {
+    lines.push("REFRESH-INTERVAL;VALUE=DURATION:PT1H", "X-PUBLISHED-TTL:PT1H");
+  }
+
+  lines.push(
     `X-WR-TIMEZONE:${CALENDAR_TIME_ZONE}`,
     `X-WR-CALNAME:${escapeText(calendarName)}`,
-    eventContent,
-    "END:VCALENDAR",
-  ].join("\r\n");
+    EUROPE_OSLO_VTIMEZONE,
+  );
+
+  if (eventContent) {
+    lines.push(eventContent);
+  }
+
+  lines.push("END:VCALENDAR");
+
+  return lines.join("\r\n");
 }
 
 async function getMealPlanCalendarData({ familyId, mealPlanId, userId }: MealPlanCalendarExportInput) {
@@ -160,9 +217,10 @@ function buildMealPlanEvents(mealPlan: Awaited<ReturnType<typeof getMealPlanCale
     }
 
     return [
-      createMealPlanEvent({
+      createMealPlanCalendarEvent({
         date,
         description: meal.description,
+        lastModified: entry.updatedAt,
         mealPlanId: mealPlan.id,
         mealPlanTitle: mealPlan.title,
         title: meal.title,
@@ -178,22 +236,21 @@ function buildMealPlanEventForDate(
   const entry = mealPlan.entries.find((mealPlanEntry) => formatDateOnly(mealPlanEntry.date) === date);
   const meal = entry ? getCalendarMealDetails(entry) : null;
 
-  if (!meal) {
+  if (!entry || !meal) {
     return null;
   }
 
-  return createMealPlanEvent({
+  return createMealPlanCalendarEvent({
     date,
     description: meal.description,
+    lastModified: entry.updatedAt,
     mealPlanId: mealPlan.id,
     mealPlanTitle: mealPlan.title,
     title: meal.title,
   });
 }
 
-function getCalendarMealDetails(
-  entry: Awaited<ReturnType<typeof getMealPlanCalendarData>>["entries"][number],
-) {
+export function getCalendarMealDetails(entry: CalendarMealEntry) {
   if (entry.recipeId && entry.recipe) {
     return {
       description: entry.recipe.description,
@@ -211,15 +268,17 @@ function getCalendarMealDetails(
   return null;
 }
 
-function createMealPlanEvent({
+export function createMealPlanCalendarEvent({
   date,
   description,
+  lastModified,
   mealPlanId,
   mealPlanTitle,
   title,
 }: {
   date: string;
   description: string | null;
+  lastModified?: Date;
   mealPlanId: string;
   mealPlanTitle: string;
   title: string;
@@ -227,25 +286,38 @@ function createMealPlanEvent({
   return {
     date,
     description: createMealPlanDescription(date, mealPlanTitle, description),
+    lastModified,
     title: `Middag: ${title}`,
     uid: `${mealPlanId}-${date}@mealplanner`,
   };
 }
 
-function createCalendarEvent(event: CalendarEventInput, stamp: Date) {
+function createCalendarEvent(
+  event: CalendarEventInput,
+  stamp: Date,
+  useEventTimestamps = false,
+) {
   const startDateTime = formatIcsLocalDateTime(event.date, DINNER_START_HOUR);
   const endDateTime = formatIcsLocalDateTime(event.date, DINNER_END_HOUR);
-
-  return [
+  const stampSource =
+    useEventTimestamps && event.lastModified ? event.lastModified : stamp;
+  const lines = [
     "BEGIN:VEVENT",
     `UID:${escapeText(event.uid)}`,
-    `DTSTAMP:${formatDateTimeStamp(stamp)}`,
+    `DTSTAMP:${formatDateTimeStamp(stampSource)}`,
     `SUMMARY:${escapeText(event.title)}`,
     `DTSTART;TZID=${CALENDAR_TIME_ZONE}:${startDateTime}`,
     `DTEND;TZID=${CALENDAR_TIME_ZONE}:${endDateTime}`,
     `DESCRIPTION:${escapeText(event.description)}`,
-    "END:VEVENT",
-  ].join("\r\n");
+  ];
+
+  if (event.lastModified) {
+    lines.push(`LAST-MODIFIED:${formatDateTimeStamp(event.lastModified)}`);
+  }
+
+  lines.push("END:VEVENT");
+
+  return lines.join("\r\n");
 }
 
 function createMealPlanDescription(date: string, mealPlanTitle: string, recipeDescription: string | null) {
@@ -263,6 +335,10 @@ function createMealPlanDescription(date: string, mealPlanTitle: string, recipeDe
 
 function getCalendarName(mealPlanTitle: string) {
   return `Mealplanner - ${mealPlanTitle}`;
+}
+
+export function getFamilyCalendarName(familyName: string) {
+  return `Mealplanner - ${familyName}`;
 }
 
 function getMealPlanFileSlug(mealPlanTitle: string) {

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,6 +13,7 @@ export default [
   ),
   route("api/generate-recipe-description", "routes/api.generate-recipe-description.ts"),
   route("s/:token", "routes/shopping-list-share.tsx"),
+  route("c/:token/calendar.ics", "routes/calendar-subscription.ts"),
   layout("routes/app-layout.tsx", [
     route("app", "routes/app.tsx"),
     route("families/:familyId", "routes/family.tsx"),

--- a/app/routes/calendar-subscription.test.ts
+++ b/app/routes/calendar-subscription.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/calendar-subscription.server", () => ({
+  getFamilyCalendarFeedByToken: vi.fn(),
+}));
+
+import { getFamilyCalendarFeedByToken } from "../lib/calendar-subscription.server";
+import { loader } from "./calendar-subscription";
+
+describe("calendar subscription route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an inline calendar without requiring a session", async () => {
+    vi.mocked(getFamilyCalendarFeedByToken).mockResolvedValue({
+      content: "BEGIN:VCALENDAR\r\nEND:VCALENDAR",
+    });
+
+    const result = await loader({
+      params: {
+        token: "feed-token",
+      },
+    });
+
+    expect(getFamilyCalendarFeedByToken).toHaveBeenCalledWith("feed-token");
+    expect(result.headers.get("Content-Type")).toBe("text/calendar; charset=utf-8");
+    expect(result.headers.get("Content-Disposition")).toBe(
+      'inline; filename="mealplanner.ics"',
+    );
+    expect(result.headers.get("Cache-Control")).toBe("private, max-age=3600");
+    await expect(result.text()).resolves.toBe("BEGIN:VCALENDAR\r\nEND:VCALENDAR");
+  });
+
+  it("returns 404 for an unknown token", async () => {
+    vi.mocked(getFamilyCalendarFeedByToken).mockResolvedValue(null);
+
+    await expect(
+      loader({
+        params: {
+          token: "missing",
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+
+  it("returns 404 when the token param is missing", async () => {
+    await expect(
+      loader({
+        params: {},
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      statusText: "Not Found",
+    });
+    expect(getFamilyCalendarFeedByToken).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/calendar-subscription.ts
+++ b/app/routes/calendar-subscription.ts
@@ -1,0 +1,35 @@
+import { getFamilyCalendarFeedByToken } from "../lib/calendar-subscription.server";
+
+export async function loader({
+  params,
+}: {
+  params: {
+    token?: string;
+  };
+}) {
+  const token = params.token?.trim();
+
+  if (!token) {
+    throw new Response("Fant ikke kalenderen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  const feed = await getFamilyCalendarFeedByToken(token);
+
+  if (!feed) {
+    throw new Response("Fant ikke kalenderen.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return new Response(feed.content, {
+    headers: {
+      "Cache-Control": "private, max-age=3600",
+      "Content-Disposition": 'inline; filename="mealplanner.ics"',
+      "Content-Type": "text/calendar; charset=utf-8",
+    },
+  });
+}

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -755,6 +755,12 @@ export default function FamilyMealPlanRoute({
                 )}
                 <Link
                   className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
+                  to={`/families/${loaderData.family.id}?tab=familie`}
+                >
+                  Abonner i kalenderen
+                </Link>
+                <Link
+                  className="rounded-2xl bg-white/10 px-5 py-3 text-sm font-medium text-slate-100 transition hover:bg-white/15"
                   to={`/families/${loaderData.family.id}/meal-plans`}
                 >
                   Tilbake til ukeplaner

--- a/app/routes/family.test.ts
+++ b/app/routes/family.test.ts
@@ -29,7 +29,22 @@ vi.mock("../lib/family-home.server", () => ({
   getFamilyWeekDinnerMenu: vi.fn(),
 }));
 
+vi.mock("../lib/calendar-subscription.server", () => {
+  return {
+    buildCalendarSubscriptionUrls: vi.fn(),
+    createOrRotateFamilyCalendarSubscription: vi.fn(),
+    getFamilyCalendarSubscriptionStatus: vi.fn(),
+    revokeFamilyCalendarSubscription: vi.fn(),
+  };
+});
+
 import { requireUser } from "../lib/auth.server";
+import {
+  buildCalendarSubscriptionUrls,
+  createOrRotateFamilyCalendarSubscription,
+  getFamilyCalendarSubscriptionStatus,
+  revokeFamilyCalendarSubscription,
+} from "../lib/calendar-subscription.server";
 import { getFamilyWeekDinnerMenu } from "../lib/family-home.server";
 import {
   getFamilyReminderEmail,
@@ -134,6 +149,9 @@ function mockMealPlansForFamily() {
   });
   vi.mocked(getFamilyWeekDinnerMenu).mockResolvedValue(mockWeekDays as never);
   vi.mocked(getFamilyReminderEmail).mockResolvedValue(null);
+  vi.mocked(getFamilyCalendarSubscriptionStatus).mockResolvedValue({
+    exists: false,
+  });
 }
 
 describe("family route", () => {
@@ -204,6 +222,9 @@ describe("family route", () => {
     });
     expect(result.weekDays).toEqual(mockWeekDays);
     expect(getFamilyReminderEmail).toHaveBeenCalledWith("family-1");
+    expect(getFamilyCalendarSubscriptionStatus).toHaveBeenCalledWith({
+      familyId: "family-1",
+    });
     expect(result).toMatchObject({
       family: {
         id: "family-1",
@@ -211,6 +232,7 @@ describe("family route", () => {
         name: "Solberg",
         reminderEmail: "familie@example.com",
       },
+      hasCalendarSubscription: false,
       members: [
         {
           id: "membership-1",
@@ -280,6 +302,7 @@ describe("family route", () => {
 
     expect(listFamilyMembers).not.toHaveBeenCalled();
     expect(getFamilyReminderEmail).not.toHaveBeenCalled();
+    expect(getFamilyCalendarSubscriptionStatus).not.toHaveBeenCalled();
     expect(result).toEqual({
       activeTab: "oversikt",
       family: {
@@ -288,6 +311,7 @@ describe("family route", () => {
         name: "Solberg",
         reminderEmail: null,
       },
+      hasCalendarSubscription: false,
       members: [],
       notice: null,
       recentMealPlans: [
@@ -547,6 +571,94 @@ describe("family route", () => {
     const formData = new FormData();
     formData.set("intent", "save-reminder-email");
     formData.set("reminderEmail", "familie@example.com");
+
+    await expect(
+      action({
+        params: {
+          familyId: "family-1",
+        },
+        request: buildRequest("http://localhost/families/family-1", formData),
+        context: {} as never,
+      } as unknown as Parameters<typeof action>[0]),
+    ).rejects.toMatchObject({
+      status: 403,
+      statusText: "Forbidden",
+    });
+  });
+
+  it("returns subscribe URLs after an admin creates a calendar subscription", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createOrRotateFamilyCalendarSubscription).mockResolvedValue({
+      token: "feed-token",
+    });
+    vi.mocked(buildCalendarSubscriptionUrls).mockReturnValue({
+      httpsUrl: "https://example.com/c/feed-token/calendar.ics",
+      webcalUrl: "webcal://example.com/c/feed-token/calendar.ics",
+    });
+
+    const formData = new FormData();
+    formData.set("intent", "create-calendar-subscription");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1?tab=familie", formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(createOrRotateFamilyCalendarSubscription).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(buildCalendarSubscriptionUrls).toHaveBeenCalledWith({
+      origin: "http://localhost",
+      token: "feed-token",
+    });
+    expect(result).toEqual({
+      httpsUrl: "https://example.com/c/feed-token/calendar.ics",
+      intent: "create-calendar-subscription",
+      webcalUrl: "webcal://example.com/c/feed-token/calendar.ics",
+    });
+  });
+
+  it("redirects after an admin revokes a calendar subscription", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(revokeFamilyCalendarSubscription).mockResolvedValue(undefined);
+
+    const formData = new FormData();
+    formData.set("intent", "revoke-calendar-subscription");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1", formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(revokeFamilyCalendarSubscription).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1?notice=calendar-subscription-revoked&tab=familie",
+    );
+  });
+
+  it("rethrows forbidden calendar subscription updates from members", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createOrRotateFamilyCalendarSubscription).mockRejectedValue(
+      new Response("Du har ikke tilgang til å administrere denne familien.", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    const formData = new FormData();
+    formData.set("intent", "create-calendar-subscription");
 
     await expect(
       action({

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -1,8 +1,15 @@
 import { Form, Link, isRouteErrorResponse, useNavigation } from "react-router";
 
 import type { Route } from "./+types/family";
+import { FamilyCalendarSubscriptionCard } from "../components/family-calendar-subscription-card";
 import { FamilyHomeTabs } from "../components/family-home-tabs";
 import { requireUser } from "../lib/auth.server";
+import {
+  buildCalendarSubscriptionUrls,
+  createOrRotateFamilyCalendarSubscription,
+  getFamilyCalendarSubscriptionStatus,
+  revokeFamilyCalendarSubscription,
+} from "../lib/calendar-subscription.server";
 import {
   getFamilyReminderEmail,
   listFamilyMembers,
@@ -17,6 +24,7 @@ import { isMealPlanPast } from "../lib/meal-plan-week";
 import { listMealPlansForFamily } from "../lib/meal-plan.server";
 
 type FamilyNotice =
+  | "calendar-subscription-revoked"
   | "member-removed"
   | "reminder-email-cleared"
   | "reminder-email-saved";
@@ -36,17 +44,20 @@ interface FamilyActionData {
     reminderEmail?: string;
   };
   formError?: string;
+  httpsUrl?: string;
   intent?: string;
   targetUserId?: string;
   values?: {
     reminderEmail?: string;
   };
+  webcalUrl?: string;
 }
 
 function getFamilyNotice(request: Request): FamilyNotice | null {
   const notice = new URL(request.url).searchParams.get("notice");
 
   if (
+    notice === "calendar-subscription-revoked" ||
     notice === "member-removed" ||
     notice === "reminder-email-cleared" ||
     notice === "reminder-email-saved"
@@ -85,6 +96,12 @@ function buildFamilyRedirect({
 
 function getFamilyNoticeContent(notice: FamilyNotice) {
   switch (notice) {
+    case "calendar-subscription-revoked":
+      return {
+        description:
+          "Kalenderabonnementet er opphevet. Eksisterende abonnement slutter å oppdatere.",
+        title: "Endringen er lagret",
+      };
     case "member-removed":
       return {
         description: "Medlemmet ble fjernet fra familien.",
@@ -282,7 +299,8 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     familyId,
     userId: user.id,
   });
-  const [members, mealPlanResult, weekDays, reminderEmail] = await Promise.all([
+  const [members, mealPlanResult, weekDays, reminderEmail, calendarSubscription] =
+    await Promise.all([
     membership.role === "ADMIN"
       ? listFamilyMembers(familyId)
       : Promise.resolve([]),
@@ -297,6 +315,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     membership.role === "ADMIN"
       ? getFamilyReminderEmail(familyId)
       : Promise.resolve(null),
+    membership.role === "ADMIN"
+      ? getFamilyCalendarSubscriptionStatus({ familyId })
+      : Promise.resolve({ exists: false }),
   ]);
 
   const serializedMealPlans = mealPlanResult.mealPlans.map(
@@ -311,6 +332,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
       name: membership.family.name,
       reminderEmail,
     },
+    hasCalendarSubscription: calendarSubscription.exists,
     members,
     notice: getFamilyNotice(request),
     recentMealPlans: serializedMealPlans.slice(0, 3),
@@ -320,7 +342,10 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   };
 }
 
-export async function action({ params, request }: Route.ActionArgs) {
+export async function action({
+  params,
+  request,
+}: Route.ActionArgs): Promise<FamilyActionData | Response> {
   const user = await requireUser(request);
   const familyId = params.familyId;
 
@@ -358,6 +383,37 @@ export async function action({ params, request }: Route.ActionArgs) {
         result.status === "CLEARED"
           ? "reminder-email-cleared"
           : "reminder-email-saved",
+      request,
+    });
+  }
+
+  if (
+    intent === "create-calendar-subscription" ||
+    intent === "rotate-calendar-subscription"
+  ) {
+    const result = await createOrRotateFamilyCalendarSubscription({
+      familyId,
+      userId: user.id,
+    });
+
+    return {
+      intent,
+      ...buildCalendarSubscriptionUrls({
+        origin: new URL(request.url).origin,
+        token: result.token,
+      }),
+    } satisfies FamilyActionData;
+  }
+
+  if (intent === "revoke-calendar-subscription") {
+    await revokeFamilyCalendarSubscription({
+      familyId,
+      userId: user.id,
+    });
+
+    return buildFamilyRedirect({
+      familyId,
+      notice: "calendar-subscription-revoked",
       request,
     });
   }
@@ -426,6 +482,15 @@ export default function FamilyRoute({
     navigation.state !== "idle" && pendingIntent === "remove-member";
   const isSavingReminderEmail =
     navigation.state !== "idle" && pendingIntent === "save-reminder-email";
+  const isCreatingCalendarSubscription =
+    navigation.state !== "idle" &&
+    pendingIntent === "create-calendar-subscription";
+  const isRotatingCalendarSubscription =
+    navigation.state !== "idle" &&
+    pendingIntent === "rotate-calendar-subscription";
+  const isRevokingCalendarSubscription =
+    navigation.state !== "idle" &&
+    pendingIntent === "revoke-calendar-subscription";
   const isAdmin = loaderData.userRole === "ADMIN";
   const familyId = loaderData.family.id;
   const reminderEmailValue = isSavingReminderEmail
@@ -563,6 +628,20 @@ export default function FamilyRoute({
                     </button>
                   </Form>
                 </section>
+              ) : null}
+
+              {isAdmin ? (
+                <FamilyCalendarSubscriptionCard
+                  hasCalendarSubscription={
+                    loaderData.hasCalendarSubscription &&
+                    !isRevokingCalendarSubscription
+                  }
+                  httpsUrl={actionData?.httpsUrl}
+                  isCreating={isCreatingCalendarSubscription}
+                  isRevoking={isRevokingCalendarSubscription}
+                  isRotating={isRotatingCalendarSubscription}
+                  webcalUrl={actionData?.webcalUrl}
+                />
               ) : null}
 
               {isAdmin ? (

--- a/prisma/migrations/20260901140000_add_calendar_subscription/migration.sql
+++ b/prisma/migrations/20260901140000_add_calendar_subscription/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "CalendarSubscription" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "createdByUserId" TEXT,
+    "tokenHash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CalendarSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CalendarSubscription_familyId_key" ON "CalendarSubscription"("familyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CalendarSubscription_tokenHash_key" ON "CalendarSubscription"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "CalendarSubscription_createdByUserId_idx" ON "CalendarSubscription"("createdByUserId");
+
+-- AddForeignKey
+ALTER TABLE "CalendarSubscription" ADD CONSTRAINT "CalendarSubscription_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CalendarSubscription" ADD CONSTRAINT "CalendarSubscription_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,6 +103,7 @@ model User {
   shoppingItemCheckEvents         ShoppingItemCheckEvent[]       @relation("ShoppingItemCheckEventActor")
   passwordResetTokens             PasswordResetToken[]
   createdShoppingListShares       ShoppingListShare[]            @relation("ShoppingListShareCreatedBy")
+  createdCalendarSubscriptions    CalendarSubscription[]         @relation("CalendarSubscriptionCreatedBy")
 
   @@index([displayName])
 }
@@ -143,6 +144,7 @@ model Family {
   shoppingItemCheckEvents    ShoppingItemCheckEvent[]
   ingredientCategories       IngredientCategory[]
   shoppingListShares         ShoppingListShare[]
+  calendarSubscription       CalendarSubscription?
 
   @@index([createdByUserId])
   @@index([name])
@@ -589,6 +591,19 @@ model ShoppingListShare {
   createdByUser   User     @relation("ShoppingListShareCreatedBy", fields: [createdByUserId], references: [id], onDelete: Cascade)
 
   @@index([familyId, createdAt])
+  @@index([createdByUserId])
+}
+
+model CalendarSubscription {
+  id              String   @id @default(cuid())
+  familyId        String   @unique
+  createdByUserId String?
+  tokenHash       String   @unique
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  family          Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  createdByUser   User?    @relation("CalendarSubscriptionCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
+
   @@index([createdByUserId])
 }
 


### PR DESCRIPTION
## Summary
- Admins can create a secret family iCal URL on the Familie tab so phones can subscribe instead of importing a multi-event `.ics` file.
- Calendar apps poll `GET /c/:token/calendar.ics` without a login cookie; the feed covers this week and next, and rotate/revoke invalidates the old link.
- Existing cookie-gated week/day `.ics` downloads stay as one-shot attachments.

## Related issue
Closes #239

## Test plan
- [ ] Validation run locally: lint, test:run, typecheck
- [ ] As family admin, open Familie → Abonner i kalenderen and create a subscription
- [ ] Copy the HTTPS URL into Google Calendar “From URL”
- [ ] Open the webcal URL on iPhone and confirm dinners appear
- [ ] Change a planned dinner and confirm the subscribed event updates after refresh (may take hours)
- [ ] Rotate/revoke the link and confirm the old URL 404s
- [ ] Confirm week/day “Eksporter (.ics)” downloads still work while logged in

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck