### PR TITLE
Let AI agents read family meal data over MCP

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,38 @@
 
 ## Current Objective
 
-Ship the family iCal subscription feed ([#239](https://github.com/sndrem/mealplanner/issues/239)): commit, push, and open a PR.
+Ship family-scoped MCP on the existing Fly web process ([#241](https://github.com/sndrem/mealplanner/issues/241)): commit, push, and open a PR.
 
 ## Completed
 
-- Family-level live iCal feed at `GET /c/:token/calendar.ics` behind a hashed token
-- ADMIN Familie-tab card to create, copy HTTPS + webcal URLs, rotate, and revoke
-- Existing cookie-gated week/day `.ics` downloads unchanged
+- Read-only Streamable HTTP MCP at `/mcp` on the existing React Router process
+- Family hashed bearer token with admin create/rotate/revoke on the Familie tab
+- Tools for recipes, current-week meal plan, shopping list, recent dinners, and freezer items
+- Docs in `docs/mcp.md`; Fly pointer in `docs/deploy-fly.md`
 - Branch cut from current `origin/main` after `git pull --ff-only`
 
 ## Files To Read First
 
-- `app/lib/calendar-subscription.server.ts` — token CRUD and 14-day feed query
-- `app/routes/calendar-subscription.ts` — public unauthenticated ICS route
-- `app/components/family-calendar-subscription-card.tsx` — subscribe UI
+- `app/lib/mcp-handler.server.ts` — MCP v2 handler and tool registration
+- `app/lib/mcp-token.server.ts` — hashed token CRUD and Bearer auth
+- `app/routes/mcp.ts` — public `/mcp` resource route
+- `app/components/family-mcp-token-card.tsx` — admin mint UI
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 590 tests passed
+- `npm run test:run` — 613 tests passed
 - `npm run typecheck` — passed
-- Browser subscribe flow (iPhone `webcal://`, Google From URL) — not run
+- Browser Familie-tab mint flow — not run
+- MCP Inspector / Cursor against `/mcp` — not run (restart Vite so it picks up the new Prisma client)
 
 ## Open Items
 
-- Apply migration `20260901140000_add_calendar_subscription` on deploy/local DB
-- Manual after merge: subscribe from iPhone and Google Calendar; refresh is not instant
+- Production migration runs via Fly `release_command` (`prisma migrate deploy`)
+- After merge: mint a key, connect Inspector or Cursor to `/mcp`
+- Follow-ups: suggestion persist/view and periodic agent (out of scope)
 
 ## Next Step
 
-Merge the PR for #239 and confirm the migration runs in the usual deploy path.
+Merge the PR for #241 after review.

--- a/app/components/family-mcp-token-card.tsx
+++ b/app/components/family-mcp-token-card.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Form } from "react-router";
+
+export function FamilyMcpTokenCard({
+  hasMcpToken,
+  isCreating,
+  isRevoking,
+  isRotating,
+  mcpToken,
+  mcpUrl,
+}: {
+  hasMcpToken: boolean;
+  isCreating: boolean;
+  isRevoking: boolean;
+  isRotating: boolean;
+  mcpToken?: string;
+  mcpUrl: string;
+}) {
+  return (
+    <section className="rounded-[28px] bg-white p-6 shadow-sm ring-1 ring-slate-200">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold text-slate-950">AI-tilgang (MCP)</h2>
+        <p className="text-sm leading-6 text-slate-600">
+          Lag et hemmelig nøkkelord som en AI-agent kan bruke for å lese
+          oppskrifter, ukeplan og handleliste. Del det ikke offentlig. Bytt
+          nøkkel hvis det kommer på avveie.
+        </p>
+      </div>
+
+      <label className="mt-6 block text-sm font-medium text-slate-700">
+        MCP-adresse
+        <input
+          className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-950 outline-none transition focus:border-slate-400"
+          readOnly
+          value={mcpUrl}
+        />
+      </label>
+      <CopyButton label="Kopier adresse" value={mcpUrl} />
+
+      {mcpToken ? <McpTokenResult token={mcpToken} /> : null}
+
+      {!hasMcpToken ? (
+        <Form className="mt-6" method="post">
+          <input name="intent" type="hidden" value="create-mcp-token" />
+          <button
+            className="inline-flex w-fit items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+            type="submit"
+          >
+            {isCreating ? "Oppretter..." : "Opprett nøkkel"}
+          </button>
+        </Form>
+      ) : (
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Form
+            method="post"
+            onSubmit={(event) => {
+              if (
+                !window.confirm(
+                  "Bytter du nøkkel, slutter eksisterende agenter å få tilgang. Fortsette?",
+                )
+              ) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <input name="intent" type="hidden" value="rotate-mcp-token" />
+            <button
+              className="inline-flex w-fit items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+              type="submit"
+            >
+              {isRotating ? "Bytter nøkkel..." : "Bytt nøkkel"}
+            </button>
+          </Form>
+          <Form
+            method="post"
+            onSubmit={(event) => {
+              if (
+                !window.confirm(
+                  "Opphever du nøkkelen, mister agenter tilgang til familiens data. Fortsette?",
+                )
+              ) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <input name="intent" type="hidden" value="revoke-mcp-token" />
+            <button
+              className="inline-flex w-fit items-center justify-center rounded-2xl bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-700"
+              type="submit"
+            >
+              {isRevoking ? "Opphever..." : "Opphev"}
+            </button>
+          </Form>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function McpTokenResult({ token }: { token: string }) {
+  return (
+    <div className="mt-6 grid gap-2">
+      <p className="text-sm font-medium text-slate-950">Nøkkelen er klar</p>
+      <p className="text-sm leading-6 text-slate-600">
+        Kopier nøkkelen nå — den vises ikke igjen. Bruk den som Bearer-token mot
+        MCP-adressen.
+      </p>
+      <label className="block text-sm font-medium text-slate-700">
+        Nøkkel
+        <input
+          className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-950 outline-none transition focus:border-slate-400"
+          readOnly
+          value={token}
+        />
+      </label>
+      <CopyButton label="Kopier nøkkel" value={token} />
+    </div>
+  );
+}
+
+function CopyButton({ label, value }: { label: string; value: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
+    "idle",
+  );
+
+  return (
+    <>
+      <button
+        className="mt-2 inline-flex items-center justify-center rounded-2xl bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+        onClick={async () => {
+          try {
+            await navigator.clipboard.writeText(value);
+            setCopyState("copied");
+          } catch {
+            setCopyState("failed");
+          }
+        }}
+        type="button"
+      >
+        {copyState === "copied" ? "Kopiert" : label}
+      </button>
+      {copyState === "failed" ? (
+        <p className="mt-2 text-sm text-rose-700">
+          Kunne ikke kopiere. Marker feltet og kopier manuelt.
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/app/lib/mcp-handler.server.ts
+++ b/app/lib/mcp-handler.server.ts
@@ -1,0 +1,167 @@
+import {
+  type AuthInfo,
+  createMcpHandler,
+  McpServer,
+} from "@modelcontextprotocol/server";
+import { z } from "zod";
+
+import {
+  getCurrentWeekMealPlanForMcp,
+  getRecentDinnersForMcp,
+  getRecipeForMcp,
+  getShoppingListForMcp,
+  listFreezerItemsForMcp,
+  listMealPlansForMcp,
+  listRecipesForMcp,
+} from "./mcp-tools.server";
+
+function requireMcpActor(authInfo: AuthInfo | undefined) {
+  const familyId =
+    typeof authInfo?.extra?.familyId === "string" ? authInfo.extra.familyId : "";
+  const userId =
+    typeof authInfo?.extra?.userId === "string" ? authInfo.extra.userId : "";
+
+  if (!familyId || !userId) {
+    throw new Error("MCP request is missing family auth.");
+  }
+
+  return { familyId, userId };
+}
+
+function jsonResult(data: unknown, summary: string) {
+  return {
+    content: [{ text: summary, type: "text" as const }],
+    structuredContent: data as Record<string, unknown>,
+  };
+}
+
+export const mcpHttpHandler = createMcpHandler(
+  ({ authInfo }) => {
+    const actor = requireMcpActor(authInfo);
+    const server = new McpServer({
+      name: "mealplanner",
+      version: "1.0.0",
+    });
+
+    server.registerTool(
+      "list_recipes",
+      {
+        description:
+          "List family and global recipes with title, description, image URL, tags, servings, and prep time.",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        const data = await listRecipesForMcp(actor);
+        return jsonResult(
+          data,
+          `Found ${data.recipes.length} recipes.`,
+        );
+      },
+    );
+
+    server.registerTool(
+      "get_recipe",
+      {
+        description:
+          "Get one accessible recipe (family or global) including ingredients.",
+        inputSchema: z.object({
+          recipeId: z.string().min(1).describe("Recipe id"),
+        }),
+      },
+      async ({ recipeId }) => {
+        const data = await getRecipeForMcp({ ...actor, recipeId });
+
+        if (!data) {
+          return {
+            content: [{ text: "Fant ikke oppskriften.", type: "text" as const }],
+            isError: true,
+          };
+        }
+
+        return jsonResult(data, data.recipe.title);
+      },
+    );
+
+    server.registerTool(
+      "get_current_week_meal_plan",
+      {
+        description:
+          "Get this week's dinner plan (Europe/Oslo calendar week), including recipe title, description, and image URL.",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        const data = await getCurrentWeekMealPlanForMcp(actor);
+        return jsonResult(
+          data,
+          data.mealPlan
+            ? `Meal plan ${data.mealPlan.title} covers ${data.weekStart}–${data.weekEnd}.`
+            : `No meal plan covers ${data.weekStart}–${data.weekEnd}.`,
+        );
+      },
+    );
+
+    server.registerTool(
+      "list_meal_plans",
+      {
+        description: "List meal plan summaries for the family.",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        const data = await listMealPlansForMcp(actor);
+        return jsonResult(data, `${data.mealPlans.length} meal plans.`);
+      },
+    );
+
+    server.registerTool(
+      "get_shopping_list",
+      {
+        description:
+          "Get the current family shopping list (generated, manual, and family items).",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        const data = await getShoppingListForMcp(actor);
+        return jsonResult(
+          data,
+          `${data.itemCounts.unchecked} unchecked of ${data.itemCounts.total} items (${data.activeListMode}).`,
+        );
+      },
+    );
+
+    server.registerTool(
+      "get_recent_dinners",
+      {
+        description:
+          "List recently used dinner recipes so a planner can avoid repeats.",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        const data = await getRecentDinnersForMcp(actor);
+        return jsonResult(
+          data,
+          `${data.recipes.length} recently used dinner recipes.`,
+        );
+      },
+    );
+
+    server.registerTool(
+      "list_freezer_items",
+      {
+        description: "List the family's freezer items.",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        const data = await listFreezerItemsForMcp(actor);
+        return jsonResult(
+          data,
+          `${data.freezerItems.length} freezer items.`,
+        );
+      },
+    );
+
+    return server;
+  },
+  {
+    responseMode: "json",
+  },
+);

--- a/app/lib/mcp-token.server.test.ts
+++ b/app/lib/mcp-token.server.test.ts
@@ -1,0 +1,248 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, randomBytesMock, requireFamilyAdminMock } = vi.hoisted(() => {
+  const familyMcpToken = {
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  };
+  const familyMembership = {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+  };
+
+  return {
+    dbMock: {
+      $transaction: vi.fn(),
+      familyMembership,
+      familyMcpToken,
+    },
+    randomBytesMock: vi.fn(),
+    requireFamilyAdminMock: vi.fn(),
+  };
+});
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./family.server", () => ({
+  requireFamilyAdmin: requireFamilyAdminMock,
+  requireFamilyMembership: vi.fn(),
+}));
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+
+  return {
+    ...actual,
+    randomBytes: randomBytesMock,
+  };
+});
+
+import {
+  buildFamilyMcpUrl,
+  createOrRotateFamilyMcpToken,
+  getFamilyMcpTokenStatus,
+  hashFamilyMcpToken,
+  resolveFamilyMcpAuth,
+  revokeFamilyMcpToken,
+} from "./mcp-token.server";
+
+const RAW_TOKEN = "a".repeat(64);
+const TOKEN_HASH = createHash("sha256").update(RAW_TOKEN).digest("hex");
+
+const mockAdmin = {
+  family: {
+    id: "family-1",
+    joinCode: "ABC123",
+    name: "Solberg",
+  },
+  familyId: "family-1",
+  id: "membership-1",
+  role: "ADMIN",
+  userId: "user-1",
+};
+
+describe("mcp-token.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-02T08:00:00.000Z"));
+    requireFamilyAdminMock.mockResolvedValue(mockAdmin);
+    randomBytesMock.mockReturnValue(Buffer.from(RAW_TOKEN, "hex"));
+    dbMock.$transaction.mockImplementation(
+      async (callback: (tx: typeof dbMock) => unknown) => callback(dbMock),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hashes MCP tokens with SHA-256", () => {
+    expect(hashFamilyMcpToken(RAW_TOKEN)).toBe(TOKEN_HASH);
+  });
+
+  it("builds the MCP endpoint URL from an origin", () => {
+    expect(buildFamilyMcpUrl("https://mealplanner.example/")).toBe(
+      "https://mealplanner.example/mcp",
+    );
+  });
+
+  it("stores a hashed token and returns the raw token once", async () => {
+    dbMock.familyMcpToken.deleteMany.mockResolvedValue({ count: 0 });
+    dbMock.familyMcpToken.create.mockResolvedValue({ id: "mcp-1" });
+
+    const result = await createOrRotateFamilyMcpToken({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyAdminMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ token: RAW_TOKEN });
+    expect(dbMock.familyMcpToken.deleteMany).toHaveBeenCalledWith({
+      where: { familyId: "family-1" },
+    });
+    expect(dbMock.familyMcpToken.create).toHaveBeenCalledWith({
+      data: {
+        createdByUserId: "user-1",
+        familyId: "family-1",
+        tokenHash: TOKEN_HASH,
+      },
+    });
+  });
+
+  it("revokes the family MCP token", async () => {
+    dbMock.familyMcpToken.deleteMany.mockResolvedValue({ count: 1 });
+
+    await revokeFamilyMcpToken({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(requireFamilyAdminMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(dbMock.familyMcpToken.deleteMany).toHaveBeenCalledWith({
+      where: { familyId: "family-1" },
+    });
+  });
+
+  it("reports whether an MCP token exists", async () => {
+    dbMock.familyMcpToken.findUnique.mockResolvedValue({ id: "mcp-1" });
+
+    await expect(
+      getFamilyMcpTokenStatus({ familyId: "family-1" }),
+    ).resolves.toEqual({ exists: true });
+
+    dbMock.familyMcpToken.findUnique.mockResolvedValue(null);
+
+    await expect(
+      getFamilyMcpTokenStatus({ familyId: "family-1" }),
+    ).resolves.toEqual({ exists: false });
+  });
+
+  it("returns null when the Authorization header is missing or invalid", async () => {
+    await expect(resolveFamilyMcpAuth(null)).resolves.toBeNull();
+    await expect(resolveFamilyMcpAuth("Basic abc")).resolves.toBeNull();
+    expect(dbMock.familyMcpToken.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null for an unknown bearer token", async () => {
+    dbMock.familyMcpToken.findUnique.mockResolvedValue(null);
+
+    await expect(
+      resolveFamilyMcpAuth(`Bearer ${RAW_TOKEN}`),
+    ).resolves.toBeNull();
+  });
+
+  it("resolves family and creator user, then records lastUsedAt", async () => {
+    dbMock.familyMcpToken.findUnique.mockResolvedValue({
+      createdByUserId: "user-1",
+      familyId: "family-1",
+      id: "mcp-1",
+    });
+    dbMock.familyMembership.findUnique.mockResolvedValue({
+      userId: "user-1",
+    });
+    dbMock.familyMcpToken.update.mockResolvedValue({ id: "mcp-1" });
+
+    await expect(
+      resolveFamilyMcpAuth(`Bearer ${RAW_TOKEN}`),
+    ).resolves.toEqual({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+
+    expect(dbMock.familyMcpToken.findUnique).toHaveBeenCalledWith({
+      select: {
+        createdByUserId: true,
+        familyId: true,
+        id: true,
+      },
+      where: {
+        tokenHash: TOKEN_HASH,
+      },
+    });
+    expect(dbMock.familyMembership.findUnique).toHaveBeenCalledWith({
+      select: {
+        userId: true,
+      },
+      where: {
+        familyId_userId: {
+          familyId: "family-1",
+          userId: "user-1",
+        },
+      },
+    });
+    expect(dbMock.familyMcpToken.update).toHaveBeenCalledWith({
+      data: {
+        lastUsedAt: new Date("2026-09-02T08:00:00.000Z"),
+      },
+      where: {
+        id: "mcp-1",
+      },
+    });
+  });
+
+  it("falls back to a remaining family admin when the creator left", async () => {
+    dbMock.familyMcpToken.findUnique.mockResolvedValue({
+      createdByUserId: "user-gone",
+      familyId: "family-1",
+      id: "mcp-1",
+    });
+    dbMock.familyMembership.findUnique.mockResolvedValue(null);
+    dbMock.familyMembership.findFirst.mockResolvedValue({
+      userId: "admin-2",
+    });
+    dbMock.familyMcpToken.update.mockResolvedValue({ id: "mcp-1" });
+
+    await expect(
+      resolveFamilyMcpAuth(`Bearer ${RAW_TOKEN}`),
+    ).resolves.toEqual({
+      familyId: "family-1",
+      userId: "admin-2",
+    });
+  });
+
+  it("returns null when no family members remain", async () => {
+    dbMock.familyMcpToken.findUnique.mockResolvedValue({
+      createdByUserId: null,
+      familyId: "family-1",
+      id: "mcp-1",
+    });
+    dbMock.familyMembership.findFirst.mockResolvedValue(null);
+
+    await expect(
+      resolveFamilyMcpAuth(`Bearer ${RAW_TOKEN}`),
+    ).resolves.toBeNull();
+    expect(dbMock.familyMcpToken.update).not.toHaveBeenCalled();
+  });
+});

--- a/app/lib/mcp-token.server.ts
+++ b/app/lib/mcp-token.server.ts
@@ -1,0 +1,183 @@
+import { createHash, randomBytes } from "node:crypto";
+import { FamilyRole } from "@prisma/client";
+
+import { db } from "./db.server";
+import { requireFamilyAdmin } from "./family.server";
+
+export function hashFamilyMcpToken(rawToken: string) {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+export function createFamilyMcpRawToken() {
+  return randomBytes(32).toString("hex");
+}
+
+export function buildFamilyMcpUrl(origin: string) {
+  return `${origin.replace(/\/+$/, "")}/mcp`;
+}
+
+function parseBearerToken(authorizationHeader: string | null) {
+  if (!authorizationHeader?.startsWith("Bearer ")) {
+    return "";
+  }
+
+  return authorizationHeader.slice("Bearer ".length).trim();
+}
+
+export async function getFamilyMcpTokenStatus({
+  familyId,
+}: {
+  familyId: string;
+}) {
+  const token = await db.familyMcpToken.findUnique({
+    select: {
+      id: true,
+    },
+    where: {
+      familyId,
+    },
+  });
+
+  return {
+    exists: Boolean(token),
+  };
+}
+
+export async function createOrRotateFamilyMcpToken({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  const token = createFamilyMcpRawToken();
+  const tokenHash = hashFamilyMcpToken(token);
+
+  await db.$transaction(async (tx) => {
+    await tx.familyMcpToken.deleteMany({
+      where: {
+        familyId,
+      },
+    });
+    await tx.familyMcpToken.create({
+      data: {
+        createdByUserId: userId,
+        familyId,
+        tokenHash,
+      },
+    });
+  });
+
+  return {
+    token,
+  };
+}
+
+export async function revokeFamilyMcpToken({
+  familyId,
+  userId,
+}: {
+  familyId: string;
+  userId: string;
+}) {
+  await requireFamilyAdmin({
+    familyId,
+    userId,
+  });
+
+  await db.familyMcpToken.deleteMany({
+    where: {
+      familyId,
+    },
+  });
+}
+
+async function resolveMcpActorUserId({
+  createdByUserId,
+  familyId,
+}: {
+  createdByUserId: string | null;
+  familyId: string;
+}) {
+  if (createdByUserId) {
+    const creatorMembership = await db.familyMembership.findUnique({
+      select: {
+        userId: true,
+      },
+      where: {
+        familyId_userId: {
+          familyId,
+          userId: createdByUserId,
+        },
+      },
+    });
+
+    if (creatorMembership) {
+      return creatorMembership.userId;
+    }
+  }
+
+  const adminMembership = await db.familyMembership.findFirst({
+    orderBy: [{ createdAt: "asc" }],
+    select: {
+      userId: true,
+    },
+    where: {
+      familyId,
+      role: FamilyRole.ADMIN,
+    },
+  });
+
+  return adminMembership?.userId ?? null;
+}
+
+export async function resolveFamilyMcpAuth(authorizationHeader: string | null) {
+  const rawToken = parseBearerToken(authorizationHeader);
+
+  if (!rawToken) {
+    return null;
+  }
+
+  const token = await db.familyMcpToken.findUnique({
+    select: {
+      createdByUserId: true,
+      familyId: true,
+      id: true,
+    },
+    where: {
+      tokenHash: hashFamilyMcpToken(rawToken),
+    },
+  });
+
+  if (!token) {
+    return null;
+  }
+
+  const userId = await resolveMcpActorUserId({
+    createdByUserId: token.createdByUserId,
+    familyId: token.familyId,
+  });
+
+  if (!userId) {
+    return null;
+  }
+
+  await db.familyMcpToken.update({
+    data: {
+      lastUsedAt: new Date(),
+    },
+    where: {
+      id: token.id,
+    },
+  });
+
+  return {
+    familyId: token.familyId,
+    userId,
+  };
+}

--- a/app/lib/mcp-tools.server.test.ts
+++ b/app/lib/mcp-tools.server.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  findMealPlanCoveringDateMock,
+  getAccessibleRecipeDetailMock,
+  getCalendarWeekBoundsMock,
+  getCalendarWeekDatesMock,
+  getFamilyShoppingDataMock,
+  getMealPlanPlanningDataMock,
+  getRecentlyUsedRecipeIdsMock,
+  getRecipeManagementDataMock,
+  listFamilyFreezerItemsMock,
+  listMealPlansForFamilyMock,
+  dbMock,
+} = vi.hoisted(() => ({
+  dbMock: {
+    recipe: {
+      findMany: vi.fn(),
+    },
+  },
+  findMealPlanCoveringDateMock: vi.fn(),
+  getAccessibleRecipeDetailMock: vi.fn(),
+  getCalendarWeekBoundsMock: vi.fn(),
+  getCalendarWeekDatesMock: vi.fn(),
+  getFamilyShoppingDataMock: vi.fn(),
+  getMealPlanPlanningDataMock: vi.fn(),
+  getRecentlyUsedRecipeIdsMock: vi.fn(),
+  getRecipeManagementDataMock: vi.fn(),
+  listFamilyFreezerItemsMock: vi.fn(),
+  listMealPlansForFamilyMock: vi.fn(),
+}));
+
+vi.mock("./db.server", () => ({
+  db: dbMock,
+}));
+
+vi.mock("./recipe.server", () => ({
+  getAccessibleRecipeDetail: getAccessibleRecipeDetailMock,
+  getRecipeManagementData: getRecipeManagementDataMock,
+}));
+
+vi.mock("./meal-plan-for-date.server", () => ({
+  findMealPlanCoveringDate: findMealPlanCoveringDateMock,
+}));
+
+vi.mock("./meal-plan.server", () => ({
+  getMealPlanPlanningData: getMealPlanPlanningDataMock,
+  getRecentlyUsedRecipeIds: getRecentlyUsedRecipeIdsMock,
+  listMealPlansForFamily: listMealPlansForFamilyMock,
+}));
+
+vi.mock("./meal-plan-week", () => ({
+  getCalendarWeekBounds: getCalendarWeekBoundsMock,
+  getCalendarWeekDates: getCalendarWeekDatesMock,
+}));
+
+vi.mock("./shopping.server", () => ({
+  getFamilyShoppingData: getFamilyShoppingDataMock,
+}));
+
+vi.mock("./freezer.server", () => ({
+  listFamilyFreezerItems: listFamilyFreezerItemsMock,
+}));
+
+import {
+  getCurrentWeekMealPlanForMcp,
+  getRecentDinnersForMcp,
+  getRecipeForMcp,
+  getShoppingListForMcp,
+  listFreezerItemsForMcp,
+  listMealPlansForMcp,
+  listRecipesForMcp,
+} from "./mcp-tools.server";
+
+const actor = { familyId: "family-1", userId: "user-1" };
+
+describe("mcp-tools.server", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flattens family and global recipes including missing images", async () => {
+    getRecipeManagementDataMock.mockResolvedValue({
+      familyRecipes: [
+        {
+          defaultServings: 4,
+          description: null,
+          id: "family-recipe",
+          imageUrl: null,
+          prepMinutes: 20,
+          scope: "FAMILY",
+          tags: ["middag"],
+          title: "Taco",
+        },
+      ],
+      globalRecipes: [
+        {
+          defaultServings: 2,
+          description: "En global rett",
+          id: "global-recipe",
+          imageUrl: "https://images.example.com/pizza.jpg",
+          prepMinutes: null,
+          scope: "GLOBAL",
+          tags: [],
+          title: "Pizza",
+        },
+      ],
+    });
+
+    await expect(listRecipesForMcp(actor)).resolves.toEqual({
+      recipes: [
+        {
+          defaultServings: 4,
+          description: null,
+          id: "family-recipe",
+          imageUrl: null,
+          prepMinutes: 20,
+          scope: "FAMILY",
+          tags: ["middag"],
+          title: "Taco",
+        },
+        {
+          defaultServings: 2,
+          description: "En global rett",
+          id: "global-recipe",
+          imageUrl: "https://images.example.com/pizza.jpg",
+          prepMinutes: null,
+          scope: "GLOBAL",
+          tags: [],
+          title: "Pizza",
+        },
+      ],
+    });
+  });
+
+  it("returns a global recipe detail", async () => {
+    getAccessibleRecipeDetailMock.mockResolvedValue({
+      recipe: {
+        defaultServings: 2,
+        description: "En global rett",
+        familyId: null,
+        id: "global-recipe",
+        imageUrl: "https://images.example.com/pizza.jpg",
+        ingredients: [
+          {
+            amount: "200",
+            category: { displayName: "Meieri", id: "cat-1" },
+            displayName: "Ost",
+            unit: "g",
+          },
+        ],
+        prepMinutes: 15,
+        scope: "GLOBAL",
+        tags: [],
+        title: "Pizza",
+      },
+      status: "FOUND",
+    });
+
+    await expect(
+      getRecipeForMcp({ ...actor, recipeId: "global-recipe" }),
+    ).resolves.toEqual({
+      recipe: {
+        defaultServings: 2,
+        description: "En global rett",
+        id: "global-recipe",
+        imageUrl: "https://images.example.com/pizza.jpg",
+        ingredients: [
+          {
+            amount: "200",
+            category: "Meieri",
+            displayName: "Ost",
+            unit: "g",
+          },
+        ],
+        prepMinutes: 15,
+        scope: "GLOBAL",
+        tags: [],
+        title: "Pizza",
+      },
+    });
+  });
+
+  it("returns null when a recipe is not accessible", async () => {
+    getAccessibleRecipeDetailMock.mockResolvedValue({
+      status: "NOT_FOUND",
+    });
+
+    await expect(
+      getRecipeForMcp({ ...actor, recipeId: "missing" }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns empty dinners when no meal plan covers this week", async () => {
+    getCalendarWeekBoundsMock.mockReturnValue({
+      weekEnd: "2026-09-06",
+      weekStart: "2026-08-31",
+    });
+    getCalendarWeekDatesMock.mockReturnValue(["2026-08-31", "2026-09-01"]);
+    findMealPlanCoveringDateMock.mockResolvedValue(null);
+
+    await expect(getCurrentWeekMealPlanForMcp(actor)).resolves.toEqual({
+      dinners: [
+        {
+          date: "2026-08-31",
+          description: null,
+          freezerLabel: null,
+          imageUrl: null,
+          note: null,
+          recipeId: null,
+          title: null,
+        },
+        {
+          date: "2026-09-01",
+          description: null,
+          freezerLabel: null,
+          imageUrl: null,
+          note: null,
+          recipeId: null,
+          title: null,
+        },
+      ],
+      mealPlan: null,
+      weekEnd: "2026-09-06",
+      weekStart: "2026-08-31",
+    });
+    expect(getMealPlanPlanningDataMock).not.toHaveBeenCalled();
+  });
+
+  it("maps dinner entries from the covering meal plan", async () => {
+    getCalendarWeekBoundsMock.mockReturnValue({
+      weekEnd: "2026-09-06",
+      weekStart: "2026-08-31",
+    });
+    getCalendarWeekDatesMock.mockReturnValue(["2026-08-31", "2026-09-01"]);
+    findMealPlanCoveringDateMock.mockResolvedValue({
+      endDate: new Date("2026-09-06T00:00:00.000Z"),
+      id: "plan-1",
+      startDate: new Date("2026-08-31T00:00:00.000Z"),
+      status: "DRAFT",
+      title: "Uke 36",
+    });
+    getMealPlanPlanningDataMock.mockResolvedValue({
+      mealPlan: {
+        endDate: new Date("2026-09-06T00:00:00.000Z"),
+        entries: [
+          {
+            date: new Date("2026-08-31T00:00:00.000Z"),
+            freezerItem: null,
+            mealType: "DINNER",
+            note: null,
+            recipe: {
+              description: "Taco-kveld",
+              imageUrl: "https://images.example.com/taco.jpg",
+              title: "Taco",
+            },
+            recipeId: "recipe-taco",
+          },
+          {
+            date: new Date("2026-08-31T00:00:00.000Z"),
+            freezerItem: null,
+            mealType: "LUNCH",
+            note: "skip",
+            recipe: {
+              description: null,
+              imageUrl: null,
+              title: "Lunsj",
+            },
+            recipeId: "recipe-lunch",
+          },
+        ],
+        id: "plan-1",
+        startDate: new Date("2026-08-31T00:00:00.000Z"),
+        status: "DRAFT",
+        title: "Uke 36",
+      },
+    });
+
+    await expect(getCurrentWeekMealPlanForMcp(actor)).resolves.toEqual({
+      dinners: [
+        {
+          date: "2026-08-31",
+          description: "Taco-kveld",
+          freezerLabel: null,
+          imageUrl: "https://images.example.com/taco.jpg",
+          note: null,
+          recipeId: "recipe-taco",
+          title: "Taco",
+        },
+        {
+          date: "2026-09-01",
+          description: null,
+          freezerLabel: null,
+          imageUrl: null,
+          note: null,
+          recipeId: null,
+          title: null,
+        },
+      ],
+      mealPlan: {
+        endDate: "2026-09-06",
+        id: "plan-1",
+        startDate: "2026-08-31",
+        status: "DRAFT",
+        title: "Uke 36",
+      },
+      weekEnd: "2026-09-06",
+      weekStart: "2026-08-31",
+    });
+  });
+
+  it("lists meal plan summaries", async () => {
+    listMealPlansForFamilyMock.mockResolvedValue({
+      mealPlans: [
+        {
+          endDate: new Date("2026-09-06T00:00:00.000Z"),
+          id: "plan-1",
+          startDate: new Date("2026-08-31T00:00:00.000Z"),
+          status: "DRAFT",
+          title: "Uke 36",
+        },
+      ],
+    });
+
+    await expect(listMealPlansForMcp(actor)).resolves.toEqual({
+      mealPlans: [
+        {
+          endDate: "2026-09-06",
+          id: "plan-1",
+          startDate: "2026-08-31",
+          status: "DRAFT",
+          title: "Uke 36",
+        },
+      ],
+    });
+  });
+
+  it("maps shopping list items", async () => {
+    getFamilyShoppingDataMock.mockResolvedValue({
+      activeListMode: "COMBINED",
+      itemCounts: {
+        checked: 1,
+        family: 1,
+        mealPlan: 1,
+        total: 2,
+        unchecked: 1,
+      },
+      projectedItems: [
+        {
+          category: { id: "cat-1", name: "Meieri" },
+          checked: false,
+          name: "Melk",
+          preferredStore: { id: "store-1", name: "Kiwi" },
+          quantityLabel: "1 l",
+          sourceType: "FAMILY",
+        },
+        {
+          category: { id: "cat-2", name: "Annet" },
+          checked: true,
+          name: "Tortilla",
+          preferredStore: null,
+          quantityLabel: null,
+          sourceType: "GENERATED",
+        },
+      ],
+    });
+
+    await expect(getShoppingListForMcp(actor)).resolves.toEqual({
+      activeListMode: "COMBINED",
+      itemCounts: {
+        checked: 1,
+        family: 1,
+        mealPlan: 1,
+        total: 2,
+        unchecked: 1,
+      },
+      items: [
+        {
+          category: "Meieri",
+          checked: false,
+          name: "Melk",
+          quantity: "1 l",
+          sourceType: "FAMILY",
+          store: "Kiwi",
+        },
+        {
+          category: "Annet",
+          checked: true,
+          name: "Tortilla",
+          quantity: null,
+          sourceType: "GENERATED",
+          store: null,
+        },
+      ],
+    });
+  });
+
+  it("returns recent dinner recipe ids and titles", async () => {
+    findMealPlanCoveringDateMock.mockResolvedValue({
+      id: "plan-1",
+      startDate: new Date("2026-08-31T00:00:00.000Z"),
+    });
+    getRecentlyUsedRecipeIdsMock.mockResolvedValue(new Set(["recipe-1"]));
+    dbMock.recipe.findMany.mockResolvedValue([
+      { id: "recipe-1", title: "Taco" },
+    ]);
+
+    await expect(getRecentDinnersForMcp(actor)).resolves.toEqual({
+      recipes: [{ id: "recipe-1", title: "Taco" }],
+    });
+    expect(getRecentlyUsedRecipeIdsMock).toHaveBeenCalledWith({
+      beforeDate: new Date("2026-08-31T00:00:00.000Z"),
+      currentMealPlanId: "plan-1",
+      familyId: "family-1",
+    });
+  });
+
+  it("lists freezer items", async () => {
+    listFamilyFreezerItemsMock.mockResolvedValue({
+      freezerItems: [{ id: "fz-1", label: "Lasagne", note: null, quantity: 1 }],
+    });
+
+    await expect(listFreezerItemsForMcp(actor)).resolves.toEqual({
+      freezerItems: [{ id: "fz-1", label: "Lasagne", note: null, quantity: 1 }],
+    });
+  });
+});

--- a/app/lib/mcp-tools.server.ts
+++ b/app/lib/mcp-tools.server.ts
@@ -1,0 +1,238 @@
+import { MealType } from "@prisma/client";
+
+import { db } from "./db.server";
+import { listFamilyFreezerItems } from "./freezer.server";
+import { findMealPlanCoveringDate } from "./meal-plan-for-date.server";
+import { formatDateOnly } from "./meal-plan-dates";
+import {
+  getCalendarWeekBounds,
+  getCalendarWeekDates,
+} from "./meal-plan-week";
+import {
+  getMealPlanPlanningData,
+  getRecentlyUsedRecipeIds,
+  listMealPlansForFamily,
+} from "./meal-plan.server";
+import {
+  getAccessibleRecipeDetail,
+  getRecipeManagementData,
+} from "./recipe.server";
+import { getFamilyShoppingData } from "./shopping.server";
+
+const NO_CURRENT_MEAL_PLAN_ID = "__none__";
+
+type McpActor = {
+  familyId: string;
+  userId: string;
+};
+
+function serializeRecipeSummary(recipe: {
+  defaultServings: number | null;
+  description: string | null;
+  id: string;
+  imageUrl: string | null;
+  prepMinutes: number | null;
+  scope: "FAMILY" | "GLOBAL";
+  tags: string[];
+  title: string;
+}) {
+  return {
+    defaultServings: recipe.defaultServings,
+    description: recipe.description,
+    id: recipe.id,
+    imageUrl: recipe.imageUrl,
+    prepMinutes: recipe.prepMinutes,
+    scope: recipe.scope,
+    tags: recipe.tags,
+    title: recipe.title,
+  };
+}
+
+export async function listRecipesForMcp({ familyId, userId }: McpActor) {
+  const data = await getRecipeManagementData({ familyId, userId });
+
+  return {
+    recipes: [
+      ...data.familyRecipes.map(serializeRecipeSummary),
+      ...data.globalRecipes.map(serializeRecipeSummary),
+    ],
+  };
+}
+
+export async function getRecipeForMcp({
+  familyId,
+  recipeId,
+  userId,
+}: McpActor & { recipeId: string }) {
+  const result = await getAccessibleRecipeDetail({
+    familyId,
+    recipeId,
+    userId,
+  });
+
+  if (result.status !== "FOUND") {
+    return null;
+  }
+
+  return {
+    recipe: {
+      defaultServings: result.recipe.defaultServings,
+      description: result.recipe.description,
+      id: result.recipe.id,
+      imageUrl: result.recipe.imageUrl,
+      ingredients: result.recipe.ingredients.map((ingredient) => ({
+        amount: ingredient.amount,
+        category: ingredient.category.displayName,
+        displayName: ingredient.displayName,
+        unit: ingredient.unit,
+      })),
+      prepMinutes: result.recipe.prepMinutes,
+      scope: result.recipe.scope,
+      tags: result.recipe.tags,
+      title: result.recipe.title,
+    },
+  };
+}
+
+export async function getCurrentWeekMealPlanForMcp({
+  familyId,
+  userId,
+}: McpActor) {
+  const weekBounds = getCalendarWeekBounds();
+  const weekDates = getCalendarWeekDates(weekBounds);
+  const coveringPlan = await findMealPlanCoveringDate({ familyId });
+
+  if (!coveringPlan) {
+    return {
+      dinners: weekDates.map((date) => ({
+        date,
+        description: null,
+        freezerLabel: null,
+        imageUrl: null,
+        note: null,
+        recipeId: null,
+        title: null,
+      })),
+      mealPlan: null,
+      weekEnd: weekBounds.weekEnd,
+      weekStart: weekBounds.weekStart,
+    };
+  }
+
+  const planning = await getMealPlanPlanningData({
+    familyId,
+    mealPlanId: coveringPlan.id,
+    userId,
+  });
+  const dinnerByDate = new Map(
+    planning.mealPlan.entries
+      .filter((entry) => entry.mealType === MealType.DINNER)
+      .map((entry) => [
+        formatDateOnly(entry.date),
+        {
+          date: formatDateOnly(entry.date),
+          description: entry.recipe?.description ?? null,
+          freezerLabel: entry.freezerItem?.label ?? null,
+          imageUrl: entry.recipe?.imageUrl ?? null,
+          note: entry.note,
+          recipeId: entry.recipeId,
+          title: entry.recipe?.title ?? null,
+        },
+      ]),
+  );
+
+  return {
+    dinners: weekDates.map(
+      (date) =>
+        dinnerByDate.get(date) ?? {
+          date,
+          description: null,
+          freezerLabel: null,
+          imageUrl: null,
+          note: null,
+          recipeId: null,
+          title: null,
+        },
+    ),
+    mealPlan: {
+      endDate: formatDateOnly(planning.mealPlan.endDate),
+      id: planning.mealPlan.id,
+      startDate: formatDateOnly(planning.mealPlan.startDate),
+      status: planning.mealPlan.status,
+      title: planning.mealPlan.title,
+    },
+    weekEnd: weekBounds.weekEnd,
+    weekStart: weekBounds.weekStart,
+  };
+}
+
+export async function listMealPlansForMcp({ familyId, userId }: McpActor) {
+  const data = await listMealPlansForFamily({ familyId, userId });
+
+  return {
+    mealPlans: data.mealPlans.map((mealPlan) => ({
+      endDate: formatDateOnly(mealPlan.endDate),
+      id: mealPlan.id,
+      startDate: formatDateOnly(mealPlan.startDate),
+      status: mealPlan.status,
+      title: mealPlan.title,
+    })),
+  };
+}
+
+export async function getShoppingListForMcp({ familyId, userId }: McpActor) {
+  const data = await getFamilyShoppingData({ familyId, userId });
+
+  return {
+    activeListMode: data.activeListMode,
+    itemCounts: data.itemCounts,
+    items: data.projectedItems.map((item) => ({
+      category: item.category.name,
+      checked: item.checked,
+      name: item.name,
+      quantity: item.quantityLabel,
+      sourceType: item.sourceType,
+      store: item.preferredStore?.name ?? null,
+    })),
+  };
+}
+
+export async function getRecentDinnersForMcp({ familyId }: McpActor) {
+  const coveringPlan = await findMealPlanCoveringDate({ familyId });
+  const recipeIds = [
+    ...(await getRecentlyUsedRecipeIds({
+      beforeDate: coveringPlan?.startDate ?? new Date(),
+      currentMealPlanId: coveringPlan?.id ?? NO_CURRENT_MEAL_PLAN_ID,
+      familyId,
+    })),
+  ];
+
+  if (recipeIds.length === 0) {
+    return { recipes: [] };
+  }
+
+  const recipes = await db.recipe.findMany({
+    orderBy: [{ title: "asc" }],
+    select: {
+      id: true,
+      title: true,
+    },
+    where: {
+      id: {
+        in: recipeIds,
+      },
+    },
+  });
+
+  return {
+    recipes,
+  };
+}
+
+export async function listFreezerItemsForMcp({ familyId, userId }: McpActor) {
+  const data = await listFamilyFreezerItems({ familyId, userId });
+
+  return {
+    freezerItems: data.freezerItems,
+  };
+}

--- a/app/lib/recipe.server.ts
+++ b/app/lib/recipe.server.ts
@@ -208,6 +208,70 @@ export async function getFamilyRecipeDetail({
   };
 }
 
+export async function getAccessibleRecipeDetail({
+  familyId,
+  recipeId,
+  userId,
+}: {
+  familyId: string;
+  recipeId: string;
+  userId: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const recipe = await db.recipe.findFirst({
+    select: {
+      ...managedRecipeSelect,
+      _count: {
+        select: {
+          mealPlanEntries: true,
+        },
+      },
+    },
+    where: {
+      id: recipeId,
+      OR: [
+        {
+          scope: RecipeScope.GLOBAL,
+        },
+        {
+          familyId,
+          scope: RecipeScope.FAMILY,
+        },
+      ],
+    },
+  });
+
+  if (!recipe) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  return {
+    mealPlanEntryCount: recipe._count.mealPlanEntries,
+    recipe: {
+      createdAt: recipe.createdAt,
+      defaultServings: recipe.defaultServings,
+      description: recipe.description,
+      familyId: recipe.familyId,
+      id: recipe.id,
+      imageUrl: getRecipeImageUrl(recipe.imageKey),
+      ingredients: recipe.ingredients,
+      prepMinutes: recipe.prepMinutes,
+      reminderSuggestions: recipe.reminderSuggestions,
+      scope: recipe.scope,
+      tags: recipe.tags,
+      title: recipe.title,
+      updatedAt: recipe.updatedAt,
+    },
+    status: "FOUND" as const,
+  };
+}
+
 function withRecipeImageUrl<T extends { imageKey: string | null }>(recipe: T) {
   const { imageKey, ...rest } = recipe;
   return {

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,7 @@ export default [
     "routes/internal.jobs.weekend-plan-reminders.ts",
   ),
   route("api/generate-recipe-description", "routes/api.generate-recipe-description.ts"),
+  route("mcp", "routes/mcp.ts"),
   route("s/:token", "routes/shopping-list-share.tsx"),
   route("c/:token/calendar.ics", "routes/calendar-subscription.ts"),
   layout("routes/app-layout.tsx", [

--- a/app/routes/family.test.ts
+++ b/app/routes/family.test.ts
@@ -38,6 +38,15 @@ vi.mock("../lib/calendar-subscription.server", () => {
   };
 });
 
+vi.mock("../lib/mcp-token.server", () => {
+  return {
+    buildFamilyMcpUrl: vi.fn(),
+    createOrRotateFamilyMcpToken: vi.fn(),
+    getFamilyMcpTokenStatus: vi.fn(),
+    revokeFamilyMcpToken: vi.fn(),
+  };
+});
+
 import { requireUser } from "../lib/auth.server";
 import {
   buildCalendarSubscriptionUrls,
@@ -54,6 +63,12 @@ import {
   updateFamilyReminderEmail,
 } from "../lib/family.server";
 import { listMealPlansForFamily } from "../lib/meal-plan.server";
+import {
+  buildFamilyMcpUrl,
+  createOrRotateFamilyMcpToken,
+  getFamilyMcpTokenStatus,
+  revokeFamilyMcpToken,
+} from "../lib/mcp-token.server";
 import { action, loader } from "./family";
 
 const mockUser = {
@@ -152,6 +167,10 @@ function mockMealPlansForFamily() {
   vi.mocked(getFamilyCalendarSubscriptionStatus).mockResolvedValue({
     exists: false,
   });
+  vi.mocked(getFamilyMcpTokenStatus).mockResolvedValue({
+    exists: false,
+  });
+  vi.mocked(buildFamilyMcpUrl).mockReturnValue("http://localhost/mcp");
 }
 
 describe("family route", () => {
@@ -225,6 +244,9 @@ describe("family route", () => {
     expect(getFamilyCalendarSubscriptionStatus).toHaveBeenCalledWith({
       familyId: "family-1",
     });
+    expect(getFamilyMcpTokenStatus).toHaveBeenCalledWith({
+      familyId: "family-1",
+    });
     expect(result).toMatchObject({
       family: {
         id: "family-1",
@@ -233,6 +255,7 @@ describe("family route", () => {
         reminderEmail: "familie@example.com",
       },
       hasCalendarSubscription: false,
+      hasMcpToken: false,
       members: [
         {
           id: "membership-1",
@@ -303,6 +326,7 @@ describe("family route", () => {
     expect(listFamilyMembers).not.toHaveBeenCalled();
     expect(getFamilyReminderEmail).not.toHaveBeenCalled();
     expect(getFamilyCalendarSubscriptionStatus).not.toHaveBeenCalled();
+    expect(getFamilyMcpTokenStatus).not.toHaveBeenCalled();
     expect(result).toEqual({
       activeTab: "oversikt",
       family: {
@@ -312,7 +336,9 @@ describe("family route", () => {
         reminderEmail: null,
       },
       hasCalendarSubscription: false,
+      hasMcpToken: false,
       members: [],
+      mcpUrl: "http://localhost/mcp",
       notice: null,
       recentMealPlans: [
         {
@@ -620,6 +646,62 @@ describe("family route", () => {
       intent: "create-calendar-subscription",
       webcalUrl: "webcal://example.com/c/feed-token/calendar.ics",
     });
+  });
+
+  it("returns the raw MCP token after an admin creates one", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(createOrRotateFamilyMcpToken).mockResolvedValue({
+      token: "mcp-token",
+    });
+    vi.mocked(buildFamilyMcpUrl).mockReturnValue("http://localhost/mcp");
+
+    const formData = new FormData();
+    formData.set("intent", "create-mcp-token");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1?tab=familie", formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(createOrRotateFamilyMcpToken).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    expect(buildFamilyMcpUrl).toHaveBeenCalledWith("http://localhost");
+    expect(result).toEqual({
+      intent: "create-mcp-token",
+      mcpToken: "mcp-token",
+      mcpUrl: "http://localhost/mcp",
+    });
+  });
+
+  it("redirects after an admin revokes an MCP token", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(revokeFamilyMcpToken).mockResolvedValue(undefined);
+
+    const formData = new FormData();
+    formData.set("intent", "revoke-mcp-token");
+
+    const result = await action({
+      params: {
+        familyId: "family-1",
+      },
+      request: buildRequest("http://localhost/families/family-1", formData),
+      context: {} as never,
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(revokeFamilyMcpToken).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "http://localhost/families/family-1?notice=mcp-token-revoked&tab=familie",
+    );
   });
 
   it("redirects after an admin revokes a calendar subscription", async () => {

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -3,6 +3,7 @@ import { Form, Link, isRouteErrorResponse, useNavigation } from "react-router";
 import type { Route } from "./+types/family";
 import { FamilyCalendarSubscriptionCard } from "../components/family-calendar-subscription-card";
 import { FamilyHomeTabs } from "../components/family-home-tabs";
+import { FamilyMcpTokenCard } from "../components/family-mcp-token-card";
 import { requireUser } from "../lib/auth.server";
 import {
   buildCalendarSubscriptionUrls,
@@ -22,9 +23,16 @@ import { formatMealPlanWindow } from "../lib/meal-plan-display";
 import { formatDateOnly } from "../lib/meal-plan-dates";
 import { isMealPlanPast } from "../lib/meal-plan-week";
 import { listMealPlansForFamily } from "../lib/meal-plan.server";
+import {
+  buildFamilyMcpUrl,
+  createOrRotateFamilyMcpToken,
+  getFamilyMcpTokenStatus,
+  revokeFamilyMcpToken,
+} from "../lib/mcp-token.server";
 
 type FamilyNotice =
   | "calendar-subscription-revoked"
+  | "mcp-token-revoked"
   | "member-removed"
   | "reminder-email-cleared"
   | "reminder-email-saved";
@@ -46,6 +54,8 @@ interface FamilyActionData {
   formError?: string;
   httpsUrl?: string;
   intent?: string;
+  mcpToken?: string;
+  mcpUrl?: string;
   targetUserId?: string;
   values?: {
     reminderEmail?: string;
@@ -58,6 +68,7 @@ function getFamilyNotice(request: Request): FamilyNotice | null {
 
   if (
     notice === "calendar-subscription-revoked" ||
+    notice === "mcp-token-revoked" ||
     notice === "member-removed" ||
     notice === "reminder-email-cleared" ||
     notice === "reminder-email-saved"
@@ -100,6 +111,12 @@ function getFamilyNoticeContent(notice: FamilyNotice) {
       return {
         description:
           "Kalenderabonnementet er opphevet. Eksisterende abonnement slutter å oppdatere.",
+        title: "Endringen er lagret",
+      };
+    case "mcp-token-revoked":
+      return {
+        description:
+          "MCP-nøkkelen er opphevet. Eksisterende agenter mister tilgang.",
         title: "Endringen er lagret",
       };
     case "member-removed":
@@ -299,8 +316,14 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     familyId,
     userId: user.id,
   });
-  const [members, mealPlanResult, weekDays, reminderEmail, calendarSubscription] =
-    await Promise.all([
+  const [
+    members,
+    mealPlanResult,
+    weekDays,
+    reminderEmail,
+    calendarSubscription,
+    mcpToken,
+  ] = await Promise.all([
     membership.role === "ADMIN"
       ? listFamilyMembers(familyId)
       : Promise.resolve([]),
@@ -318,6 +341,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     membership.role === "ADMIN"
       ? getFamilyCalendarSubscriptionStatus({ familyId })
       : Promise.resolve({ exists: false }),
+    membership.role === "ADMIN"
+      ? getFamilyMcpTokenStatus({ familyId })
+      : Promise.resolve({ exists: false }),
   ]);
 
   const serializedMealPlans = mealPlanResult.mealPlans.map(
@@ -333,7 +359,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
       reminderEmail,
     },
     hasCalendarSubscription: calendarSubscription.exists,
+    hasMcpToken: mcpToken.exists,
     members,
+    mcpUrl: buildFamilyMcpUrl(new URL(request.url).origin),
     notice: getFamilyNotice(request),
     recentMealPlans: serializedMealPlans.slice(0, 3),
     user,
@@ -418,6 +446,32 @@ export async function action({
     });
   }
 
+  if (intent === "create-mcp-token" || intent === "rotate-mcp-token") {
+    const result = await createOrRotateFamilyMcpToken({
+      familyId,
+      userId: user.id,
+    });
+
+    return {
+      intent,
+      mcpToken: result.token,
+      mcpUrl: buildFamilyMcpUrl(new URL(request.url).origin),
+    } satisfies FamilyActionData;
+  }
+
+  if (intent === "revoke-mcp-token") {
+    await revokeFamilyMcpToken({
+      familyId,
+      userId: user.id,
+    });
+
+    return buildFamilyRedirect({
+      familyId,
+      notice: "mcp-token-revoked",
+      request,
+    });
+  }
+
   if (intent !== "remove-member") {
     return {
       formError: "Ukjent handling.",
@@ -491,6 +545,12 @@ export default function FamilyRoute({
   const isRevokingCalendarSubscription =
     navigation.state !== "idle" &&
     pendingIntent === "revoke-calendar-subscription";
+  const isCreatingMcpToken =
+    navigation.state !== "idle" && pendingIntent === "create-mcp-token";
+  const isRotatingMcpToken =
+    navigation.state !== "idle" && pendingIntent === "rotate-mcp-token";
+  const isRevokingMcpToken =
+    navigation.state !== "idle" && pendingIntent === "revoke-mcp-token";
   const isAdmin = loaderData.userRole === "ADMIN";
   const familyId = loaderData.family.id;
   const reminderEmailValue = isSavingReminderEmail
@@ -641,6 +701,21 @@ export default function FamilyRoute({
                   isRevoking={isRevokingCalendarSubscription}
                   isRotating={isRotatingCalendarSubscription}
                   webcalUrl={actionData?.webcalUrl}
+                />
+              ) : null}
+
+              {isAdmin ? (
+                <FamilyMcpTokenCard
+                  hasMcpToken={
+                    (loaderData.hasMcpToken && !isRevokingMcpToken) ||
+                    isCreatingMcpToken ||
+                    Boolean(actionData?.mcpToken)
+                  }
+                  isCreating={isCreatingMcpToken}
+                  isRevoking={isRevokingMcpToken}
+                  isRotating={isRotatingMcpToken}
+                  mcpToken={actionData?.mcpToken}
+                  mcpUrl={actionData?.mcpUrl ?? loaderData.mcpUrl}
                 />
               ) : null}
 

--- a/app/routes/mcp.test.ts
+++ b/app/routes/mcp.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/mcp-token.server", () => ({
+  resolveFamilyMcpAuth: vi.fn(),
+}));
+
+vi.mock("../lib/mcp-handler.server", () => ({
+  mcpHttpHandler: {
+    fetch: vi.fn(),
+  },
+}));
+
+import { mcpHttpHandler } from "../lib/mcp-handler.server";
+import { resolveFamilyMcpAuth } from "../lib/mcp-token.server";
+import { action, loader } from "./mcp";
+
+describe("mcp route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 without a valid family token", async () => {
+    vi.mocked(resolveFamilyMcpAuth).mockResolvedValue(null);
+
+    const request = new Request("http://localhost/mcp", {
+      headers: { Authorization: "Bearer bad" },
+      method: "POST",
+    });
+
+    const result = await action({ request });
+
+    expect(result.status).toBe(401);
+    expect(result.headers.get("WWW-Authenticate")).toBe(
+      'Bearer realm="mealplanner-mcp"',
+    );
+    expect(mcpHttpHandler.fetch).not.toHaveBeenCalled();
+  });
+
+  it("passes family auth into the MCP handler", async () => {
+    vi.mocked(resolveFamilyMcpAuth).mockResolvedValue({
+      familyId: "family-1",
+      userId: "user-1",
+    });
+    vi.mocked(mcpHttpHandler.fetch).mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+
+    const request = new Request("http://localhost/mcp", {
+      headers: { Authorization: "Bearer good-token" },
+      method: "POST",
+    });
+
+    const result = await loader({ request });
+
+    expect(resolveFamilyMcpAuth).toHaveBeenCalledWith("Bearer good-token");
+    expect(mcpHttpHandler.fetch).toHaveBeenCalledWith(request, {
+      authInfo: {
+        clientId: "family-1",
+        extra: {
+          familyId: "family-1",
+          userId: "user-1",
+        },
+        scopes: ["mcp:read"],
+        token: "good-token",
+      },
+    });
+    expect(result.status).toBe(200);
+  });
+});

--- a/app/routes/mcp.ts
+++ b/app/routes/mcp.ts
@@ -1,0 +1,40 @@
+import { mcpHttpHandler } from "../lib/mcp-handler.server";
+import { resolveFamilyMcpAuth } from "../lib/mcp-token.server";
+
+function unauthorizedResponse() {
+  return new Response("Unauthorized", {
+    headers: {
+      "WWW-Authenticate": 'Bearer realm="mealplanner-mcp"',
+    },
+    status: 401,
+    statusText: "Unauthorized",
+  });
+}
+
+async function handleMcpRequest(request: Request) {
+  const auth = await resolveFamilyMcpAuth(request.headers.get("Authorization"));
+
+  if (!auth) {
+    return unauthorizedResponse();
+  }
+
+  return mcpHttpHandler.fetch(request, {
+    authInfo: {
+      clientId: auth.familyId,
+      extra: {
+        familyId: auth.familyId,
+        userId: auth.userId,
+      },
+      scopes: ["mcp:read"],
+      token: request.headers.get("Authorization")?.slice("Bearer ".length).trim() ?? "",
+    },
+  });
+}
+
+export async function loader({ request }: { request: Request }) {
+  return handleMcpRequest(request);
+}
+
+export async function action({ request }: { request: Request }) {
+  return handleMcpRequest(request);
+}

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -34,6 +34,8 @@ Optional (Thursday weekend-plan reminders). The app starts without this; the job
 | -------- | ------- |
 | `CRON_SECRET` | Bearer token for `POST /internal/jobs/weekend-plan-reminders` |
 
+Family MCP (`GET`/`POST` `/mcp`) runs in the same web process. It does not use a Fly secret; admins mint a hashed family token in the app. See [mcp.md](./mcp.md).
+
 Optional (recipe cover images via Cloudflare R2). The app starts without them; image upload is disabled until all R2 variables are set:
 
 | Variable | Purpose |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,51 @@
+# Family MCP server
+
+The app exposes a **read-only** [Model Context Protocol](https://modelcontextprotocol.io) server on the same process as the website (`GET`/`POST` `/mcp`). Production transport is **Streamable HTTP**, not stdio.
+
+## Mint a token
+
+1. Sign in as a family **admin**.
+2. Open the family page → **Familie**.
+3. Under **AI-tilgang (MCP)**, create a key.
+4. Copy the key immediately. It is shown once. Rotate it if it leaks.
+
+The MCP address is `{origin}/mcp` (local: `http://localhost:5174/mcp` when running `npm run dev`; production: `https://<your-fly-app>.fly.dev/mcp`).
+
+## Client config
+
+Use Streamable HTTP with a Bearer header. Example Cursor MCP config:
+
+```json
+{
+  "mcpServers": {
+    "mealplanner": {
+      "url": "https://mealplanner-xzvzow.fly.dev/mcp",
+      "headers": {
+        "Authorization": "Bearer <paste-the-family-key>"
+      }
+    }
+  }
+}
+```
+
+For local development, point `url` at `http://localhost:5174/mcp` and use a key minted on that environment.
+
+You can also use [MCP Inspector](https://github.com/modelcontextprotocol/inspector) against the same URL and header.
+
+## Tools
+
+Authenticated clients can call:
+
+- `list_recipes` — family and global recipes (title, description, image URL, tags, servings, prep)
+- `get_recipe` — one recipe including ingredients
+- `get_current_week_meal_plan` — Europe/Oslo calendar week dinners
+- `list_meal_plans` — plan summaries
+- `get_shopping_list` — current family shopping projection
+- `get_recent_dinners` — recently used dinner recipes
+- `list_freezer_items` — freezer stock
+
+The token is scoped to one family. Tools never create or approve meal plans.
+
+## Deploy
+
+No extra Fly process, port, or secret. The `/mcp` route deploys with the existing web app. See [deploy-fly.md](./deploy-fly.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "workspace",
+  "name": "mealplanner",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1114.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "@prisma/client": "^6.19.3",
         "@react-router/node": "7.15.0",
         "@react-router/serve": "7.15.0",
@@ -1833,6 +1834,31 @@
       "resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
       "integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1114.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@prisma/client": "^6.19.3",
     "@react-router/node": "7.15.0",
     "@react-router/serve": "7.15.0",

--- a/prisma/migrations/20260902080000_add_family_mcp_token/migration.sql
+++ b/prisma/migrations/20260902080000_add_family_mcp_token/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "FamilyMcpToken" (
+    "id" TEXT NOT NULL,
+    "familyId" TEXT NOT NULL,
+    "createdByUserId" TEXT,
+    "tokenHash" TEXT NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FamilyMcpToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FamilyMcpToken_familyId_key" ON "FamilyMcpToken"("familyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FamilyMcpToken_tokenHash_key" ON "FamilyMcpToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "FamilyMcpToken_createdByUserId_idx" ON "FamilyMcpToken"("createdByUserId");
+
+-- AddForeignKey
+ALTER TABLE "FamilyMcpToken" ADD CONSTRAINT "FamilyMcpToken_familyId_fkey" FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FamilyMcpToken" ADD CONSTRAINT "FamilyMcpToken_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,7 @@ model User {
   passwordResetTokens             PasswordResetToken[]
   createdShoppingListShares       ShoppingListShare[]            @relation("ShoppingListShareCreatedBy")
   createdCalendarSubscriptions    CalendarSubscription[]         @relation("CalendarSubscriptionCreatedBy")
+  createdFamilyMcpTokens          FamilyMcpToken[]               @relation("FamilyMcpTokenCreatedBy")
 
   @@index([displayName])
 }
@@ -145,6 +146,7 @@ model Family {
   ingredientCategories       IngredientCategory[]
   shoppingListShares         ShoppingListShare[]
   calendarSubscription       CalendarSubscription?
+  mcpToken                   FamilyMcpToken?
 
   @@index([createdByUserId])
   @@index([name])
@@ -603,6 +605,20 @@ model CalendarSubscription {
   updatedAt       DateTime @updatedAt
   family          Family   @relation(fields: [familyId], references: [id], onDelete: Cascade)
   createdByUser   User?    @relation("CalendarSubscriptionCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
+
+  @@index([createdByUserId])
+}
+
+model FamilyMcpToken {
+  id              String    @id @default(cuid())
+  familyId        String    @unique
+  createdByUserId String?
+  tokenHash       String    @unique
+  lastUsedAt      DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  family          Family    @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  createdByUser   User?     @relation("FamilyMcpTokenCreatedBy", fields: [createdByUserId], references: [id], onDelete: SetNull)
 
   @@index([createdByUserId])
 }


### PR DESCRIPTION
## Summary
- Add a family-scoped, read-only MCP server on the existing Fly web process (`/mcp`) so an agent can query recipes, the current week’s plan, and the shopping list without a second machine.
- Admins mint, rotate, and revoke a hashed bearer token on the Familie tab; tools wrap the same server helpers the app already uses.
- Show the copied MCP address as `https` on Fly (localhost stays `http`) so MCP Inspector can connect.
- Document Streamable HTTP client setup in `docs/mcp.md`. The periodic planner agent and in-app suggestion view stay out of scope.

## Related issue
Closes #241

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] After deploy, copy MCP-adresse from Familie and confirm it is `https://…/mcp`
- [ ] Connect MCP Inspector or Cursor to `/mcp` with `Authorization: Bearer <key>`
- [ ] Confirm `list_recipes`, `get_current_week_meal_plan`, and `get_shopping_list` match the family UI
- [ ] Confirm an invalid token is rejected (401)

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck