### PR TITLE
Show stored dinners on proposal pages opened from email

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,14 +2,14 @@
 
 ## Current Objective
 
-Ship the proposal picker fix so stored dinners show when opening a proposal URL from email (follow-up to [#244](https://github.com/sndrem/mealplanner/pull/244)).
+Proposal picker fix is in PR [#245](https://github.com/sndrem/mealplanner/pull/245): stored dinners show when opening a proposal URL from email (follow-up to [#244](https://github.com/sndrem/mealplanner/pull/244)).
 
 ## Completed
 
 - `MealPlanRecipePicker` labels the trigger with the selected recipe or freezer item instead of always “Velg middag”
 - Proposal loader maps `recipeTitle` / `recipeImageUrl` / `freezerLabel` onto each day; the day card shows the stored meal
 - Tests for `getMealSelectionTriggerLabel` and proposal loader mapping
-- Local validation passed; ready to push and open PR
+- Pushed `fix/proposal-picker-shows-selected-meal` and opened PR #245
 
 ## Files To Read First
 
@@ -27,9 +27,9 @@ Ship the proposal picker fix so stored dinners show when opening a proposal URL 
 
 ## Open Items
 
-- Confirm in the app: open a proposal URL and see recipe names (not “Velg middag”) on each day
-- No dedicated GitHub issue; this is a follow-up to #244 / #243
+- Confirm in the app after merge: open a proposal URL and see recipe names (not “Velg middag”) on each day
+- No dedicated GitHub issue; this is a follow-up to #244 / #243 (already closed)
 
 ## Next Step
 
-Push the branch and open a pull request.
+Merge PR #245 after CI.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,41 +2,34 @@
 
 ## Current Objective
 
-Ship MCP meal-plan proposals ([#243](https://github.com/sndrem/mealplanner/issues/243)): write tool, `PROPOSED` persistence, and email-linked review UI.
+Ship the proposal picker fix so stored dinners show when opening a proposal URL from email (follow-up to [#244](https://github.com/sndrem/mealplanner/pull/244)).
 
 ## Completed
 
-- Cut `issue/243-mcp-meal-plan-proposal` from current `origin/main` after `git pull --ff-only`
-- Added `MealPlanStatus.PROPOSED` plus migration `20260902093000_add_meal_plan_proposed_status`
-- Live surfaces (covering date, ukeplaner list, home week, calendar sub, store mode, shopping ranges) ignore `PROPOSED`
-- `create_meal_plan_proposal` MCP tool upserts next-week (or given Mon–Sun) dinners and returns `proposalUrl`
-- Authenticated `/families/:familyId/meal-plans/:mealPlanId/proposal` for adjust + Godkjenn (`PROPOSED` → `APPROVED`)
-- Docs (`docs/mcp.md`) and Familie MCP card copy updated
-- Local validation passed; ready to open PR
+- `MealPlanRecipePicker` labels the trigger with the selected recipe or freezer item instead of always “Velg middag”
+- Proposal loader maps `recipeTitle` / `recipeImageUrl` / `freezerLabel` onto each day; the day card shows the stored meal
+- Tests for `getMealSelectionTriggerLabel` and proposal loader mapping
+- Local validation passed; ready to push and open PR
 
 ## Files To Read First
 
-- `app/lib/meal-plan.server.ts` — `createOrReplaceMealPlanProposal`, `approveMealPlanProposal`
-- `app/lib/mcp-tools.server.ts` / `app/lib/mcp-handler.server.ts` — write tool
-- `app/routes/family-meal-plan-proposal.tsx` — review UI
-- `app/lib/meal-plan-status.server.ts` — live-plan status filter
+- `app/components/meal-plan-recipe-picker.tsx` — trigger label from selection
+- `app/lib/meal-plan-display.ts` — `getMealSelectionTriggerLabel`
+- `app/routes/family-meal-plan-proposal.tsx` — day card + selectedLabel
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 628 tests passed
+- `npm run test:run` — 633 tests passed
 - `npm run typecheck` — passed
-- Browser proposal/approve flow — not run
-- MCP Inspector against `/mcp` — not run
-- Prisma migrate against local DB — not run (`prisma:generate` only)
+- Browser proposal page from email link — not run
 
 ## Open Items
 
-- Production migration runs via Fly `release_command` (`prisma migrate deploy`)
-- After merge: mint a key, call `create_meal_plan_proposal`, open `proposalUrl`, tweak a dinner, approve
-- Confirm proposals stay off shopping/calendar/`list_meal_plans` until approved
+- Confirm in the app: open a proposal URL and see recipe names (not “Velg middag”) on each day
+- No dedicated GitHub issue; this is a follow-up to #244 / #243
 
 ## Next Step
 
-Merge the PR for #243 after review.
+Push the branch and open a pull request.

--- a/app/components/meal-plan-recipe-picker.tsx
+++ b/app/components/meal-plan-recipe-picker.tsx
@@ -6,7 +6,7 @@ import {
   groupRecipePickerResults,
   hasActiveRecipeSearch,
 } from "../lib/recipe-list-search";
-import { parseMealSelection } from "../lib/meal-plan-display";
+import { getMealSelectionTriggerLabel, parseMealSelection } from "../lib/meal-plan-display";
 import {
   RecipePickerCard,
   type RecipePickerCardFreezerItem,
@@ -20,6 +20,7 @@ export function MealPlanRecipePicker({
   onChange,
   recentlyUsedRecipeIds,
   recipes,
+  selectedLabel,
   triggerLabel,
   value,
 }: {
@@ -29,6 +30,7 @@ export function MealPlanRecipePicker({
   onChange: (value: string) => void;
   recentlyUsedRecipeIds: ReadonlySet<string>;
   recipes: RecipePickerCardRecipe[];
+  selectedLabel?: string;
   triggerLabel: string;
   value: string;
 }) {
@@ -40,6 +42,13 @@ export function MealPlanRecipePicker({
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
   const parsedSelection = parseMealSelection(value);
+  const buttonLabel = getMealSelectionTriggerLabel({
+    emptyLabel: triggerLabel,
+    fallbackLabel: selectedLabel,
+    freezerItems,
+    recipes,
+    value,
+  });
   const tagOptions = useMemo(() => deriveRecipeTagOptions(recipes), [recipes]);
   const filteredRecipes = useMemo(
     () =>
@@ -154,7 +163,7 @@ export function MealPlanRecipePicker({
         onClick={() => setIsOpen((current) => !current)}
         type="button"
       >
-        <span className="min-w-0 truncate font-medium">{triggerLabel}</span>
+        <span className="min-w-0 truncate font-medium">{buttonLabel}</span>
         <span className="shrink-0 text-xs text-slate-400">
           {isOpen ? "Lukk" : "Velg"}
         </span>

--- a/app/lib/meal-plan-display.test.ts
+++ b/app/lib/meal-plan-display.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatMealPlanRecipeSelectLabel,
   getDinnerMenuLabel,
+  getMealSelectionTriggerLabel,
   swapOrMoveMealSelection,
 } from "./meal-plan-display";
 
@@ -71,6 +72,52 @@ describe("getDinnerMenuLabel", () => {
 
   it("returns default label when entry is empty", () => {
     expect(getDinnerMenuLabel(null)).toBe("Ikke planlagt");
+  });
+});
+
+describe("getMealSelectionTriggerLabel", () => {
+  const recipes = [{ id: "recipe-taco", title: "Taco" }];
+  const freezerItems = [{ id: "freezer-1", label: "Lasagne" }];
+
+  it("returns the empty label when nothing is selected", () => {
+    expect(
+      getMealSelectionTriggerLabel({
+        freezerItems,
+        recipes,
+        value: "",
+      }),
+    ).toBe("Velg middag");
+  });
+
+  it("returns the selected recipe title", () => {
+    expect(
+      getMealSelectionTriggerLabel({
+        freezerItems,
+        recipes,
+        value: "recipe:recipe-taco",
+      }),
+    ).toBe("Taco");
+  });
+
+  it("returns the selected freezer label", () => {
+    expect(
+      getMealSelectionTriggerLabel({
+        freezerItems,
+        recipes,
+        value: "freezer:freezer-1",
+      }),
+    ).toBe("Lasagne");
+  });
+
+  it("falls back to the stored label when the recipe is missing from the picker list", () => {
+    expect(
+      getMealSelectionTriggerLabel({
+        fallbackLabel: "Gammel gryte",
+        freezerItems,
+        recipes,
+        value: "recipe:deleted-recipe",
+      }),
+    ).toBe("Gammel gryte");
   });
 });
 

--- a/app/lib/meal-plan-display.ts
+++ b/app/lib/meal-plan-display.ts
@@ -111,6 +111,45 @@ export function parseMealSelection(value: string) {
   };
 }
 
+export function getMealSelectionTriggerLabel({
+  emptyLabel = "Velg middag",
+  fallbackLabel,
+  freezerItems,
+  recipes,
+  value,
+}: {
+  emptyLabel?: string;
+  fallbackLabel?: string;
+  freezerItems: Array<{ id: string; label: string }>;
+  recipes: Array<{ id: string; title: string }>;
+  value: string;
+}) {
+  if (!value) {
+    return emptyLabel;
+  }
+
+  const parsed = parseMealSelection(value);
+  const recipe = recipes.find((item) => item.id === parsed.recipeId);
+
+  if (recipe) {
+    return recipe.title;
+  }
+
+  const freezerItem = freezerItems.find(
+    (item) => item.id === parsed.freezerItemId,
+  );
+
+  if (freezerItem) {
+    return freezerItem.label;
+  }
+
+  if (fallbackLabel) {
+    return fallbackLabel;
+  }
+
+  return emptyLabel;
+}
+
 /** Swap or move encoded meal selections between two fixed dates (dates stay put). */
 export function swapOrMoveMealSelection(
   selections: Record<string, string>,

--- a/app/routes/family-meal-plan-proposal.test.ts
+++ b/app/routes/family-meal-plan-proposal.test.ts
@@ -107,6 +107,50 @@ describe("family meal plan proposal route", () => {
     expect(result.visibleDates).toEqual(["2026-05-11", "2026-05-12"]);
   });
 
+  it("maps stored dinners onto each proposal day", async () => {
+    vi.mocked(requireUser).mockResolvedValue(mockUser);
+    vi.mocked(getMealPlanPlanningData).mockResolvedValue({
+      ...buildPlanningData(),
+      mealPlan: {
+        ...buildPlanningData().mealPlan,
+        entries: [
+          {
+            date: new Date("2026-05-11T00:00:00.000Z"),
+            freezerItem: null,
+            freezerItemId: null,
+            mealType: "DINNER",
+            note: "Bruk extra ost",
+            recipe: {
+              imageUrl: "https://img.example/taco.jpg",
+              title: "Taco",
+            },
+            recipeId: "recipe-taco",
+            updatedAt: new Date("2026-05-10T12:00:00.000Z"),
+          },
+        ],
+      },
+    } as never);
+
+    const result = await loader({
+      params: { familyId: "family-1", mealPlanId: "proposal-1" },
+      request: new Request(
+        "http://localhost/families/family-1/meal-plans/proposal-1/proposal",
+      ),
+    } as never);
+
+    expect(result.entriesByDate["2026-05-11"]).toMatchObject({
+      freezerItemId: "",
+      note: "Bruk extra ost",
+      recipeId: "recipe-taco",
+      recipeImageUrl: "https://img.example/taco.jpg",
+      recipeTitle: "Taco",
+    });
+    expect(result.entriesByDate["2026-05-12"]).toMatchObject({
+      recipeId: "",
+      recipeTitle: "",
+    });
+  });
+
   it("shows an already-approved proposal without editing", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(getMealPlanPlanningData).mockResolvedValue(

--- a/app/routes/family-meal-plan-proposal.tsx
+++ b/app/routes/family-meal-plan-proposal.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { Form, Link, useNavigation, type MetaFunction } from "react-router";
 
 import { MealPlanRecipePicker } from "../components/meal-plan-recipe-picker";
+import { RecipePickerMedia } from "../components/recipe-picker-card";
 import { requireUser } from "../lib/auth.server";
 import { formatDateOnly } from "../lib/meal-plan-dates";
 import {
@@ -74,8 +75,11 @@ export async function loader({
         date,
         {
           freezerItemId: entry?.freezerItemId ?? "",
+          freezerLabel: entry?.freezerItem?.label ?? "",
           note: entry?.note ?? "",
           recipeId: entry?.recipeId ?? "",
+          recipeImageUrl: entry?.recipe?.imageUrl ?? null,
+          recipeTitle: entry?.recipe?.title ?? "",
           updatedAt: entry?.updatedAt.toISOString() ?? "",
         },
       ];
@@ -350,6 +354,23 @@ export default function FamilyMealPlanProposalRoute({
             const weekday = formatWeekdayLabel(date);
             const capitalizedWeekday =
               weekday.charAt(0).toUpperCase() + weekday.slice(1);
+            const entry = loaderData.entriesByDate[date];
+            const selection = displaySelections[date] ?? "";
+            const parsedSelection = parseMealSelection(selection);
+            const selectedRecipe = loaderData.recipes.find(
+              (recipe) => recipe.id === parsedSelection.recipeId,
+            );
+            const selectedFreezerItem = loaderData.freezerItems.find(
+              (item) => item.id === parsedSelection.freezerItemId,
+            );
+            const selectedLabel =
+              selectedRecipe?.title ||
+              selectedFreezerItem?.label ||
+              entry?.recipeTitle ||
+              entry?.freezerLabel ||
+              "";
+            const selectedImageUrl =
+              selectedRecipe?.imageUrl ?? entry?.recipeImageUrl ?? null;
 
             return (
               <section
@@ -364,6 +385,17 @@ export default function FamilyMealPlanProposalRoute({
                     {formatShortDateLabel(date)}
                   </p>
                 </div>
+                {selectedLabel ? (
+                  <div className="mt-3 flex min-w-0 items-center gap-3">
+                    <RecipePickerMedia
+                      imageUrl={selectedImageUrl}
+                      title={selectedLabel}
+                    />
+                    <p className="min-w-0 truncate text-base font-semibold text-slate-950">
+                      {selectedLabel}
+                    </p>
+                  </div>
+                ) : null}
                 <div className="mt-3">
                   <MealPlanRecipePicker
                     freezerItems={loaderData.freezerItems}
@@ -377,8 +409,9 @@ export default function FamilyMealPlanProposalRoute({
                     }}
                     recentlyUsedRecipeIds={recentlyUsedRecipeIds}
                     recipes={loaderData.recipes}
+                    selectedLabel={selectedLabel || undefined}
                     triggerLabel="Velg middag"
-                    value={displaySelections[date] ?? ""}
+                    value={selection}
                   />
                 </div>
                 <label className="mt-3 block text-sm font-medium text-slate-700">


### PR DESCRIPTION
## Summary
- The meal picker on the proposal page always showed «Velg middag», even when dinners were already saved (notes still appeared, which made this look like missing data).
- The picker now labels the trigger with the selected recipe or freezer item, and each proposal day card shows the stored meal.

## Related
Follow-up to #244 / #243. No new issue — this is a bugfix for the email deep-link review UI.

## Test plan
- [ ] Open a proposal URL from an email (or `/families/:familyId/meal-plans/:mealPlanId/proposal`)
- [ ] Confirm each planned day shows the recipe/freezer name instead of «Velg middag»
- [ ] Confirm notes still show
- [ ] Change a dinner, save, and reload — the new selection still shows

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run (633 tests)
- npm run typecheck