### PR TITLE
Let an AI agent propose next week's dinners for in-app approval

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,38 +2,41 @@
 
 ## Current Objective
 
-Ship family-scoped MCP on the existing Fly web process ([#241](https://github.com/sndrem/mealplanner/issues/241)): commit, push, and open a PR.
+Ship MCP meal-plan proposals ([#243](https://github.com/sndrem/mealplanner/issues/243)): write tool, `PROPOSED` persistence, and email-linked review UI.
 
 ## Completed
 
-- Read-only Streamable HTTP MCP at `/mcp` on the existing React Router process
-- Family hashed bearer token with admin create/rotate/revoke on the Familie tab
-- Tools for recipes, current-week meal plan, shopping list, recent dinners, and freezer items
-- Docs in `docs/mcp.md`; Fly pointer in `docs/deploy-fly.md`
-- Branch cut from current `origin/main` after `git pull --ff-only`
+- Cut `issue/243-mcp-meal-plan-proposal` from current `origin/main` after `git pull --ff-only`
+- Added `MealPlanStatus.PROPOSED` plus migration `20260902093000_add_meal_plan_proposed_status`
+- Live surfaces (covering date, ukeplaner list, home week, calendar sub, store mode, shopping ranges) ignore `PROPOSED`
+- `create_meal_plan_proposal` MCP tool upserts next-week (or given Mon–Sun) dinners and returns `proposalUrl`
+- Authenticated `/families/:familyId/meal-plans/:mealPlanId/proposal` for adjust + Godkjenn (`PROPOSED` → `APPROVED`)
+- Docs (`docs/mcp.md`) and Familie MCP card copy updated
+- Local validation passed; ready to open PR
 
 ## Files To Read First
 
-- `app/lib/mcp-handler.server.ts` — MCP v2 handler and tool registration
-- `app/lib/mcp-token.server.ts` — hashed token CRUD and Bearer auth
-- `app/routes/mcp.ts` — public `/mcp` resource route
-- `app/components/family-mcp-token-card.tsx` — admin mint UI
+- `app/lib/meal-plan.server.ts` — `createOrReplaceMealPlanProposal`, `approveMealPlanProposal`
+- `app/lib/mcp-tools.server.ts` / `app/lib/mcp-handler.server.ts` — write tool
+- `app/routes/family-meal-plan-proposal.tsx` — review UI
+- `app/lib/meal-plan-status.server.ts` — live-plan status filter
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 613 tests passed
+- `npm run test:run` — 628 tests passed
 - `npm run typecheck` — passed
-- Browser Familie-tab mint flow — not run
-- MCP Inspector / Cursor against `/mcp` — not run (restart Vite so it picks up the new Prisma client)
+- Browser proposal/approve flow — not run
+- MCP Inspector against `/mcp` — not run
+- Prisma migrate against local DB — not run (`prisma:generate` only)
 
 ## Open Items
 
 - Production migration runs via Fly `release_command` (`prisma migrate deploy`)
-- After merge: mint a key, connect Inspector or Cursor to `/mcp`
-- Follow-ups: suggestion persist/view and periodic agent (out of scope)
+- After merge: mint a key, call `create_meal_plan_proposal`, open `proposalUrl`, tweak a dinner, approve
+- Confirm proposals stay off shopping/calendar/`list_meal_plans` until approved
 
 ## Next Step
 
-Merge the PR for #241 after review.
+Merge the PR for #243 after review.

--- a/app/components/family-mcp-token-card.tsx
+++ b/app/components/family-mcp-token-card.tsx
@@ -22,8 +22,8 @@ export function FamilyMcpTokenCard({
         <h2 className="text-lg font-semibold text-slate-950">AI-tilgang (MCP)</h2>
         <p className="text-sm leading-6 text-slate-600">
           Lag et hemmelig nøkkelord som en AI-agent kan bruke for å lese
-          oppskrifter, ukeplan og handleliste. Del det ikke offentlig. Bytt
-          nøkkel hvis det kommer på avveie.
+          oppskrifter, ukeplan og handleliste, og for å foreslå en ukeplan.
+          Del det ikke offentlig. Bytt nøkkel hvis det kommer på avveie.
         </p>
       </div>
 

--- a/app/lib/calendar-subscription.server.test.ts
+++ b/app/lib/calendar-subscription.server.test.ts
@@ -296,6 +296,9 @@ describe("calendar-subscription.server", () => {
           startDate: {
             lte: new Date("2026-05-24T00:00:00.000Z"),
           },
+          status: {
+            in: ["APPROVED", "DRAFT"],
+          },
         },
       }),
     );

--- a/app/lib/calendar-subscription.server.ts
+++ b/app/lib/calendar-subscription.server.ts
@@ -10,6 +10,7 @@ import {
 import { db } from "./db.server";
 import { requireFamilyAdmin } from "./family.server";
 import { formatDateOnly } from "./meal-plan-dates";
+import { LIVE_MEAL_PLAN_STATUS_FILTER } from "./meal-plan-status.server";
 import {
   getCalendarWeekBounds,
   getCalendarWeekDates,
@@ -222,6 +223,7 @@ async function getFamilyCalendarEvents({
       startDate: {
         lte: windowEndDate,
       },
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
     },
   });
 

--- a/app/lib/family-home.server.ts
+++ b/app/lib/family-home.server.ts
@@ -8,6 +8,7 @@ import {
   getDinnerMenuLabel,
 } from "./meal-plan-display";
 import { formatDateOnly, isPlanDateToday } from "./meal-plan-dates";
+import { LIVE_MEAL_PLAN_STATUS_FILTER } from "./meal-plan-status.server";
 import {
   getCalendarWeekBounds,
   getCalendarWeekDates,
@@ -88,6 +89,7 @@ export async function getFamilyWeekDinnerMenu({
       startDate: {
         lte: weekEndDate,
       },
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
     },
   });
 

--- a/app/lib/mcp-handler.server.ts
+++ b/app/lib/mcp-handler.server.ts
@@ -6,6 +6,7 @@ import {
 import { z } from "zod";
 
 import {
+  createMealPlanProposalForMcp,
   getCurrentWeekMealPlanForMcp,
   getRecentDinnersForMcp,
   getRecipeForMcp,
@@ -26,6 +27,17 @@ function requireMcpActor(authInfo: AuthInfo | undefined) {
   }
 
   return { familyId, userId };
+}
+
+function requireMcpOrigin(authInfo: AuthInfo | undefined) {
+  const origin =
+    typeof authInfo?.extra?.origin === "string" ? authInfo.extra.origin : "";
+
+  if (!origin) {
+    throw new Error("MCP request is missing origin.");
+  }
+
+  return origin;
 }
 
 function jsonResult(data: unknown, summary: string) {
@@ -155,6 +167,58 @@ export const mcpHttpHandler = createMcpHandler(
         return jsonResult(
           data,
           `${data.freezerItems.length} freezer items.`,
+        );
+      },
+    );
+
+    server.registerTool(
+      "create_meal_plan_proposal",
+      {
+        description:
+          "Create or replace a proposed dinner plan for a Europe/Oslo calendar week (defaults to next week). Does not approve the plan.",
+        inputSchema: z.object({
+          dinners: z
+            .array(
+              z.object({
+                date: z.string().min(1).describe("YYYY-MM-DD"),
+                freezerItemId: z.string().optional(),
+                note: z.string().optional(),
+                recipeId: z.string().optional(),
+              }),
+            )
+            .describe("Dinners to store. Days omitted stay empty."),
+          title: z.string().optional().describe("Optional meal plan title"),
+          weekEnd: z
+            .string()
+            .optional()
+            .describe("Sunday YYYY-MM-DD of the calendar week"),
+          weekStart: z
+            .string()
+            .optional()
+            .describe("Monday YYYY-MM-DD of the calendar week"),
+        }),
+      },
+      async ({ dinners, title, weekEnd, weekStart }) => {
+        const origin = requireMcpOrigin(authInfo);
+        const data = await createMealPlanProposalForMcp({
+          ...actor,
+          dinners,
+          origin,
+          title,
+          weekEnd,
+          weekStart,
+        });
+
+        if (data.status !== "CREATED") {
+          return {
+            content: [{ text: data.formError, type: "text" as const }],
+            isError: true,
+          };
+        }
+
+        return jsonResult(
+          data,
+          `Proposal ${data.proposalId} ready for ${data.weekStart}–${data.weekEnd}.`,
         );
       },
     );

--- a/app/lib/mcp-token.server.test.ts
+++ b/app/lib/mcp-token.server.test.ts
@@ -44,6 +44,7 @@ vi.mock("node:crypto", async (importOriginal) => {
 
 import {
   buildFamilyMcpUrl,
+  buildFamilyMealPlanProposalUrl,
   createOrRotateFamilyMcpToken,
   getFamilyMcpTokenStatus,
   hashFamilyMcpToken,
@@ -89,6 +90,18 @@ describe("mcp-token.server", () => {
   it("builds the MCP endpoint URL from an origin", () => {
     expect(buildFamilyMcpUrl("https://mealplanner.example/")).toBe(
       "https://mealplanner.example/mcp",
+    );
+  });
+
+  it("builds a meal plan proposal URL from origin and ids", () => {
+    expect(
+      buildFamilyMealPlanProposalUrl({
+        familyId: "family-1",
+        mealPlanId: "proposal-1",
+        origin: "https://mealplanner.example/",
+      }),
+    ).toBe(
+      "https://mealplanner.example/families/family-1/meal-plans/proposal-1/proposal",
     );
   });
 

--- a/app/lib/mcp-token.server.ts
+++ b/app/lib/mcp-token.server.ts
@@ -16,6 +16,18 @@ export function buildFamilyMcpUrl(origin: string) {
   return `${origin.replace(/\/+$/, "")}/mcp`;
 }
 
+export function buildFamilyMealPlanProposalUrl({
+  familyId,
+  mealPlanId,
+  origin,
+}: {
+  familyId: string;
+  mealPlanId: string;
+  origin: string;
+}) {
+  return `${origin.replace(/\/+$/, "")}/families/${familyId}/meal-plans/${mealPlanId}/proposal`;
+}
+
 function parseBearerToken(authorizationHeader: string | null) {
   if (!authorizationHeader?.startsWith("Bearer ")) {
     return "";

--- a/app/lib/mcp-tools.server.test.ts
+++ b/app/lib/mcp-tools.server.test.ts
@@ -11,6 +11,7 @@ const {
   getRecipeManagementDataMock,
   listFamilyFreezerItemsMock,
   listMealPlansForFamilyMock,
+  createOrReplaceMealPlanProposalMock,
   dbMock,
 } = vi.hoisted(() => ({
   dbMock: {
@@ -28,6 +29,7 @@ const {
   getRecipeManagementDataMock: vi.fn(),
   listFamilyFreezerItemsMock: vi.fn(),
   listMealPlansForFamilyMock: vi.fn(),
+  createOrReplaceMealPlanProposalMock: vi.fn(),
 }));
 
 vi.mock("./db.server", () => ({
@@ -44,6 +46,7 @@ vi.mock("./meal-plan-for-date.server", () => ({
 }));
 
 vi.mock("./meal-plan.server", () => ({
+  createOrReplaceMealPlanProposal: createOrReplaceMealPlanProposalMock,
   getMealPlanPlanningData: getMealPlanPlanningDataMock,
   getRecentlyUsedRecipeIds: getRecentlyUsedRecipeIdsMock,
   listMealPlansForFamily: listMealPlansForFamilyMock,
@@ -63,6 +66,7 @@ vi.mock("./freezer.server", () => ({
 }));
 
 import {
+  createMealPlanProposalForMcp,
   getCurrentWeekMealPlanForMcp,
   getRecentDinnersForMcp,
   getRecipeForMcp,
@@ -422,6 +426,70 @@ describe("mcp-tools.server", () => {
 
     await expect(listFreezerItemsForMcp(actor)).resolves.toEqual({
       freezerItems: [{ id: "fz-1", label: "Lasagne", note: null, quantity: 1 }],
+    });
+  });
+
+  it("creates a meal plan proposal and returns a proposal URL", async () => {
+    createOrReplaceMealPlanProposalMock.mockResolvedValue({
+      dinners: [
+        {
+          date: "2026-05-18",
+          freezerItemId: null,
+          freezerLabel: null,
+          note: null,
+          recipeId: "recipe-taco",
+          title: "Taco",
+        },
+      ],
+      proposalId: "proposal-1",
+      status: "CREATED",
+      title: "Uke 21",
+      weekEnd: "2026-05-24",
+      weekStart: "2026-05-18",
+    });
+
+    await expect(
+      createMealPlanProposalForMcp({
+        ...actor,
+        dinners: [{ date: "2026-05-18", recipeId: "recipe-taco" }],
+        origin: "https://mealplanner.example",
+      }),
+    ).resolves.toEqual({
+      dinners: [
+        {
+          date: "2026-05-18",
+          freezerItemId: null,
+          freezerLabel: null,
+          note: null,
+          recipeId: "recipe-taco",
+          title: "Taco",
+        },
+      ],
+      proposalId: "proposal-1",
+      proposalUrl:
+        "https://mealplanner.example/families/family-1/meal-plans/proposal-1/proposal",
+      status: "CREATED",
+      title: "Uke 21",
+      weekEnd: "2026-05-24",
+      weekStart: "2026-05-18",
+    });
+  });
+
+  it("returns proposal validation errors without a URL", async () => {
+    createOrReplaceMealPlanProposalMock.mockResolvedValue({
+      formError: "Det finnes allerede en ukeplan for denne uken.",
+      status: "LIVE_PLAN_EXISTS",
+    });
+
+    await expect(
+      createMealPlanProposalForMcp({
+        ...actor,
+        dinners: [],
+        origin: "https://mealplanner.example",
+      }),
+    ).resolves.toEqual({
+      formError: "Det finnes allerede en ukeplan for denne uken.",
+      status: "LIVE_PLAN_EXISTS",
     });
   });
 });

--- a/app/lib/mcp-tools.server.ts
+++ b/app/lib/mcp-tools.server.ts
@@ -9,10 +9,12 @@ import {
   getCalendarWeekDates,
 } from "./meal-plan-week";
 import {
+  createOrReplaceMealPlanProposal,
   getMealPlanPlanningData,
   getRecentlyUsedRecipeIds,
   listMealPlansForFamily,
 } from "./meal-plan.server";
+import { buildFamilyMealPlanProposalUrl } from "./mcp-token.server";
 import {
   getAccessibleRecipeDetail,
   getRecipeManagementData,
@@ -234,5 +236,53 @@ export async function listFreezerItemsForMcp({ familyId, userId }: McpActor) {
 
   return {
     freezerItems: data.freezerItems,
+  };
+}
+
+export async function createMealPlanProposalForMcp({
+  dinners,
+  familyId,
+  origin,
+  title,
+  userId,
+  weekEnd,
+  weekStart,
+}: McpActor & {
+  dinners: {
+    date: string;
+    freezerItemId?: string;
+    note?: string;
+    recipeId?: string;
+  }[];
+  origin: string;
+  title?: string;
+  weekEnd?: string;
+  weekStart?: string;
+}) {
+  const result = await createOrReplaceMealPlanProposal({
+    dinners,
+    familyId,
+    title,
+    userId,
+    weekEnd,
+    weekStart,
+  });
+
+  if (result.status !== "CREATED") {
+    return result;
+  }
+
+  return {
+    dinners: result.dinners,
+    proposalId: result.proposalId,
+    proposalUrl: buildFamilyMealPlanProposalUrl({
+      familyId,
+      mealPlanId: result.proposalId,
+      origin,
+    }),
+    status: "CREATED" as const,
+    title: result.title,
+    weekEnd: result.weekEnd,
+    weekStart: result.weekStart,
   };
 }

--- a/app/lib/meal-plan-display.ts
+++ b/app/lib/meal-plan-display.ts
@@ -1,3 +1,9 @@
+export type LiveMealPlanStatus = "APPROVED" | "DRAFT";
+
+export function toLiveMealPlanStatus(status: string): LiveMealPlanStatus {
+  return status === "APPROVED" ? "APPROVED" : "DRAFT";
+}
+
 export function formatMealPlanRecipeSelectLabel(title: string, tags: string[]) {
   const cleaned = tags.map((tag) => tag.trim()).filter(Boolean);
   if (cleaned.length === 0) {

--- a/app/lib/meal-plan-for-date.server.test.ts
+++ b/app/lib/meal-plan-for-date.server.test.ts
@@ -50,6 +50,9 @@ describe("findMealPlanCoveringDate", () => {
           startDate: {
             lte: new Date("2026-05-16T00:00:00.000Z"),
           },
+          status: {
+            in: ["APPROVED", "DRAFT"],
+          },
         }),
       }),
     );
@@ -104,7 +107,12 @@ describe("resolveStoreModeAnchorMealPlan", () => {
       expect.objectContaining({
         orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
         select: { id: true },
-        where: { familyId: "family-1" },
+        where: {
+          familyId: "family-1",
+          status: {
+            in: ["APPROVED", "DRAFT"],
+          },
+        },
       }),
     );
   });
@@ -143,6 +151,9 @@ describe("resolveStoreModeNextMealPlan", () => {
           familyId: "family-1",
           startDate: {
             gt: new Date("2026-05-14T00:00:00.000Z"),
+          },
+          status: {
+            in: ["APPROVED", "DRAFT"],
           },
         }),
       }),

--- a/app/lib/meal-plan-for-date.server.ts
+++ b/app/lib/meal-plan-for-date.server.ts
@@ -1,5 +1,7 @@
 import { db } from "./db.server";
 import { formatDateOnly } from "./meal-plan-dates";
+import { toLiveMealPlanStatus } from "./meal-plan-display";
+import { LIVE_MEAL_PLAN_STATUS_FILTER } from "./meal-plan-status.server";
 
 const storeModeAnchorMealPlanSelect = {
   id: true,
@@ -42,7 +44,7 @@ export async function findMealPlanCoveringDate({
   const dateOnly = formatDateOnly(referenceDate);
   const dateAtUtcMidnight = new Date(`${dateOnly}T00:00:00.000Z`);
 
-  return db.mealPlan.findFirst({
+  const mealPlan = await db.mealPlan.findFirst({
     orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
     select: mealPlanForDateSelect,
     where: {
@@ -53,8 +55,18 @@ export async function findMealPlanCoveringDate({
       startDate: {
         lte: dateAtUtcMidnight,
       },
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
     },
   });
+
+  if (!mealPlan) {
+    return null;
+  }
+
+  return {
+    ...mealPlan,
+    status: toLiveMealPlanStatus(mealPlan.status),
+  };
 }
 
 export async function resolveStoreModeAnchorMealPlan({
@@ -73,7 +85,10 @@ export async function resolveStoreModeAnchorMealPlan({
   return db.mealPlan.findFirst({
     orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
     select: storeModeAnchorMealPlanSelect,
-    where: { familyId },
+    where: {
+      familyId,
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
+    },
   });
 }
 
@@ -95,6 +110,7 @@ export async function resolveStoreModeNextMealPlan({
       startDate: {
         gt: dateAtUtcMidnight,
       },
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
     },
   });
 }

--- a/app/lib/meal-plan-status.server.ts
+++ b/app/lib/meal-plan-status.server.ts
@@ -1,0 +1,10 @@
+import { MealPlanStatus } from "@prisma/client";
+
+export const LIVE_MEAL_PLAN_STATUSES = [
+  MealPlanStatus.APPROVED,
+  MealPlanStatus.DRAFT,
+] as const;
+
+export const LIVE_MEAL_PLAN_STATUS_FILTER = {
+  in: [...LIVE_MEAL_PLAN_STATUSES],
+};

--- a/app/lib/meal-plan.server.test.ts
+++ b/app/lib/meal-plan.server.test.ts
@@ -17,6 +17,7 @@ const {
         findUniqueOrThrow: vi.fn(),
         update: vi.fn(),
         updateMany: vi.fn(),
+        deleteMany: vi.fn(),
       },
       mealPlanShare: {
         updateMany: vi.fn(),
@@ -79,6 +80,8 @@ import {
   autoFillMealPlanEntries,
   copyMealPlan,
   createMealPlan,
+  createOrReplaceMealPlanProposal,
+  approveMealPlanProposal,
   deleteMealPlan,
   getDinnerAnalyticsForFamily,
   formatDateOnly,
@@ -230,6 +233,9 @@ describe("meal-plan.server", () => {
       },
       where: {
         familyId: "family-1",
+        status: {
+          in: ["APPROVED", "DRAFT"],
+        },
       },
     });
     expect(result.family).toEqual({
@@ -293,6 +299,153 @@ describe("meal-plan.server", () => {
       },
     });
     expect(dbMock.mealPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a proposed meal plan for a calendar week", async () => {
+    dbMock.mealPlan.findMany.mockResolvedValue([]);
+    dbMock.mealPlan.create.mockResolvedValue({ id: "proposal-1" });
+    dbMock.mealPlan.findFirst.mockImplementation(async ({ select }: { select?: { entries?: unknown } }) => {
+      if (select?.entries) {
+        return {
+          endDate: new Date("2026-05-17T00:00:00.000Z"),
+          entries: [
+            {
+              date: new Date("2026-05-11T00:00:00.000Z"),
+              freezerItem: null,
+              freezerItemId: null,
+              note: null,
+              recipe: { title: "Taco" },
+              recipeId: "recipe-taco",
+            },
+          ],
+          id: "proposal-1",
+          startDate: new Date("2026-05-11T00:00:00.000Z"),
+          title: "Uke 20",
+        };
+      }
+
+      return {
+        endDate: new Date("2026-05-17T00:00:00.000Z"),
+        id: "proposal-1",
+        startDate: new Date("2026-05-11T00:00:00.000Z"),
+      };
+    });
+    dbMock.recipe.findMany.mockResolvedValue([{ id: "recipe-taco" }]);
+
+    const result = await createOrReplaceMealPlanProposal({
+      dinners: [
+        {
+          date: "2026-05-11",
+          recipeId: "recipe-taco",
+        },
+      ],
+      familyId: "family-1",
+      userId: "user-1",
+      weekEnd: "2026-05-17",
+      weekStart: "2026-05-11",
+    });
+
+    expect(result.status).toBe("CREATED");
+    if (result.status !== "CREATED") {
+      throw new Error("expected CREATED");
+    }
+    expect(result.proposalId).toBe("proposal-1");
+    expect(result.weekStart).toBe("2026-05-11");
+    expect(result.dinners[0]).toMatchObject({
+      date: "2026-05-11",
+      recipeId: "recipe-taco",
+      title: "Taco",
+    });
+    expect(dbMock.mealPlan.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          familyId: "family-1",
+          status: "PROPOSED",
+          title: "Uke 20",
+        }),
+      }),
+    );
+  });
+
+  it("replaces an existing proposal for the same week in place", async () => {
+    dbMock.mealPlan.findMany.mockImplementation(async ({ where }: { where?: { status?: unknown } }) => {
+      if (where?.status === "PROPOSED") {
+        return [
+          {
+            entries: [],
+            id: "proposal-1",
+          },
+        ];
+      }
+
+      return [];
+    });
+    dbMock.mealPlan.findFirst.mockImplementation(async ({ select }: { select?: { entries?: unknown } }) => {
+      if (select?.entries) {
+        return {
+          endDate: new Date("2026-05-17T00:00:00.000Z"),
+          entries: [],
+          id: "proposal-1",
+          startDate: new Date("2026-05-11T00:00:00.000Z"),
+          title: "Uke 20",
+        };
+      }
+
+      return {
+        endDate: new Date("2026-05-17T00:00:00.000Z"),
+        id: "proposal-1",
+        startDate: new Date("2026-05-11T00:00:00.000Z"),
+      };
+    });
+
+    const result = await createOrReplaceMealPlanProposal({
+      dinners: [],
+      familyId: "family-1",
+      userId: "user-1",
+      weekEnd: "2026-05-17",
+      weekStart: "2026-05-11",
+    });
+
+    expect(result.status).toBe("CREATED");
+    expect(dbMock.mealPlan.create).not.toHaveBeenCalled();
+    expect(dbMock.mealPlan.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "proposal-1" },
+      }),
+    );
+  });
+
+  it("rejects a proposal when a live meal plan covers the week", async () => {
+    dbMock.mealPlan.findMany.mockResolvedValue([{ id: "live-plan" }]);
+
+    const result = await createOrReplaceMealPlanProposal({
+      dinners: [],
+      familyId: "family-1",
+      userId: "user-1",
+      weekEnd: "2026-05-17",
+      weekStart: "2026-05-11",
+    });
+
+    expect(result).toEqual({
+      formError: "Det finnes allerede en ukeplan for denne uken.",
+      status: "LIVE_PLAN_EXISTS",
+    });
+    expect(dbMock.mealPlan.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects proposal weeks that are not Monday-Sunday", async () => {
+    const result = await createOrReplaceMealPlanProposal({
+      dinners: [],
+      familyId: "family-1",
+      userId: "user-1",
+      weekEnd: "2026-05-16",
+      weekStart: "2026-05-11",
+    });
+
+    expect(result).toEqual({
+      formError: "Uken må være en kalenderuke fra mandag til søndag.",
+      status: "VALIDATION_ERROR",
+    });
   });
 
   it("copies dinner entries into a new target range using relative offsets", async () => {
@@ -783,6 +936,71 @@ describe("meal-plan.server", () => {
       },
     });
     expect(result.status).toBe("APPROVED");
+  });
+
+  it("approves a proposed meal plan", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-17T00:00:00.000Z"),
+      entries: [],
+      id: "proposal-1",
+      startDate: new Date("2026-05-11T00:00:00.000Z"),
+      status: "PROPOSED",
+      updatedAt: new Date("2026-05-16T09:00:00.000Z"),
+    });
+    dbMock.mealPlan.findMany.mockResolvedValue([]);
+    dbMock.mealPlan.update.mockResolvedValue({
+      approvedAt: new Date("2026-05-16T09:30:00.000Z"),
+      approvedByUserId: "user-1",
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-17T00:00:00.000Z"),
+      id: "proposal-1",
+      startDate: new Date("2026-05-11T00:00:00.000Z"),
+      status: "APPROVED",
+      title: "Uke 20",
+      updatedAt: new Date("2026-05-16T09:30:00.000Z"),
+    });
+
+    const result = await approveMealPlanProposal({
+      familyId: "family-1",
+      mealPlanId: "proposal-1",
+      userId: "user-1",
+    });
+
+    expect(result.status).toBe("APPROVED");
+    expect(dbMock.mealPlan.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: "APPROVED",
+          approvedByUserId: "user-1",
+        }),
+        where: { id: "proposal-1" },
+      }),
+    );
+  });
+
+  it("rejects approving a proposal when a live plan now overlaps", async () => {
+    dbMock.mealPlan.findFirst.mockResolvedValue({
+      endDate: new Date("2026-05-17T00:00:00.000Z"),
+      entries: [],
+      id: "proposal-1",
+      startDate: new Date("2026-05-11T00:00:00.000Z"),
+      status: "PROPOSED",
+      updatedAt: new Date("2026-05-16T09:00:00.000Z"),
+    });
+    dbMock.mealPlan.findMany.mockResolvedValue([{ id: "live-plan" }]);
+
+    const result = await approveMealPlanProposal({
+      familyId: "family-1",
+      mealPlanId: "proposal-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      formError: "Det finnes allerede en ukeplan for denne uken.",
+      status: "LIVE_PLAN_EXISTS",
+    });
+    expect(dbMock.mealPlan.update).not.toHaveBeenCalled();
   });
 
   it("reopens an approved meal plan back to draft", async () => {

--- a/app/lib/meal-plan.server.ts
+++ b/app/lib/meal-plan.server.ts
@@ -21,6 +21,13 @@ import {
 import { listActiveFreezerItemsForPlanning } from "./freezer.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import { formatDateOnly, MEAL_PLAN_MAX_SPAN_DAYS, getMealPlanMaxSpanMessage } from "./meal-plan-dates";
+import { LIVE_MEAL_PLAN_STATUS_FILTER } from "./meal-plan-status.server";
+import {
+  formatMealPlanAutoTitle,
+  getCalendarWeekBounds,
+  getCalendarWeekDates,
+  getNextCalendarWeekBounds,
+} from "./meal-plan-week";
 import { getRecipeImageUrl } from "./r2.server";
 import {
   logCollaborationFailure,
@@ -207,6 +214,22 @@ type AutoFillMealPlanEntriesInput = DeleteMealPlanInput;
 type MealPlanApprovalAction = "APPROVE" | "REOPEN";
 export type DinnerAnalyticsTimeframe = "30d" | "90d" | "all";
 
+export type MealPlanProposalDinnerInput = {
+  date: string;
+  freezerItemId?: string | null;
+  note?: string | null;
+  recipeId?: string | null;
+};
+
+export type MealPlanProposalDinner = {
+  date: string;
+  freezerItemId: string | null;
+  freezerLabel: string | null;
+  note: string | null;
+  recipeId: string | null;
+  title: string | null;
+};
+
 export interface DinnerIngredientUsageStat {
   count: number;
   ingredientName: string;
@@ -226,6 +249,18 @@ export interface DinnerLatestRecipeUsageStat {
 
 const AUTO_FILL_NOT_DRAFT_MESSAGE =
   "Godkjente ukeplaner kan ikke fylles automatisk.";
+const PROPOSAL_INVALID_WEEK_MESSAGE =
+  "Uken må være en kalenderuke fra mandag til søndag.";
+const PROPOSAL_WEEK_PAIR_MESSAGE =
+  "Oppgi både weekStart og weekEnd, eller ingen av dem.";
+const PROPOSAL_LIVE_PLAN_EXISTS_MESSAGE =
+  "Det finnes allerede en ukeplan for denne uken.";
+const PROPOSAL_OUTSIDE_WEEK_MESSAGE =
+  "En av middagene ligger utenfor uken.";
+const PROPOSAL_DUPLICATE_DAY_MESSAGE =
+  "Hver dag kan bare ha én middag.";
+const PROPOSAL_NOT_PROPOSED_MESSAGE =
+  "Forslaget kan ikke godkjennes fra gjeldende status.";
 const AUTO_FILL_NO_ELIGIBLE_RECIPES_MESSAGE =
   `Ingen tilgjengelige oppskrifter etter a ha utelatt middager fra de siste ${MEAL_PLAN_MAX_SPAN_DAYS} dagene.`;
 const AUTO_FILL_REPEAT_WARNING_MESSAGE =
@@ -356,6 +391,7 @@ export async function listMealPlansForFamily({
     select: mealPlanSummarySelect,
     where: {
       familyId,
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
     },
   });
 
@@ -523,6 +559,482 @@ export async function createMealPlan(input: MealPlanMutationInput) {
     },
     mealPlan,
     status: "CREATED" as const,
+  };
+}
+
+export async function createOrReplaceMealPlanProposal({
+  dinners,
+  familyId,
+  title,
+  userId,
+  weekEnd,
+  weekStart,
+}: {
+  dinners: MealPlanProposalDinnerInput[];
+  familyId: string;
+  title?: string;
+  userId: string;
+  weekEnd?: string;
+  weekStart?: string;
+}) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const week = resolveProposalWeekBounds({
+    weekEnd,
+    weekStart,
+  });
+
+  if (!week.ok) {
+    return {
+      formError: week.formError,
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  const weekDates = getCalendarWeekDates(week);
+  const startDate = parseDateOnly(week.weekStart)!;
+  const endDate = parseDateOnly(week.weekEnd)!;
+  const expanded = expandProposalDinners({
+    dinners,
+    weekDates,
+  });
+
+  if (!expanded.ok) {
+    return {
+      formError: expanded.formError,
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  const livePlans = await db.mealPlan.findMany({
+    select: {
+      id: true,
+    },
+    where: {
+      endDate: {
+        gte: startDate,
+      },
+      familyId,
+      startDate: {
+        lte: endDate,
+      },
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
+    },
+  });
+
+  if (livePlans.length > 0) {
+    return {
+      formError: PROPOSAL_LIVE_PLAN_EXISTS_MESSAGE,
+      status: "LIVE_PLAN_EXISTS" as const,
+    };
+  }
+
+  const existingProposals = await db.mealPlan.findMany({
+    orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
+    select: {
+      entries: {
+        select: {
+          date: true,
+          updatedAt: true,
+        },
+        where: {
+          mealType: PLANNING_MEAL_TYPE,
+        },
+      },
+      id: true,
+    },
+    where: {
+      endDate: {
+        gte: startDate,
+      },
+      familyId,
+      startDate: {
+        lte: endDate,
+      },
+      status: MealPlanStatus.PROPOSED,
+    },
+  });
+  const [existingProposal, ...staleProposals] = existingProposals;
+  const proposalTitle =
+    title?.trim() || formatMealPlanAutoTitle(week.weekStart);
+
+  let mealPlanId: string;
+  let createdNewPlan = false;
+
+  if (existingProposal) {
+    mealPlanId = existingProposal.id;
+
+    if (staleProposals.length > 0) {
+      await db.mealPlan.deleteMany({
+        where: {
+          familyId,
+          id: {
+            in: staleProposals.map((proposal) => proposal.id),
+          },
+        },
+      });
+    }
+
+    await db.mealPlan.update({
+      data: {
+        activeShoppingDate: startDate,
+        endDate,
+        startDate,
+        title: proposalTitle,
+        ...buildActorUpdate(userId),
+      },
+      where: {
+        id: mealPlanId,
+      },
+    });
+  } else {
+    const created = await db.mealPlan.create({
+      data: {
+        activeShoppingDate: startDate,
+        endDate,
+        familyId,
+        startDate,
+        status: MealPlanStatus.PROPOSED,
+        title: proposalTitle,
+        ...buildActorUpdate(userId),
+      },
+      select: {
+        id: true,
+      },
+    });
+    createdNewPlan = true;
+    mealPlanId = created.id;
+  }
+
+  const entryVersions = Object.fromEntries(
+    weekDates.map((date) => {
+      const existingEntry = existingProposal?.entries.find(
+        (entry) => formatDateOnly(entry.date) === date,
+      );
+
+      return [date, existingEntry?.updatedAt.toISOString() ?? ""];
+    }),
+  );
+
+  try {
+    const saveResult = await saveMealPlanEntries({
+      entries: expanded.entries,
+      entryVersions,
+      familyId,
+      mealPlanId,
+      userId,
+    });
+
+    if (saveResult.status !== "UPDATED") {
+      if (createdNewPlan) {
+        await db.mealPlan.delete({
+          where: {
+            id: mealPlanId,
+          },
+        });
+      }
+
+      return {
+        formError:
+          saveResult.status === "NOT_FOUND"
+            ? "Fant ikke ukeplanforslaget."
+            : saveResult.formError,
+        status: "VALIDATION_ERROR" as const,
+      };
+    }
+  } catch (error) {
+    if (createdNewPlan) {
+      await db.mealPlan.delete({
+        where: {
+          id: mealPlanId,
+        },
+      });
+    }
+
+    throw error;
+  }
+
+  const proposal = await loadMealPlanProposalSummary(mealPlanId);
+
+  if (!proposal) {
+    return {
+      formError: "Fant ikke ukeplanforslaget.",
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  return {
+    status: "CREATED" as const,
+    ...proposal,
+  };
+}
+
+export async function approveMealPlanProposal({
+  familyId,
+  mealPlanId,
+  userId,
+}: DeleteMealPlanInput) {
+  await requireFamilyMembership({
+    familyId,
+    userId,
+  });
+
+  const mealPlan = await db.mealPlan.findFirst({
+    select: {
+      endDate: true,
+      entries: {
+        select: {
+          date: true,
+          mealType: true,
+          updatedAt: true,
+        },
+        where: {
+          mealType: PLANNING_MEAL_TYPE,
+        },
+      },
+      id: true,
+      startDate: true,
+      status: true,
+      updatedAt: true,
+    },
+    where: {
+      familyId,
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    return {
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (mealPlan.status !== MealPlanStatus.PROPOSED) {
+    return {
+      formError:
+        mealPlan.status === MealPlanStatus.APPROVED
+          ? "Ukeplanen er allerede godkjent."
+          : PROPOSAL_NOT_PROPOSED_MESSAGE,
+      status: "INVALID_TRANSITION" as const,
+    };
+  }
+
+  const overlappingLivePlans = await db.mealPlan.findMany({
+    select: {
+      id: true,
+    },
+    where: {
+      endDate: {
+        gte: mealPlan.startDate,
+      },
+      familyId,
+      id: {
+        not: mealPlan.id,
+      },
+      startDate: {
+        lte: mealPlan.endDate,
+      },
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
+    },
+  });
+
+  if (overlappingLivePlans.length > 0) {
+    return {
+      formError: PROPOSAL_LIVE_PLAN_EXISTS_MESSAGE,
+      status: "LIVE_PLAN_EXISTS" as const,
+    };
+  }
+
+  return approveMealPlan({
+    entriesSnapshot: buildMealPlanEntriesSnapshot(mealPlan.entries),
+    expectedMealPlanUpdatedAt: mealPlan.updatedAt.toISOString(),
+    familyId,
+    mealPlanId,
+    userId,
+  });
+}
+
+async function loadMealPlanProposalSummary(mealPlanId: string) {
+  const mealPlan = await db.mealPlan.findFirst({
+    select: {
+      endDate: true,
+      entries: {
+        select: {
+          date: true,
+          freezerItem: {
+            select: {
+              label: true,
+            },
+          },
+          freezerItemId: true,
+          note: true,
+          recipe: {
+            select: {
+              title: true,
+            },
+          },
+          recipeId: true,
+        },
+        where: {
+          mealType: PLANNING_MEAL_TYPE,
+        },
+      },
+      id: true,
+      startDate: true,
+      title: true,
+    },
+    where: {
+      id: mealPlanId,
+    },
+  });
+
+  if (!mealPlan) {
+    return null;
+  }
+
+  const weekStart = formatDateOnly(mealPlan.startDate);
+  const weekEnd = formatDateOnly(mealPlan.endDate);
+  const dinnerByDate = new Map(
+    mealPlan.entries.map((entry) => [
+      formatDateOnly(entry.date),
+      {
+        date: formatDateOnly(entry.date),
+        freezerItemId: entry.freezerItemId,
+        freezerLabel: entry.freezerItem?.label ?? null,
+        note: entry.note,
+        recipeId: entry.recipeId,
+        title: entry.recipe?.title ?? null,
+      } satisfies MealPlanProposalDinner,
+    ]),
+  );
+
+  return {
+    dinners: getCalendarWeekDates({ weekEnd, weekStart }).map(
+      (date) =>
+        dinnerByDate.get(date) ?? {
+          date,
+          freezerItemId: null,
+          freezerLabel: null,
+          note: null,
+          recipeId: null,
+          title: null,
+        },
+    ),
+    proposalId: mealPlan.id,
+    title: mealPlan.title,
+    weekEnd,
+    weekStart,
+  };
+}
+
+function resolveProposalWeekBounds({
+  weekEnd,
+  weekStart,
+}: {
+  weekEnd?: string;
+  weekStart?: string;
+}) {
+  const trimmedStart = weekStart?.trim() ?? "";
+  const trimmedEnd = weekEnd?.trim() ?? "";
+  const hasStart = trimmedStart.length > 0;
+  const hasEnd = trimmedEnd.length > 0;
+
+  if (hasStart !== hasEnd) {
+    return {
+      formError: PROPOSAL_WEEK_PAIR_MESSAGE,
+      ok: false as const,
+    };
+  }
+
+  if (!hasStart) {
+    const nextWeek = getNextCalendarWeekBounds();
+
+    return {
+      ok: true as const,
+      weekEnd: nextWeek.weekEnd,
+      weekStart: nextWeek.weekStart,
+    };
+  }
+
+  if (!parseDateOnly(trimmedStart) || !parseDateOnly(trimmedEnd)) {
+    return {
+      formError: PROPOSAL_INVALID_WEEK_MESSAGE,
+      ok: false as const,
+    };
+  }
+
+  const calendarWeek = getCalendarWeekBounds(
+    new Date(`${trimmedStart}T12:00:00.000Z`),
+  );
+
+  if (
+    calendarWeek.weekStart !== trimmedStart ||
+    calendarWeek.weekEnd !== trimmedEnd
+  ) {
+    return {
+      formError: PROPOSAL_INVALID_WEEK_MESSAGE,
+      ok: false as const,
+    };
+  }
+
+  return {
+    ok: true as const,
+    weekEnd: trimmedEnd,
+    weekStart: trimmedStart,
+  };
+}
+
+function expandProposalDinners({
+  dinners,
+  weekDates,
+}: {
+  dinners: MealPlanProposalDinnerInput[];
+  weekDates: string[];
+}) {
+  const weekDateSet = new Set(weekDates);
+  const byDate = new Map<string, MealPlanEntryValues>();
+
+  for (const dinner of dinners) {
+    const date = dinner.date.trim();
+
+    if (!weekDateSet.has(date)) {
+      return {
+        formError: PROPOSAL_OUTSIDE_WEEK_MESSAGE,
+        ok: false as const,
+      };
+    }
+
+    if (byDate.has(date)) {
+      return {
+        formError: PROPOSAL_DUPLICATE_DAY_MESSAGE,
+        ok: false as const,
+      };
+    }
+
+    byDate.set(date, {
+      date,
+      freezerItemId: dinner.freezerItemId?.trim() ?? "",
+      note: dinner.note?.trim() ?? "",
+      recipeId: dinner.recipeId?.trim() ?? "",
+      responsibleUserId: "",
+    });
+  }
+
+  return {
+    entries: weekDates.map(
+      (date) =>
+        byDate.get(date) ?? {
+          date,
+          freezerItemId: "",
+          note: "",
+          recipeId: "",
+          responsibleUserId: "",
+        },
+    ),
+    ok: true as const,
   };
 }
 
@@ -1790,7 +2302,9 @@ function isMealPlanStatusTransitionAllowed(
   action: MealPlanApprovalAction,
 ) {
   if (action === "APPROVE") {
-    return status === MealPlanStatus.DRAFT;
+    return (
+      status === MealPlanStatus.DRAFT || status === MealPlanStatus.PROPOSED
+    );
   }
 
   return status === MealPlanStatus.APPROVED;

--- a/app/lib/shopping-write.server.ts
+++ b/app/lib/shopping-write.server.ts
@@ -7,6 +7,7 @@ import {
 } from "./collaboration.server";
 import { db } from "./db.server";
 import { requireFamilyMembership } from "./family.server";
+import { LIVE_MEAL_PLAN_STATUS_FILTER } from "./meal-plan-status.server";
 import { normalizeIngredientCanonicalName } from "./ingredient-normalize";
 import {
   recordShoppingCheckEvent,
@@ -2148,6 +2149,7 @@ async function validateOptionalDateInFamilyMealPlans({
     },
     where: {
       familyId,
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
     },
   });
 

--- a/app/lib/shopping.server.ts
+++ b/app/lib/shopping.server.ts
@@ -14,6 +14,7 @@ import {
   getMealPlanDateRange,
   unionMealPlanDateRanges,
 } from "./meal-plan.server";
+import { LIVE_MEAL_PLAN_STATUS_FILTER } from "./meal-plan-status.server";
 import { getFamilyShoppingListMode } from "./shopping-preference.server";
 import {
   getFamilyStockMatchSet,
@@ -377,6 +378,7 @@ export async function getMealPlanShoppingData({
         },
         where: {
           familyId,
+          status: LIVE_MEAL_PLAN_STATUS_FILTER,
         },
       }),
     ]);
@@ -894,6 +896,7 @@ export async function getMealPlanStoreModeData({
           gte: todayAtUtcMidnight,
         },
         familyId,
+        status: LIVE_MEAL_PLAN_STATUS_FILTER,
       },
     }),
     db.store.findMany({

--- a/app/lib/weekend-plan-reminder.server.ts
+++ b/app/lib/weekend-plan-reminder.server.ts
@@ -6,6 +6,7 @@ import { db } from "./db.server";
 import { sendEmail } from "./mailer.server";
 import { formatDateOnly } from "./meal-plan-dates";
 import { formatWeekdayLabel } from "./meal-plan-display";
+import { LIVE_MEAL_PLAN_STATUS_FILTER } from "./meal-plan-status.server";
 import {
   getCalendarWeekBounds,
   getCalendarWeekDates,
@@ -174,6 +175,7 @@ export async function getUnplannedWeekendDays({
       startDate: {
         lte: weekEndDate,
       },
+      status: LIVE_MEAL_PLAN_STATUS_FILTER,
     },
   });
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -28,6 +28,10 @@ export default [
       "families/:familyId/meal-plans/:mealPlanId/review",
       "routes/family-meal-plan-review.tsx",
     ),
+    route(
+      "families/:familyId/meal-plans/:mealPlanId/proposal",
+      "routes/family-meal-plan-proposal.tsx",
+    ),
     route("families/:familyId/meal-plans/:mealPlanId", "routes/family-meal-plan.tsx"),
     route(
       "families/:familyId/meal-plans/:mealPlanId/calendar.ics",

--- a/app/routes/family-meal-plan-proposal.test.ts
+++ b/app/routes/family-meal-plan-proposal.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/auth.server", async () => {
+  const actual = await vi.importActual<typeof import("../lib/auth.server")>(
+    "../lib/auth.server",
+  );
+
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  };
+});
+
+vi.mock("../lib/meal-plan.server", () => ({
+  approveMealPlanProposal: vi.fn(),
+  formatDateOnly: vi.fn((date: Date) => date.toISOString().slice(0, 10)),
+  getMealPlanPlanningData: vi.fn(),
+  saveMealPlanEntries: vi.fn(),
+}));
+
+import { requireUser } from "../lib/auth.server";
+import {
+  approveMealPlanProposal,
+  getMealPlanPlanningData,
+  saveMealPlanEntries,
+} from "../lib/meal-plan.server";
+import { action, loader } from "./family-meal-plan-proposal";
+
+const mockUser = {
+  displayName: "Ola",
+  email: "ola@example.com",
+  id: "user-1",
+  isGlobalAdmin: false,
+};
+
+function buildPlanningData({
+  status = "PROPOSED",
+}: {
+  status?: "APPROVED" | "DRAFT" | "PROPOSED";
+} = {}) {
+  return {
+    family: {
+      id: "family-1",
+      name: "Solberg",
+    },
+    freezerItems: [],
+    mealPlan: {
+      activeShoppingDate: new Date("2026-05-11T00:00:00.000Z"),
+      approvedAt: null,
+      approvedByUserId: null,
+      copiedFromMealPlanId: null,
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      endDate: new Date("2026-05-17T00:00:00.000Z"),
+      entries: [],
+      id: "proposal-1",
+      startDate: new Date("2026-05-11T00:00:00.000Z"),
+      status,
+      title: "Uke 20",
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    },
+    recentlyUsedRecipeIds: [],
+    recipes: [],
+    userRole: "ADMIN",
+    visibleDates: ["2026-05-11", "2026-05-12"],
+  };
+}
+
+describe("family meal plan proposal route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects unauthenticated visitors to login with redirectTo", async () => {
+    const redirectResponse = new Response(null, {
+      headers: {
+        Location:
+          "/login?redirectTo=%2Ffamilies%2Ffamily-1%2Fmeal-plans%2Fproposal-1%2Fproposal",
+      },
+      status: 302,
+    });
+    vi.mocked(requireUser).mockRejectedValue(redirectResponse);
+
+    await expect(
+      loader({
+        params: { familyId: "family-1", mealPlanId: "proposal-1" },
+        request: new Request(
+          "http://localhost/families/family-1/meal-plans/proposal-1/proposal",
+        ),
+      } as never),
+    ).rejects.toBe(redirectResponse);
+  });
+
+  it("loads a proposed meal plan for review", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanPlanningData).mockResolvedValue(
+      buildPlanningData() as never,
+    );
+
+    const result = await loader({
+      params: { familyId: "family-1", mealPlanId: "proposal-1" },
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/proposal-1/proposal",
+      ),
+    } as never);
+
+    expect(result.mealPlan.status).toBe("PROPOSED");
+    expect(result.visibleDates).toEqual(["2026-05-11", "2026-05-12"]);
+  });
+
+  it("shows an already-approved proposal without editing", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanPlanningData).mockResolvedValue(
+      buildPlanningData({ status: "APPROVED" }) as never,
+    );
+
+    const result = await loader({
+      params: { familyId: "family-1", mealPlanId: "proposal-1" },
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/proposal-1/proposal",
+      ),
+    } as never);
+
+    expect(result.mealPlan.status).toBe("APPROVED");
+  });
+
+  it("redirects draft plans to the regular ukeplan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanPlanningData).mockResolvedValue(
+      buildPlanningData({ status: "DRAFT" }) as never,
+    );
+
+    await expect(
+      loader({
+        params: { familyId: "family-1", mealPlanId: "proposal-1" },
+        request: new Request(
+          "http://localhost/families/family-1/meal-plans/proposal-1/proposal",
+        ),
+      } as never),
+    ).rejects.toMatchObject({
+      status: 302,
+    });
+  });
+
+  it("approves a proposal and redirects to the ukeplan", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(saveMealPlanEntries).mockResolvedValue({
+      status: "UPDATED",
+    });
+    vi.mocked(approveMealPlanProposal).mockResolvedValue({
+      status: "APPROVED",
+    } as never);
+
+    const formData = new FormData();
+    formData.set("intent", "approve-meal-plan");
+    formData.append("entryDate", "2026-05-11");
+    formData.set("mealSelection:2026-05-11", "recipe:recipe-taco");
+    formData.set("note:2026-05-11", "");
+    formData.set("entryUpdatedAt:2026-05-11", "");
+
+    const result = await action({
+      params: { familyId: "family-1", mealPlanId: "proposal-1" },
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/proposal-1/proposal",
+        {
+          body: formData,
+          method: "POST",
+        },
+      ),
+    } as never);
+
+    expect(saveMealPlanEntries).toHaveBeenCalled();
+    expect(approveMealPlanProposal).toHaveBeenCalledWith({
+      familyId: "family-1",
+      mealPlanId: "proposal-1",
+      userId: "user-1",
+    });
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(302);
+    expect((result as Response).headers.get("Location")).toBe(
+      "http://localhost/families/family-1/meal-plans/proposal-1?notice=meal-plan-approved",
+    );
+  });
+});

--- a/app/routes/family-meal-plan-proposal.tsx
+++ b/app/routes/family-meal-plan-proposal.tsx
@@ -1,0 +1,464 @@
+import { useMemo, useState } from "react";
+import { Form, Link, useNavigation, type MetaFunction } from "react-router";
+
+import { MealPlanRecipePicker } from "../components/meal-plan-recipe-picker";
+import { requireUser } from "../lib/auth.server";
+import { formatDateOnly } from "../lib/meal-plan-dates";
+import {
+  encodeMealSelection,
+  formatMealPlanWindow,
+  formatShortDateLabel,
+  formatWeekdayLabel,
+  parseMealSelection,
+} from "../lib/meal-plan-display";
+import {
+  approveMealPlanProposal,
+  getMealPlanPlanningData,
+  saveMealPlanEntries,
+  type MealPlanEntryValues,
+} from "../lib/meal-plan.server";
+
+type ProposalIntent = "approve-meal-plan" | "save-meal-plan-entries";
+
+interface ProposalActionData {
+  approvalFormError?: string;
+  entryFormError?: string;
+  intent?: ProposalIntent;
+}
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: "Ukeplanforslag | Mealplanner" },
+    {
+      name: "description",
+      content: "Se, juster og godkjenn et foreslått ukesmeny.",
+    },
+  ];
+};
+
+export async function loader({
+  params,
+  request,
+}: {
+  params: { familyId?: string; mealPlanId?: string };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
+  const data = await getMealPlanPlanningData({
+    familyId,
+    mealPlanId,
+    userId: user.id,
+  });
+
+  if (data.mealPlan.status === "DRAFT") {
+    throw Response.redirect(
+      new URL(`/families/${familyId}/meal-plans/${mealPlanId}`, request.url).toString(),
+      302,
+    );
+  }
+
+  const entriesByDate = Object.fromEntries(
+    data.visibleDates.map((date) => {
+      const entry = data.mealPlan.entries.find(
+        (mealPlanEntry) =>
+          mealPlanEntry.mealType === "DINNER" &&
+          formatDateOnly(mealPlanEntry.date) === date,
+      );
+
+      return [
+        date,
+        {
+          freezerItemId: entry?.freezerItemId ?? "",
+          note: entry?.note ?? "",
+          recipeId: entry?.recipeId ?? "",
+          updatedAt: entry?.updatedAt.toISOString() ?? "",
+        },
+      ];
+    }),
+  );
+
+  return {
+    entriesByDate,
+    family: data.family,
+    freezerItems: data.freezerItems,
+    mealPlan: {
+      endDate: formatDateOnly(data.mealPlan.endDate),
+      id: data.mealPlan.id,
+      startDate: formatDateOnly(data.mealPlan.startDate),
+      status: data.mealPlan.status,
+      title: data.mealPlan.title,
+    },
+    recentlyUsedRecipeIds: data.recentlyUsedRecipeIds,
+    recipes: data.recipes,
+    visibleDates: data.visibleDates,
+  };
+}
+
+export async function action({
+  params,
+  request,
+}: {
+  params: { familyId?: string; mealPlanId?: string };
+  request: Request;
+}) {
+  const user = await requireUser(request);
+  const familyId = requireRouteParam(params.familyId, "Fant ikke familien.");
+  const mealPlanId = requireRouteParam(
+    params.mealPlanId,
+    "Fant ikke ukeplanen.",
+  );
+  const formData = await request.formData();
+  const intent = String(formData.get("intent") ?? "") as ProposalIntent;
+  const entries = parseProposalEntries(formData);
+  const entryVersions = parseProposalEntryVersions(formData);
+
+  if (intent === "save-meal-plan-entries" || intent === "approve-meal-plan") {
+    const saveResult = await saveMealPlanEntries({
+      entries,
+      entryVersions,
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (saveResult.status === "NOT_FOUND") {
+      throw new Response("Fant ikke ukeplanen.", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    }
+
+    if (
+      saveResult.status === "CONFLICT" ||
+      saveResult.status === "VALIDATION_ERROR"
+    ) {
+      return {
+        entryFormError: saveResult.formError,
+        intent,
+      } satisfies ProposalActionData;
+    }
+  }
+
+  if (intent === "approve-meal-plan") {
+    const result = await approveMealPlanProposal({
+      familyId,
+      mealPlanId,
+      userId: user.id,
+    });
+
+    if (result.status === "NOT_FOUND") {
+      throw new Response("Fant ikke ukeplanen.", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    }
+
+    if (
+      result.status === "CONFLICT" ||
+      result.status === "INVALID_TRANSITION" ||
+      result.status === "LIVE_PLAN_EXISTS"
+    ) {
+      return {
+        approvalFormError: result.formError,
+        intent,
+      } satisfies ProposalActionData;
+    }
+
+    if (result.status === "APPROVED") {
+      const url = new URL(request.url);
+      url.pathname = `/families/${familyId}/meal-plans/${mealPlanId}`;
+      url.search = "";
+      url.searchParams.set("notice", "meal-plan-approved");
+
+      return Response.redirect(url.toString(), 302);
+    }
+
+    return {
+      approvalFormError: "Kunne ikke godkjenne forslaget.",
+      intent,
+    } satisfies ProposalActionData;
+  }
+
+  if (intent === "save-meal-plan-entries") {
+    return {
+      intent,
+    } satisfies ProposalActionData;
+  }
+
+  return {
+    entryFormError: "Ugyldig handling.",
+  } satisfies ProposalActionData;
+}
+
+export default function FamilyMealPlanProposalRoute({
+  actionData,
+  loaderData,
+}: {
+  actionData?: ProposalActionData;
+  loaderData: Awaited<ReturnType<typeof loader>>;
+}) {
+  const navigation = useNavigation();
+  const pendingIntent = String(navigation.formData?.get("intent") ?? "");
+  const isPending = navigation.state !== "idle";
+  const isSavingEntries =
+    isPending && pendingIntent === "save-meal-plan-entries";
+  const isApprovingMealPlan =
+    isPending && pendingIntent === "approve-meal-plan";
+  const isApprovedView =
+    loaderData.mealPlan.status === "APPROVED" || isApprovingMealPlan;
+  const [mealSelectionsByDate, setMealSelectionsByDate] = useState(() =>
+    Object.fromEntries(
+      loaderData.visibleDates.map((date) => [
+        date,
+        encodeMealSelection(loaderData.entriesByDate[date] ?? {
+          freezerItemId: "",
+          recipeId: "",
+        }),
+      ]),
+    ),
+  );
+  const [notesByDate, setNotesByDate] = useState(() =>
+    Object.fromEntries(
+      loaderData.visibleDates.map((date) => [
+        date,
+        loaderData.entriesByDate[date]?.note ?? "",
+      ]),
+    ),
+  );
+  const displaySelections = useMemo(() => {
+    if (!isPending) {
+      return mealSelectionsByDate;
+    }
+
+    return {
+      ...mealSelectionsByDate,
+      ...Object.fromEntries(
+        loaderData.visibleDates.flatMap((date) => {
+          const pending = navigation.formData?.get(`mealSelection:${date}`);
+
+          return pending == null ? [] : [[date, String(pending)]];
+        }),
+      ),
+    };
+  }, [isPending, loaderData.visibleDates, mealSelectionsByDate, navigation.formData]);
+  const displayNotes = useMemo(() => {
+    if (!isPending) {
+      return notesByDate;
+    }
+
+    return {
+      ...notesByDate,
+      ...Object.fromEntries(
+        loaderData.visibleDates.flatMap((date) => {
+          const pending = navigation.formData?.get(`note:${date}`);
+
+          return pending == null ? [] : [[date, String(pending)]];
+        }),
+      ),
+    };
+  }, [isPending, loaderData.visibleDates, notesByDate, navigation.formData]);
+  const inPlanRecipeIds = useMemo(() => {
+    const ids = new Set<string>();
+
+    for (const selection of Object.values(displaySelections)) {
+      const parsed = parseMealSelection(selection);
+
+      if (parsed.recipeId) {
+        ids.add(parsed.recipeId);
+      }
+    }
+
+    return ids;
+  }, [displaySelections]);
+  const recentlyUsedRecipeIds = useMemo(
+    () => new Set(loaderData.recentlyUsedRecipeIds),
+    [loaderData.recentlyUsedRecipeIds],
+  );
+
+  if (isApprovedView) {
+    return (
+      <main className="min-h-screen overflow-x-hidden bg-slate-100 px-4 py-6 text-slate-900">
+        <div className="mx-auto flex w-full max-w-lg flex-col gap-4">
+          <section className="rounded-[24px] border border-emerald-200 bg-emerald-50 px-4 py-4 text-emerald-950">
+            <h1 className="text-xl font-semibold">Forslaget er godkjent</h1>
+            <p className="mt-2 text-sm leading-6 text-emerald-900">
+              {loaderData.mealPlan.title} er nå en ekte ukeplan.
+            </p>
+            <Link
+              className="mt-4 inline-flex min-h-11 items-center justify-center rounded-2xl bg-emerald-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-700"
+              to={`/families/${loaderData.family.id}/meal-plans/${loaderData.mealPlan.id}`}
+            >
+              {isApprovingMealPlan ? "Godkjent" : "Åpne ukeplanen"}
+            </Link>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen overflow-x-hidden bg-slate-100 px-4 py-6 text-slate-900">
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-4">
+        <section className="sticky top-14 z-40 rounded-[24px] bg-slate-950 px-4 py-4 text-white shadow-lg">
+          <p className="text-xs font-medium uppercase tracking-[0.2em] text-emerald-200">
+            Forslag
+          </p>
+          <h1 className="mt-1 truncate text-xl font-semibold">
+            {loaderData.mealPlan.title}
+          </h1>
+          <p className="mt-1 text-sm text-slate-300">
+            {formatMealPlanWindow(
+              loaderData.mealPlan.startDate,
+              loaderData.mealPlan.endDate,
+            )}
+          </p>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            Juster middagene om du vil, og godkjenn når forslaget ser bra ut.
+          </p>
+        </section>
+
+        <Form className="flex flex-col gap-4" method="post">
+          {loaderData.visibleDates.map((date) => (
+            <input key={`entryDate:${date}`} name="entryDate" type="hidden" value={date} />
+          ))}
+          {loaderData.visibleDates.map((date) => (
+            <input
+              key={`entryUpdatedAt:${date}`}
+              name={`entryUpdatedAt:${date}`}
+              type="hidden"
+              value={loaderData.entriesByDate[date]?.updatedAt ?? ""}
+            />
+          ))}
+
+          {actionData?.entryFormError ? (
+            <p className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+              {actionData.entryFormError}
+            </p>
+          ) : null}
+          {actionData?.approvalFormError ? (
+            <p className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+              {actionData.approvalFormError}
+            </p>
+          ) : null}
+
+          {loaderData.visibleDates.map((date) => {
+            const weekday = formatWeekdayLabel(date);
+            const capitalizedWeekday =
+              weekday.charAt(0).toUpperCase() + weekday.slice(1);
+
+            return (
+              <section
+                className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm"
+                key={date}
+              >
+                <div className="flex items-baseline justify-between gap-3">
+                  <h2 className="text-base font-semibold text-slate-950">
+                    {capitalizedWeekday}
+                  </h2>
+                  <p className="text-sm text-slate-500">
+                    {formatShortDateLabel(date)}
+                  </p>
+                </div>
+                <div className="mt-3">
+                  <MealPlanRecipePicker
+                    freezerItems={loaderData.freezerItems}
+                    inPlanRecipeIds={inPlanRecipeIds}
+                    name={`mealSelection:${date}`}
+                    onChange={(value) => {
+                      setMealSelectionsByDate((current) => ({
+                        ...current,
+                        [date]: value,
+                      }));
+                    }}
+                    recentlyUsedRecipeIds={recentlyUsedRecipeIds}
+                    recipes={loaderData.recipes}
+                    triggerLabel="Velg middag"
+                    value={displaySelections[date] ?? ""}
+                  />
+                </div>
+                <label className="mt-3 block text-sm font-medium text-slate-700">
+                  Notat
+                  <textarea
+                    className="mt-2 min-h-20 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-950 outline-none transition focus:border-slate-400"
+                    name={`note:${date}`}
+                    onChange={(event) => {
+                      setNotesByDate((current) => ({
+                        ...current,
+                        [date]: event.target.value,
+                      }));
+                    }}
+                    value={displayNotes[date] ?? ""}
+                  />
+                </label>
+              </section>
+            );
+          })}
+
+          <div className="sticky bottom-4 z-40 flex flex-col gap-3">
+            <button
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-white px-5 py-3 text-sm font-medium text-slate-800 ring-1 ring-slate-200 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400"
+              disabled={isPending}
+              name="intent"
+              type="submit"
+              value="save-meal-plan-entries"
+            >
+              {isSavingEntries ? "Lagret" : "Lagre endringer"}
+            </button>
+            <button
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-2xl bg-emerald-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-300"
+              disabled={isPending}
+              name="intent"
+              type="submit"
+              value="approve-meal-plan"
+            >
+              {isApprovingMealPlan ? "Godkjent" : "Godkjenn"}
+            </button>
+          </div>
+        </Form>
+      </div>
+    </main>
+  );
+}
+
+function parseProposalEntries(formData: FormData): MealPlanEntryValues[] {
+  return formData.getAll("entryDate").map((dateValue) => {
+    const date = String(dateValue);
+    const selection = parseMealSelection(
+      String(formData.get(`mealSelection:${date}`) ?? ""),
+    );
+
+    return {
+      date,
+      freezerItemId: selection.freezerItemId,
+      note: String(formData.get(`note:${date}`) ?? ""),
+      recipeId: selection.recipeId,
+      responsibleUserId: "",
+    };
+  });
+}
+
+function parseProposalEntryVersions(formData: FormData) {
+  return Object.fromEntries(
+    formData.getAll("entryDate").map((dateValue) => {
+      const date = String(dateValue);
+
+      return [date, String(formData.get(`entryUpdatedAt:${date}`) ?? "")];
+    }),
+  );
+}
+
+function requireRouteParam(value: string | undefined, message: string): string {
+  if (!value) {
+    throw new Response(message, {
+      status: 404,
+      statusText: "Not Found",
+    });
+  }
+
+  return value;
+}

--- a/app/routes/family-meal-plan.test.ts
+++ b/app/routes/family-meal-plan.test.ts
@@ -245,6 +245,53 @@ describe("family meal plan route", () => {
     });
   });
 
+  it("redirects proposed meal plans to the proposal UI", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanPlanningData).mockResolvedValue({
+      family: {
+        id: "family-1",
+        name: "Solberg",
+      },
+      freezerItems: [],
+      mealPlan: {
+        activeShoppingDate: new Date("2026-05-15T00:00:00.000Z"),
+        approvedAt: null,
+        approvedByUserId: null,
+        copiedFromMealPlanId: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        endDate: new Date("2026-05-18T00:00:00.000Z"),
+        entries: [],
+        id: "meal-plan-1",
+        startDate: new Date("2026-05-15T00:00:00.000Z"),
+        status: "PROPOSED",
+        title: "Langhelg",
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+      recipes: [],
+      recentlyUsedRecipeIds: [],
+      userRole: "ADMIN",
+      visibleDates: ["2026-05-15"],
+    } as never);
+    vi.mocked(listFamilyMembers).mockResolvedValue([]);
+
+    try {
+      await loader({
+        params: {
+          familyId: "family-1",
+          mealPlanId: "meal-plan-1",
+        },
+        request: buildRequest(),
+      });
+      throw new Error("expected redirect");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Response);
+      expect((error as Response).status).toBe(302);
+      expect((error as Response).headers.get("Location")).toBe(
+        "/families/family-1/meal-plans/meal-plan-1/proposal",
+      );
+    }
+  });
+
   it("returns planner validation errors from the server module", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(saveMealPlanEntries).mockResolvedValue({

--- a/app/routes/family-meal-plan.tsx
+++ b/app/routes/family-meal-plan.tsx
@@ -2,6 +2,7 @@ import {
   Form,
   Link,
   isRouteErrorResponse,
+  redirect,
   useFetcher,
   useNavigation,
   type MetaFunction,
@@ -30,6 +31,7 @@ import {
   encodeMealSelection,
   formatShortDateLabel,
   parseMealSelection,
+  toLiveMealPlanStatus,
 } from "../lib/meal-plan-display";
 import { useMealPlanEntriesAutosave } from "../lib/use-meal-plan-entries-autosave";
 import {
@@ -150,6 +152,10 @@ export async function loader({
     }),
     listFamilyMembers(familyId),
   ]);
+
+  if (result.mealPlan.status === "PROPOSED") {
+    throw redirect(`/families/${familyId}/meal-plans/${mealPlanId}/proposal`);
+  }
   const familyMembers: MealPlanFamilyMemberOption[] = members.map((member) => ({
     displayName: member.user.displayName,
     id: member.user.id,
@@ -609,7 +615,7 @@ export default function FamilyMealPlanRoute({
     ? "APPROVED"
     : isReopeningMealPlan
       ? "DRAFT"
-      : loaderData.mealPlan.status;
+      : toLiveMealPlanStatus(loaderData.mealPlan.status);
   const displayApprovedAt = isApprovingMealPlan
     ? new Date().toISOString()
     : isReopeningMealPlan

--- a/app/routes/family.tsx
+++ b/app/routes/family.tsx
@@ -19,7 +19,7 @@ import {
   updateFamilyReminderEmail,
 } from "../lib/family.server";
 import { getFamilyWeekDinnerMenu } from "../lib/family-home.server";
-import { formatMealPlanWindow } from "../lib/meal-plan-display";
+import { formatMealPlanWindow, toLiveMealPlanStatus } from "../lib/meal-plan-display";
 import { formatDateOnly } from "../lib/meal-plan-dates";
 import { isMealPlanPast } from "../lib/meal-plan-week";
 import { listMealPlansForFamily } from "../lib/meal-plan.server";
@@ -148,7 +148,7 @@ function serializeMealPlanSummary(
     endDate: formatDateOnly(mealPlan.endDate),
     id: mealPlan.id,
     startDate: formatDateOnly(mealPlan.startDate),
-    status: mealPlan.status,
+    status: toLiveMealPlanStatus(mealPlan.status),
     title: mealPlan.title,
   };
 }

--- a/app/routes/mcp.test.ts
+++ b/app/routes/mcp.test.ts
@@ -58,9 +58,10 @@ describe("mcp route", () => {
         clientId: "family-1",
         extra: {
           familyId: "family-1",
+          origin: "http://localhost",
           userId: "user-1",
         },
-        scopes: ["mcp:read"],
+        scopes: ["mcp:read", "mcp:write"],
         token: "good-token",
       },
     });

--- a/app/routes/mcp.ts
+++ b/app/routes/mcp.ts
@@ -23,9 +23,10 @@ async function handleMcpRequest(request: Request) {
       clientId: auth.familyId,
       extra: {
         familyId: auth.familyId,
+        origin: new URL(request.url).origin,
         userId: auth.userId,
       },
-      scopes: ["mcp:read"],
+      scopes: ["mcp:read", "mcp:write"],
       token: request.headers.get("Authorization")?.slice("Bearer ".length).trim() ?? "",
     },
   });

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,8 @@
 # Family MCP server
 
-The app exposes a **read-only** [Model Context Protocol](https://modelcontextprotocol.io) server on the same process as the website (`GET`/`POST` `/mcp`). Production transport is **Streamable HTTP**, not stdio.
+The app exposes a [Model Context Protocol](https://modelcontextprotocol.io) server on the same process as the website (`GET`/`POST` `/mcp`). Production transport is **Streamable HTTP**, not stdio.
+
+Most tools are read-only. `create_meal_plan_proposal` can store a **proposal** for a week; it never approves a live meal plan.
 
 ## Mint a token
 
@@ -38,13 +40,18 @@ Authenticated clients can call:
 
 - `list_recipes` — family and global recipes (title, description, image URL, tags, servings, prep)
 - `get_recipe` — one recipe including ingredients
-- `get_current_week_meal_plan` — Europe/Oslo calendar week dinners
-- `list_meal_plans` — plan summaries
+- `get_current_week_meal_plan` — Europe/Oslo calendar week dinners (live DRAFT/APPROVED plans only)
+- `list_meal_plans` — plan summaries (excludes open proposals)
 - `get_shopping_list` — current family shopping projection
 - `get_recent_dinners` — recently used dinner recipes
 - `list_freezer_items` — freezer stock
+- `create_meal_plan_proposal` — create or replace a proposed dinner plan for a calendar week
 
-The token is scoped to one family. Tools never create or approve meal plans.
+`create_meal_plan_proposal` defaults to **next** Europe/Oslo week (Monday–Sunday) when `weekStart` / `weekEnd` are omitted. Re-running for the same week updates the existing proposal in place and returns the same URL. It fails if a live DRAFT or APPROVED plan already covers that week.
+
+The tool returns `proposalUrl`. Put that in email as **Se forslaget i Mealplanner her**. Opening the link (after login) shows the proposal UI, where a family member can adjust dinners and approve. Approval turns the proposal into a live meal plan. MCP cannot approve or reopen plans.
+
+The token is scoped to one family.
 
 ## Deploy
 

--- a/prisma/migrations/20260902093000_add_meal_plan_proposed_status/migration.sql
+++ b/prisma/migrations/20260902093000_add_meal_plan_proposed_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "MealPlanStatus" ADD VALUE 'PROPOSED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ enum RecipeScope {
 enum MealPlanStatus {
   DRAFT
   APPROVED
+  PROPOSED
 }
 
 enum FamilyShoppingListMode {


### PR DESCRIPTION
## Summary
- Add MCP `create_meal_plan_proposal` so an agent can store next week's dinners as a proposal and get an email-safe `proposalUrl`.
- Keep proposals off shopping, calendar, home week, store mode, and ukeplaner lists until a family member reviews, adjusts, and approves them in a dedicated UI.
- Approving turns the proposal into a live meal plan and redirects to the ukeplan page.

## Related issue
Closes #243

## Test plan
- [x] Validation run locally: lint, test:run, typecheck
- [ ] Apply the Prisma migration locally, mint an MCP key, and call `create_meal_plan_proposal`
- [ ] Open `proposalUrl` while logged out, then after login; tweak one dinner and Godkjenn
- [ ] Confirm the plan appears as a real ukeplan and stays off `list_meal_plans` / shopping / calendar until approved

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck