### PR TITLE
Let AI agents create and update family recipes over MCP

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -2,34 +2,34 @@
 
 ## Current Objective
 
-Proposal picker fix is in PR [#245](https://github.com/sndrem/mealplanner/pull/245): stored dinners show when opening a proposal URL from email (follow-up to [#244](https://github.com/sndrem/mealplanner/pull/244)).
+Ship MCP family recipe upsert for [#246](https://github.com/sndrem/mealplanner/issues/246) on `issue/246-mcp-upsert-recipe`.
 
 ## Completed
 
-- `MealPlanRecipePicker` labels the trigger with the selected recipe or freezer item instead of always “Velg middag”
-- Proposal loader maps `recipeTitle` / `recipeImageUrl` / `freezerLabel` onto each day; the day card shows the stored meal
-- Tests for `getMealSelectionTriggerLabel` and proposal loader mapping
-- Pushed `fix/proposal-picker-shows-selected-meal` and opened PR #245
+- `upsert_recipe` MCP tool creates or partially updates family recipes with Zod validation
+- `list_ingredient_categories` plus richer `get_recipe` (category key/id, store, reminders)
+- `createFamilyRecipe` persists reminder suggestions
+- Docs in `docs/mcp.md`
 
 ## Files To Read First
 
-- `app/components/meal-plan-recipe-picker.tsx` — trigger label from selection
-- `app/lib/meal-plan-display.ts` — `getMealSelectionTriggerLabel`
-- `app/routes/family-meal-plan-proposal.tsx` — day card + selectedLabel
+- `app/lib/mcp-recipe-schema.ts` — Zod input contract
+- `app/lib/mcp-tools.server.ts` — resolve, merge, upsert
+- `app/lib/mcp-handler.server.ts` — tool registration
 
 ## Validation
 
 - `npm run prisma:generate` — passed
 - `npm run lint` — passed
-- `npm run test:run` — 633 tests passed
+- `npm run test:run` — 649 tests passed
 - `npm run typecheck` — passed
-- Browser proposal page from email link — not run
+- MCP Inspector / live `/mcp` — not run
 
 ## Open Items
 
-- Confirm in the app after merge: open a proposal URL and see recipe names (not “Velg middag”) on each day
-- No dedicated GitHub issue; this is a follow-up to #244 / #243 (already closed)
+- After merge: smoke-test `upsert_recipe` against local or production `/mcp`
+- Cover images remain web-only
 
 ## Next Step
 
-Merge PR #245 after CI.
+Merge the PR for #246 after CI.

--- a/app/components/store-mode-shopping-item-card.test.tsx
+++ b/app/components/store-mode-shopping-item-card.test.tsx
@@ -50,7 +50,7 @@ describe("StoreModeShoppingItemCard", () => {
   it("shows quick-add when not read-only", () => {
     renderWithRouter(
       <StoreModeShoppingItemCard
-        categories={[{ displayName: "Meieri", familyId: null, id: "cat-dairy" }]}
+        categories={[{ displayName: "Meieri", familyId: null, id: "cat-dairy", key: "dairy" }]}
         item={familyItem}
         layout="grid"
         onToggle={vi.fn()}

--- a/app/lib/mcp-handler.server.ts
+++ b/app/lib/mcp-handler.server.ts
@@ -5,6 +5,7 @@ import {
 } from "@modelcontextprotocol/server";
 import { z } from "zod";
 
+import { upsertRecipeInputSchema } from "./mcp-recipe-schema";
 import {
   createMealPlanProposalForMcp,
   getCurrentWeekMealPlanForMcp,
@@ -12,8 +13,10 @@ import {
   getRecipeForMcp,
   getShoppingListForMcp,
   listFreezerItemsForMcp,
+  listIngredientCategoriesForMcp,
   listMealPlansForMcp,
   listRecipesForMcp,
+  upsertRecipeForMcp,
 } from "./mcp-tools.server";
 
 function requireMcpActor(authInfo: AuthInfo | undefined) {
@@ -75,7 +78,7 @@ export const mcpHttpHandler = createMcpHandler(
       "get_recipe",
       {
         description:
-          "Get one accessible recipe (family or global) including ingredients.",
+          "Get one accessible recipe (family or global) including ingredients, category keys, preferred stores, and reminder suggestions.",
         inputSchema: z.object({
           recipeId: z.string().min(1).describe("Recipe id"),
         }),
@@ -172,6 +175,22 @@ export const mcpHttpHandler = createMcpHandler(
     );
 
     server.registerTool(
+      "list_ingredient_categories",
+      {
+        description:
+          "List global ingredient categories (id, key, display name) for recipe ingredients.",
+        inputSchema: z.object({}),
+      },
+      async () => {
+        const data = await listIngredientCategoriesForMcp();
+        return jsonResult(
+          data,
+          `${data.categories.length} ingredient categories.`,
+        );
+      },
+    );
+
+    server.registerTool(
       "create_meal_plan_proposal",
       {
         description:
@@ -219,6 +238,37 @@ export const mcpHttpHandler = createMcpHandler(
         return jsonResult(
           data,
           `Proposal ${data.proposalId} ready for ${data.weekStart}–${data.weekEnd}.`,
+        );
+      },
+    );
+
+    server.registerTool(
+      "upsert_recipe",
+      {
+        description:
+          "Create a family recipe, or update one by recipeId. Omitted fields stay unchanged on update. tags, ingredients, and reminderSuggestions replace the stored list when sent. FAMILY recipes only; cover images stay in the web UI. Omit servings/prep on create to use the same defaults as the web form (2 servings, 45 minutes).",
+        inputSchema: upsertRecipeInputSchema,
+      },
+      async (input) => {
+        const origin = requireMcpOrigin(authInfo);
+        const data = await upsertRecipeForMcp({
+          ...actor,
+          ...input,
+          origin,
+        });
+
+        if (data.status === "VALIDATION_ERROR" || data.status === "NOT_FOUND") {
+          return {
+            content: [{ text: data.formError, type: "text" as const }],
+            isError: true,
+          };
+        }
+
+        return jsonResult(
+          data,
+          data.status === "CREATED"
+            ? `Created recipe ${data.recipe.title}.`
+            : `Updated recipe ${data.recipe.title}.`,
         );
       },
     );

--- a/app/lib/mcp-recipe-schema.test.ts
+++ b/app/lib/mcp-recipe-schema.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { upsertRecipeInputSchema } from "./mcp-recipe-schema";
+
+const validIngredient = {
+  categoryKey: "meat-fish",
+  displayName: "Kyllingfilet",
+};
+
+describe("upsertRecipeInputSchema", () => {
+  it("accepts a create payload with title and ingredients", () => {
+    const result = upsertRecipeInputSchema.safeParse({
+      ingredients: [validIngredient],
+      title: "Kyllingwok",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects create without title or ingredients", () => {
+    const result = upsertRecipeInputSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    const paths = result.error.issues.map((issue) => issue.path.join("."));
+    expect(paths).toContain("title");
+    expect(paths).toContain("ingredients");
+  });
+
+  it("rejects an ingredient without category identity", () => {
+    const result = upsertRecipeInputSchema.safeParse({
+      ingredients: [{ displayName: "Kyllingfilet" }],
+      title: "Kyllingwok",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects extra fields", () => {
+    const result = upsertRecipeInputSchema.safeParse({
+      ingredients: [validIngredient],
+      scope: "GLOBAL",
+      title: "Kyllingwok",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a tags-only update", () => {
+    const result = upsertRecipeInputSchema.safeParse({
+      recipeId: "recipe-1",
+      tags: ["middag", "rask"],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects update with recipeId but no writable fields", () => {
+    const result = upsertRecipeInputSchema.safeParse({
+      recipeId: "recipe-1",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues[0]?.message).toBe(
+      "Provide at least one field to update.",
+    );
+  });
+});

--- a/app/lib/mcp-recipe-schema.ts
+++ b/app/lib/mcp-recipe-schema.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+import { RECIPE_REMINDER_TIMING_KINDS } from "./recipe-reminder";
+
+export const UPSERT_RECIPE_WRITABLE_KEYS = [
+  "defaultServings",
+  "description",
+  "ingredients",
+  "prepMinutes",
+  "reminderSuggestions",
+  "tags",
+  "title",
+] as const;
+
+export type UpsertRecipeWritableKey =
+  (typeof UPSERT_RECIPE_WRITABLE_KEYS)[number];
+
+export const mcpRecipeIngredientInputSchema = z
+  .object({
+    amount: z.string().optional().describe("Quantity amount, e.g. 500"),
+    category: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Ingredient category display name"),
+    categoryId: z.string().min(1).optional().describe("Ingredient category id"),
+    categoryKey: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Ingredient category key, e.g. meat-fish"),
+    displayName: z.string().min(1).describe("Ingredient name"),
+    preferredStoreId: z.string().min(1).optional(),
+    unit: z.string().optional().describe("Unit, e.g. g"),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (!value.categoryKey && !value.categoryId && !value.category) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Provide categoryKey, categoryId, or category display name.",
+        path: ["categoryKey"],
+      });
+    }
+  });
+
+export const mcpRecipeReminderInputSchema = z
+  .object({
+    note: z.string().optional(),
+    timingKind: z.enum(RECIPE_REMINDER_TIMING_KINDS).optional(),
+    title: z.string().min(1),
+  })
+  .strict();
+
+export const upsertRecipeInputSchema = z
+  .object({
+    defaultServings: z.number().int().positive().optional(),
+    description: z.string().optional(),
+    ingredients: z.array(mcpRecipeIngredientInputSchema).optional(),
+    prepMinutes: z.number().int().positive().optional(),
+    recipeId: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("When set, update this family recipe"),
+    reminderSuggestions: z.array(mcpRecipeReminderInputSchema).optional(),
+    tags: z.array(z.string()).optional(),
+    title: z.string().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const hasWritableField = UPSERT_RECIPE_WRITABLE_KEYS.some(
+      (key) => value[key] !== undefined,
+    );
+
+    if (value.recipeId) {
+      if (!hasWritableField) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Provide at least one field to update.",
+        });
+      }
+      return;
+    }
+
+    if (!value.title?.trim()) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Title is required when creating a recipe.",
+        path: ["title"],
+      });
+    }
+
+    if (!value.ingredients || value.ingredients.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Add at least one ingredient when creating a recipe.",
+        path: ["ingredients"],
+      });
+    }
+  });
+
+export type UpsertRecipeInput = z.infer<typeof upsertRecipeInputSchema>;

--- a/app/lib/mcp-tools.server.test.ts
+++ b/app/lib/mcp-tools.server.test.ts
@@ -10,10 +10,15 @@ const {
   getRecentlyUsedRecipeIdsMock,
   getRecipeManagementDataMock,
   listFamilyFreezerItemsMock,
+  listIngredientCategoriesMock,
   listMealPlansForFamilyMock,
+  createFamilyRecipeMock,
   createOrReplaceMealPlanProposalMock,
+  updateFamilyRecipeMock,
   dbMock,
 } = vi.hoisted(() => ({
+  createFamilyRecipeMock: vi.fn(),
+  createOrReplaceMealPlanProposalMock: vi.fn(),
   dbMock: {
     recipe: {
       findMany: vi.fn(),
@@ -28,8 +33,9 @@ const {
   getRecentlyUsedRecipeIdsMock: vi.fn(),
   getRecipeManagementDataMock: vi.fn(),
   listFamilyFreezerItemsMock: vi.fn(),
+  listIngredientCategoriesMock: vi.fn(),
   listMealPlansForFamilyMock: vi.fn(),
-  createOrReplaceMealPlanProposalMock: vi.fn(),
+  updateFamilyRecipeMock: vi.fn(),
 }));
 
 vi.mock("./db.server", () => ({
@@ -65,6 +71,15 @@ vi.mock("./freezer.server", () => ({
   listFamilyFreezerItems: listFamilyFreezerItemsMock,
 }));
 
+vi.mock("./store.server", () => ({
+  listIngredientCategories: listIngredientCategoriesMock,
+}));
+
+vi.mock("./recipe-write.server", () => ({
+  createFamilyRecipe: createFamilyRecipeMock,
+  updateFamilyRecipe: updateFamilyRecipeMock,
+}));
+
 import {
   createMealPlanProposalForMcp,
   getCurrentWeekMealPlanForMcp,
@@ -72,11 +87,71 @@ import {
   getRecipeForMcp,
   getShoppingListForMcp,
   listFreezerItemsForMcp,
+  listIngredientCategoriesForMcp,
   listMealPlansForMcp,
   listRecipesForMcp,
+  upsertRecipeForMcp,
 } from "./mcp-tools.server";
 
 const actor = { familyId: "family-1", userId: "user-1" };
+
+const familyRecipeDetail = {
+  defaultServings: 4,
+  description: "En god middag",
+  familyId: "family-1",
+  id: "recipe-1",
+  imageUrl: null,
+  ingredients: [
+    {
+      amount: "500",
+      category: { displayName: "Kjøtt og fisk", id: "cat-meat", key: "meat-fish" },
+      categoryId: "cat-meat",
+      displayName: "Kyllingfilet",
+      preferredStoreId: "store-1",
+      unit: "g",
+    },
+  ],
+  prepMinutes: 30,
+  reminderSuggestions: [
+    {
+      note: "Ta ut kvelden før",
+      timingKind: "HOURS_BEFORE_16",
+      title: "Ta deigen ut",
+    },
+  ],
+  scope: "FAMILY" as const,
+  tags: ["middag"],
+  title: "Kyllingwok",
+};
+
+const serializedFamilyRecipe = {
+  defaultServings: 4,
+  description: "En god middag",
+  id: "recipe-1",
+  imageUrl: null,
+  ingredients: [
+    {
+      amount: "500",
+      category: "Kjøtt og fisk",
+      categoryId: "cat-meat",
+      categoryKey: "meat-fish",
+      displayName: "Kyllingfilet",
+      preferredStoreId: "store-1",
+      unit: "g",
+    },
+  ],
+  prepMinutes: 30,
+  reminderSuggestions: [
+    {
+      note: "Ta ut kvelden før",
+      timingKind: "HOURS_BEFORE_16",
+      title: "Ta deigen ut",
+    },
+  ],
+  scope: "FAMILY",
+  tags: ["middag"],
+  title: "Kyllingwok",
+};
 
 describe("mcp-tools.server", () => {
   afterEach(() => {
@@ -148,12 +223,15 @@ describe("mcp-tools.server", () => {
         ingredients: [
           {
             amount: "200",
-            category: { displayName: "Meieri", id: "cat-1" },
+            category: { displayName: "Meieri", id: "cat-1", key: "dairy" },
+            categoryId: "cat-1",
             displayName: "Ost",
+            preferredStoreId: null,
             unit: "g",
           },
         ],
         prepMinutes: 15,
+        reminderSuggestions: [],
         scope: "GLOBAL",
         tags: [],
         title: "Pizza",
@@ -173,11 +251,15 @@ describe("mcp-tools.server", () => {
           {
             amount: "200",
             category: "Meieri",
+            categoryId: "cat-1",
+            categoryKey: "dairy",
             displayName: "Ost",
+            preferredStoreId: null,
             unit: "g",
           },
         ],
         prepMinutes: 15,
+        reminderSuggestions: [],
         scope: "GLOBAL",
         tags: [],
         title: "Pizza",
@@ -490,6 +572,422 @@ describe("mcp-tools.server", () => {
     ).resolves.toEqual({
       formError: "Det finnes allerede en ukeplan for denne uken.",
       status: "LIVE_PLAN_EXISTS",
+    });
+  });
+
+  it("lists ingredient categories with keys", async () => {
+    listIngredientCategoriesMock.mockResolvedValue([
+      {
+        displayName: "Kjøtt og fisk",
+        familyId: null,
+        id: "cat-meat",
+        key: "meat-fish",
+      },
+    ]);
+
+    await expect(listIngredientCategoriesForMcp()).resolves.toEqual({
+      categories: [
+        {
+          displayName: "Kjøtt og fisk",
+          id: "cat-meat",
+          key: "meat-fish",
+        },
+      ],
+    });
+  });
+
+  it("creates a family recipe through createFamilyRecipe", async () => {
+    listIngredientCategoriesMock.mockResolvedValue([
+      {
+        displayName: "Kjøtt og fisk",
+        familyId: null,
+        id: "cat-meat",
+        key: "meat-fish",
+      },
+    ]);
+    createFamilyRecipeMock.mockResolvedValue({
+      recipe: { id: "recipe-1", title: "Kyllingwok" },
+      status: "CREATED",
+    });
+    getAccessibleRecipeDetailMock.mockResolvedValue({
+      recipe: familyRecipeDetail,
+      status: "FOUND",
+    });
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        ingredients: [
+          {
+            amount: "500",
+            categoryKey: "meat-fish",
+            displayName: "Kyllingfilet",
+            preferredStoreId: "store-1",
+            unit: "g",
+          },
+        ],
+        origin: "https://mealplanner.example",
+        tags: ["middag"],
+        title: "Kyllingwok",
+      }),
+    ).resolves.toEqual({
+      action: "created",
+      recipe: serializedFamilyRecipe,
+      recipeId: "recipe-1",
+      recipeUrl:
+        "https://mealplanner.example/families/family-1/recipes/recipe-1",
+      status: "CREATED",
+      title: "Kyllingwok",
+    });
+    expect(createFamilyRecipeMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        defaultServings: "",
+        description: "",
+        ingredients: [
+          {
+            amount: "500",
+            categoryId: "cat-meat",
+            displayName: "Kyllingfilet",
+            preferredStoreId: "store-1",
+            unit: "g",
+          },
+        ],
+        prepMinutes: "",
+        reminderSuggestions: [],
+        tags: "middag",
+        title: "Kyllingwok",
+      },
+    });
+    expect(updateFamilyRecipeMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown ingredient categories without writing", async () => {
+    listIngredientCategoriesMock.mockResolvedValue([
+      {
+        displayName: "Kjøtt og fisk",
+        familyId: null,
+        id: "cat-meat",
+        key: "meat-fish",
+      },
+    ]);
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        ingredients: [
+          {
+            categoryKey: "unknown",
+            displayName: "Kyllingfilet",
+          },
+        ],
+        origin: "https://mealplanner.example",
+        title: "Kyllingwok",
+      }),
+    ).resolves.toEqual({
+      formError: "Ingrediens 1: Ukjent kategorinøkkel: unknown",
+      status: "VALIDATION_ERROR",
+    });
+    expect(createFamilyRecipeMock).not.toHaveBeenCalled();
+  });
+
+  it("does not update a global recipe", async () => {
+    getAccessibleRecipeDetailMock.mockResolvedValue({
+      recipe: {
+        ...familyRecipeDetail,
+        familyId: null,
+        id: "global-recipe",
+        scope: "GLOBAL",
+      },
+      status: "FOUND",
+    });
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        origin: "https://mealplanner.example",
+        recipeId: "global-recipe",
+        tags: ["middag"],
+      }),
+    ).resolves.toEqual({
+      formError: "Fant ikke oppskriften.",
+      status: "NOT_FOUND",
+    });
+    expect(updateFamilyRecipeMock).not.toHaveBeenCalled();
+  });
+
+  it("does not write when the recipe id is missing", async () => {
+    getAccessibleRecipeDetailMock.mockResolvedValue({
+      status: "NOT_FOUND",
+    });
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        origin: "https://mealplanner.example",
+        recipeId: "missing",
+        tags: ["middag"],
+      }),
+    ).resolves.toEqual({
+      formError: "Fant ikke oppskriften.",
+      status: "NOT_FOUND",
+    });
+    expect(updateFamilyRecipeMock).not.toHaveBeenCalled();
+  });
+
+  it("merges a tags-only update onto the stored recipe", async () => {
+    getAccessibleRecipeDetailMock
+      .mockResolvedValueOnce({
+        recipe: familyRecipeDetail,
+        status: "FOUND",
+      })
+      .mockResolvedValueOnce({
+        recipe: {
+          ...familyRecipeDetail,
+          tags: ["middag", "rask", "kylling"],
+        },
+        status: "FOUND",
+      });
+    updateFamilyRecipeMock.mockResolvedValue({ status: "UPDATED" });
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        origin: "https://mealplanner.example",
+        recipeId: "recipe-1",
+        tags: ["middag", "rask", "kylling"],
+      }),
+    ).resolves.toEqual({
+      action: "updated",
+      recipe: {
+        ...serializedFamilyRecipe,
+        tags: ["middag", "rask", "kylling"],
+      },
+      recipeId: "recipe-1",
+      recipeUrl:
+        "https://mealplanner.example/families/family-1/recipes/recipe-1",
+      status: "UPDATED",
+      title: "Kyllingwok",
+    });
+    expect(updateFamilyRecipeMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      recipeId: "recipe-1",
+      userId: "user-1",
+      values: {
+        defaultServings: "4",
+        description: "En god middag",
+        ingredients: [
+          {
+            amount: "500",
+            categoryId: "cat-meat",
+            displayName: "Kyllingfilet",
+            preferredStoreId: "store-1",
+            unit: "g",
+          },
+        ],
+        prepMinutes: "30",
+        reminderSuggestions: [
+          {
+            note: "Ta ut kvelden før",
+            timingKind: "HOURS_BEFORE_16",
+            title: "Ta deigen ut",
+          },
+        ],
+        tags: "middag, rask, kylling",
+        title: "Kyllingwok",
+      },
+    });
+    expect(createFamilyRecipeMock).not.toHaveBeenCalled();
+  });
+
+  it("merges a description-only update without changing tags", async () => {
+    getAccessibleRecipeDetailMock
+      .mockResolvedValueOnce({
+        recipe: familyRecipeDetail,
+        status: "FOUND",
+      })
+      .mockResolvedValueOnce({
+        recipe: {
+          ...familyRecipeDetail,
+          description: "Ny beskrivelse",
+        },
+        status: "FOUND",
+      });
+    updateFamilyRecipeMock.mockResolvedValue({ status: "UPDATED" });
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        description: "Ny beskrivelse",
+        origin: "https://mealplanner.example",
+        recipeId: "recipe-1",
+      }),
+    ).resolves.toMatchObject({
+      action: "updated",
+      recipe: { description: "Ny beskrivelse", tags: ["middag"] },
+      status: "UPDATED",
+    });
+    expect(updateFamilyRecipeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({
+          description: "Ny beskrivelse",
+          tags: "middag",
+          title: "Kyllingwok",
+        }),
+      }),
+    );
+  });
+
+  it("replaces ingredients on update when they are sent", async () => {
+    listIngredientCategoriesMock.mockResolvedValue([
+      {
+        displayName: "Meieri",
+        familyId: null,
+        id: "cat-dairy",
+        key: "dairy",
+      },
+    ]);
+    getAccessibleRecipeDetailMock
+      .mockResolvedValueOnce({
+        recipe: familyRecipeDetail,
+        status: "FOUND",
+      })
+      .mockResolvedValueOnce({
+        recipe: {
+          ...familyRecipeDetail,
+          ingredients: [
+            {
+              amount: "200",
+              category: { displayName: "Meieri", id: "cat-dairy", key: "dairy" },
+              categoryId: "cat-dairy",
+              displayName: "Ost",
+              preferredStoreId: null,
+              unit: "g",
+            },
+          ],
+        },
+        status: "FOUND",
+      });
+    updateFamilyRecipeMock.mockResolvedValue({ status: "UPDATED" });
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        ingredients: [
+          {
+            amount: "200",
+            category: "Meieri",
+            displayName: "Ost",
+            unit: "g",
+          },
+        ],
+        origin: "https://mealplanner.example",
+        recipeId: "recipe-1",
+      }),
+    ).resolves.toMatchObject({
+      action: "updated",
+      status: "UPDATED",
+    });
+    expect(updateFamilyRecipeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({
+          ingredients: [
+            {
+              amount: "200",
+              categoryId: "cat-dairy",
+              displayName: "Ost",
+              preferredStoreId: "",
+              unit: "g",
+            },
+          ],
+          title: "Kyllingwok",
+        }),
+      }),
+    );
+  });
+
+  it("applies a full-field update", async () => {
+    listIngredientCategoriesMock.mockResolvedValue([
+      {
+        displayName: "Kjøtt og fisk",
+        familyId: null,
+        id: "cat-meat",
+        key: "meat-fish",
+      },
+    ]);
+    getAccessibleRecipeDetailMock
+      .mockResolvedValueOnce({
+        recipe: familyRecipeDetail,
+        status: "FOUND",
+      })
+      .mockResolvedValueOnce({
+        recipe: {
+          ...familyRecipeDetail,
+          defaultServings: 6,
+          description: "Oppdatert",
+          prepMinutes: 40,
+          tags: ["middag", "wok"],
+          title: "Wok",
+        },
+        status: "FOUND",
+      });
+    updateFamilyRecipeMock.mockResolvedValue({ status: "UPDATED" });
+
+    await expect(
+      upsertRecipeForMcp({
+        ...actor,
+        defaultServings: 6,
+        description: "Oppdatert",
+        ingredients: [
+          {
+            amount: "500",
+            categoryKey: "meat-fish",
+            displayName: "Kyllingfilet",
+            unit: "g",
+          },
+        ],
+        origin: "https://mealplanner.example",
+        prepMinutes: 40,
+        recipeId: "recipe-1",
+        reminderSuggestions: [
+          { timingKind: "MORNING_OF", title: "Sett ovnen på" },
+        ],
+        tags: ["middag", "wok"],
+        title: "Wok",
+      }),
+    ).resolves.toMatchObject({
+      action: "updated",
+      recipe: { title: "Wok" },
+      status: "UPDATED",
+    });
+    expect(updateFamilyRecipeMock).toHaveBeenCalledWith({
+      familyId: "family-1",
+      recipeId: "recipe-1",
+      userId: "user-1",
+      values: {
+        defaultServings: "6",
+        description: "Oppdatert",
+        ingredients: [
+          {
+            amount: "500",
+            categoryId: "cat-meat",
+            displayName: "Kyllingfilet",
+            preferredStoreId: "",
+            unit: "g",
+          },
+        ],
+        prepMinutes: "40",
+        reminderSuggestions: [
+          {
+            note: "",
+            timingKind: "MORNING_OF",
+            title: "Sett ovnen på",
+          },
+        ],
+        tags: "middag, wok",
+        title: "Wok",
+      },
     });
   });
 });

--- a/app/lib/mcp-tools.server.ts
+++ b/app/lib/mcp-tools.server.ts
@@ -14,12 +14,22 @@ import {
   getRecentlyUsedRecipeIds,
   listMealPlansForFamily,
 } from "./meal-plan.server";
+import type { UpsertRecipeInput } from "./mcp-recipe-schema";
 import { buildFamilyMealPlanProposalUrl } from "./mcp-token.server";
+import { buildFamilyRecipeUrl } from "./recipe-reminder";
 import {
   getAccessibleRecipeDetail,
   getRecipeManagementData,
 } from "./recipe.server";
+import {
+  createFamilyRecipe,
+  updateFamilyRecipe,
+  type FamilyRecipeFieldErrors,
+  type FamilyRecipeIngredientValues,
+  type FamilyRecipeValues,
+} from "./recipe-write.server";
 import { getFamilyShoppingData } from "./shopping.server";
+import { listIngredientCategories } from "./store.server";
 
 const NO_CURRENT_MEAL_PLAN_ID = "__none__";
 
@@ -61,6 +71,57 @@ export async function listRecipesForMcp({ familyId, userId }: McpActor) {
   };
 }
 
+function serializeMcpRecipeDetail(recipe: {
+  defaultServings: number | null;
+  description: string | null;
+  id: string;
+  imageUrl: string | null;
+  ingredients: Array<{
+    amount: string | null;
+    category: { displayName: string; id: string; key: string };
+    categoryId: string;
+    displayName: string;
+    preferredStoreId: string | null;
+    unit: string | null;
+  }>;
+  prepMinutes: number | null;
+  reminderSuggestions?: Array<{
+    note: string | null;
+    timingKind: string | null;
+    title: string;
+  }>;
+  scope: "FAMILY" | "GLOBAL";
+  tags: string[];
+  title: string;
+}) {
+  return {
+    defaultServings: recipe.defaultServings,
+    description: recipe.description,
+    id: recipe.id,
+    imageUrl: recipe.imageUrl,
+    ingredients: recipe.ingredients.map((ingredient) => ({
+      amount: ingredient.amount,
+      category: ingredient.category.displayName,
+      categoryId: ingredient.categoryId,
+      categoryKey: ingredient.category.key,
+      displayName: ingredient.displayName,
+      preferredStoreId: ingredient.preferredStoreId,
+      unit: ingredient.unit,
+    })),
+    prepMinutes: recipe.prepMinutes,
+    reminderSuggestions: (recipe.reminderSuggestions ?? []).map(
+      (suggestion) => ({
+        note: suggestion.note,
+        timingKind: suggestion.timingKind,
+        title: suggestion.title,
+      }),
+    ),
+    scope: recipe.scope,
+    tags: recipe.tags,
+    title: recipe.title,
+  };
+}
+
 export async function getRecipeForMcp({
   familyId,
   recipeId,
@@ -77,22 +138,19 @@ export async function getRecipeForMcp({
   }
 
   return {
-    recipe: {
-      defaultServings: result.recipe.defaultServings,
-      description: result.recipe.description,
-      id: result.recipe.id,
-      imageUrl: result.recipe.imageUrl,
-      ingredients: result.recipe.ingredients.map((ingredient) => ({
-        amount: ingredient.amount,
-        category: ingredient.category.displayName,
-        displayName: ingredient.displayName,
-        unit: ingredient.unit,
-      })),
-      prepMinutes: result.recipe.prepMinutes,
-      scope: result.recipe.scope,
-      tags: result.recipe.tags,
-      title: result.recipe.title,
-    },
+    recipe: serializeMcpRecipeDetail(result.recipe),
+  };
+}
+
+export async function listIngredientCategoriesForMcp() {
+  const categories = await listIngredientCategories();
+
+  return {
+    categories: categories.map((category) => ({
+      displayName: category.displayName,
+      id: category.id,
+      key: category.key,
+    })),
   };
 }
 
@@ -285,4 +343,378 @@ export async function createMealPlanProposalForMcp({
     weekEnd: result.weekEnd,
     weekStart: result.weekStart,
   };
+}
+
+const EMPTY_FAMILY_RECIPE_VALUES: FamilyRecipeValues = {
+  defaultServings: "",
+  description: "",
+  ingredients: [],
+  prepMinutes: "",
+  reminderSuggestions: [],
+  tags: "",
+  title: "",
+};
+
+function formatFamilyRecipeFieldErrors(fieldErrors: FamilyRecipeFieldErrors) {
+  const lines: string[] = [];
+
+  const pushIndexed = (
+    records: Record<number, string> | undefined,
+    prefix: string,
+  ) => {
+    if (!records) {
+      return;
+    }
+
+    for (const [index, message] of Object.entries(records)) {
+      lines.push(`${prefix} ${Number(index) + 1}: ${message}`);
+    }
+  };
+
+  if (fieldErrors.title) {
+    lines.push(fieldErrors.title);
+  }
+
+  if (fieldErrors.defaultServings) {
+    lines.push(fieldErrors.defaultServings);
+  }
+
+  if (fieldErrors.prepMinutes) {
+    lines.push(fieldErrors.prepMinutes);
+  }
+
+  if (fieldErrors.ingredients) {
+    lines.push(fieldErrors.ingredients);
+  }
+
+  if (fieldErrors.coverImage) {
+    lines.push(fieldErrors.coverImage);
+  }
+
+  if (fieldErrors.reminderSuggestions) {
+    lines.push(fieldErrors.reminderSuggestions);
+  }
+
+  pushIndexed(fieldErrors.ingredientDisplayNames, "Ingrediens");
+  pushIndexed(fieldErrors.ingredientCategories, "Ingrediens");
+  pushIndexed(fieldErrors.ingredientAmounts, "Ingrediens");
+  pushIndexed(fieldErrors.reminderTitles, "Påminnelse");
+  pushIndexed(fieldErrors.reminderNotes, "Påminnelse");
+  pushIndexed(fieldErrors.reminderTimingKinds, "Påminnelse");
+
+  return lines.join(" ");
+}
+
+function resolveIngredientCategoryId(
+  ingredient: {
+    category?: string;
+    categoryId?: string;
+    categoryKey?: string;
+  },
+  categories: Array<{ displayName: string; id: string; key: string }>,
+): { categoryId: string; ok: true } | { error: string; ok: false } {
+  if (ingredient.categoryKey) {
+    const match = categories.find(
+      (category) => category.key === ingredient.categoryKey,
+    );
+
+    if (!match) {
+      return {
+        error: `Ukjent kategorinøkkel: ${ingredient.categoryKey}`,
+        ok: false,
+      };
+    }
+
+    return { categoryId: match.id, ok: true };
+  }
+
+  if (ingredient.categoryId) {
+    const match = categories.find(
+      (category) => category.id === ingredient.categoryId,
+    );
+
+    if (!match) {
+      return {
+        error: `Ukjent kategori-id: ${ingredient.categoryId}`,
+        ok: false,
+      };
+    }
+
+    return { categoryId: match.id, ok: true };
+  }
+
+  const name = ingredient.category?.trim().toLowerCase() ?? "";
+  const matches = categories.filter(
+    (category) => category.displayName.trim().toLowerCase() === name,
+  );
+
+  if (matches.length === 1) {
+    return { categoryId: matches[0].id, ok: true };
+  }
+
+  if (matches.length > 1) {
+    return {
+      error: `Kategorinavnet matcher flere kategorier: ${ingredient.category}`,
+      ok: false,
+    };
+  }
+
+  return {
+    error: `Ukjent kategori: ${ingredient.category}`,
+    ok: false,
+  };
+}
+
+async function mapUpsertIngredients(
+  ingredients: NonNullable<UpsertRecipeInput["ingredients"]>,
+): Promise<
+  | { ingredients: FamilyRecipeIngredientValues[]; ok: true }
+  | { formError: string; ok: false }
+> {
+  const categories = await listIngredientCategories();
+  const mapped: FamilyRecipeIngredientValues[] = [];
+
+  for (const [index, ingredient] of ingredients.entries()) {
+    const resolved = resolveIngredientCategoryId(ingredient, categories);
+
+    if (!resolved.ok) {
+      return {
+        formError: `Ingrediens ${index + 1}: ${resolved.error}`,
+        ok: false,
+      };
+    }
+
+    mapped.push({
+      amount: ingredient.amount ?? "",
+      categoryId: resolved.categoryId,
+      displayName: ingredient.displayName,
+      preferredStoreId: ingredient.preferredStoreId ?? "",
+      unit: ingredient.unit ?? "",
+    });
+  }
+
+  return { ingredients: mapped, ok: true };
+}
+
+function mapUpsertReminders(
+  reminders: NonNullable<UpsertRecipeInput["reminderSuggestions"]>,
+) {
+  return reminders.map((suggestion) => ({
+    note: suggestion.note ?? "",
+    timingKind: suggestion.timingKind ?? "",
+    title: suggestion.title,
+  }));
+}
+
+function overlayUpsertOnFamilyValues({
+  base,
+  input,
+  resolvedIngredients,
+}: {
+  base: FamilyRecipeValues;
+  input: UpsertRecipeInput;
+  resolvedIngredients?: FamilyRecipeIngredientValues[];
+}): FamilyRecipeValues {
+  return {
+    defaultServings:
+      input.defaultServings !== undefined
+        ? String(input.defaultServings)
+        : base.defaultServings,
+    description:
+      input.description !== undefined ? input.description : base.description,
+    ingredients: resolvedIngredients ?? base.ingredients,
+    prepMinutes:
+      input.prepMinutes !== undefined
+        ? String(input.prepMinutes)
+        : base.prepMinutes,
+    reminderSuggestions:
+      input.reminderSuggestions !== undefined
+        ? mapUpsertReminders(input.reminderSuggestions)
+        : base.reminderSuggestions,
+    tags: input.tags !== undefined ? input.tags.join(", ") : base.tags,
+    title: input.title !== undefined ? input.title : base.title,
+  };
+}
+
+function storedRecipeToFamilyValues(recipe: {
+  defaultServings: number | null;
+  description: string | null;
+  ingredients: Array<{
+    amount: string | null;
+    categoryId: string;
+    displayName: string;
+    preferredStoreId: string | null;
+    unit: string | null;
+  }>;
+  prepMinutes: number | null;
+  reminderSuggestions: Array<{
+    note: string | null;
+    timingKind: string | null;
+    title: string;
+  }>;
+  tags: string[];
+  title: string;
+}): FamilyRecipeValues {
+  return {
+    defaultServings:
+      recipe.defaultServings != null ? String(recipe.defaultServings) : "",
+    description: recipe.description ?? "",
+    ingredients: recipe.ingredients.map((ingredient) => ({
+      amount: ingredient.amount ?? "",
+      categoryId: ingredient.categoryId,
+      displayName: ingredient.displayName,
+      preferredStoreId: ingredient.preferredStoreId ?? "",
+      unit: ingredient.unit ?? "",
+    })),
+    prepMinutes: recipe.prepMinutes != null ? String(recipe.prepMinutes) : "",
+    reminderSuggestions: recipe.reminderSuggestions.map((suggestion) => ({
+      note: suggestion.note ?? "",
+      timingKind: suggestion.timingKind ?? "",
+      title: suggestion.title,
+    })),
+    tags: recipe.tags.join(", "),
+    title: recipe.title,
+  };
+}
+
+async function buildUpsertSuccessResult({
+  action,
+  familyId,
+  origin,
+  recipeId,
+  title,
+  userId,
+}: McpActor & {
+  action: "created" | "updated";
+  origin: string;
+  recipeId: string;
+  title: string;
+}) {
+  const detail = await getRecipeForMcp({ familyId, recipeId, userId });
+
+  return {
+    action,
+    recipe: detail?.recipe ?? {
+      defaultServings: null,
+      description: null,
+      id: recipeId,
+      imageUrl: null,
+      ingredients: [],
+      prepMinutes: null,
+      reminderSuggestions: [],
+      scope: "FAMILY" as const,
+      tags: [],
+      title,
+    },
+    recipeId,
+    recipeUrl: buildFamilyRecipeUrl({ familyId, origin, recipeId }),
+    status: action === "created" ? ("CREATED" as const) : ("UPDATED" as const),
+    title: detail?.recipe.title ?? title,
+  };
+}
+
+export async function upsertRecipeForMcp({
+  familyId,
+  origin,
+  userId,
+  ...input
+}: McpActor & { origin: string } & UpsertRecipeInput) {
+  let resolvedIngredients: FamilyRecipeIngredientValues[] | undefined;
+
+  if (input.ingredients) {
+    const mapped = await mapUpsertIngredients(input.ingredients);
+
+    if (!mapped.ok) {
+      return {
+        formError: mapped.formError,
+        status: "VALIDATION_ERROR" as const,
+      };
+    }
+
+    resolvedIngredients = mapped.ingredients;
+  }
+
+  if (!input.recipeId) {
+    const values = overlayUpsertOnFamilyValues({
+      base: EMPTY_FAMILY_RECIPE_VALUES,
+      input,
+      resolvedIngredients,
+    });
+    const result = await createFamilyRecipe({
+      familyId,
+      userId,
+      values,
+    });
+
+    if (result.status !== "CREATED") {
+      return {
+        formError: formatFamilyRecipeFieldErrors(result.fieldErrors),
+        status: "VALIDATION_ERROR" as const,
+      };
+    }
+
+    return buildUpsertSuccessResult({
+      action: "created",
+      familyId,
+      origin,
+      recipeId: result.recipe.id,
+      title: result.recipe.title,
+      userId,
+    });
+  }
+
+  const existing = await getAccessibleRecipeDetail({
+    familyId,
+    recipeId: input.recipeId,
+    userId,
+  });
+
+  if (
+    existing.status !== "FOUND" ||
+    existing.recipe.scope !== "FAMILY" ||
+    existing.recipe.familyId !== familyId
+  ) {
+    return {
+      formError: "Fant ikke oppskriften.",
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  const values = overlayUpsertOnFamilyValues({
+    base: storedRecipeToFamilyValues({
+      ...existing.recipe,
+      reminderSuggestions: existing.recipe.reminderSuggestions ?? [],
+    }),
+    input,
+    resolvedIngredients,
+  });
+  const result = await updateFamilyRecipe({
+    familyId,
+    recipeId: input.recipeId,
+    userId,
+    values,
+  });
+
+  if (result.status === "NOT_FOUND") {
+    return {
+      formError: "Fant ikke oppskriften.",
+      status: "NOT_FOUND" as const,
+    };
+  }
+
+  if (result.status !== "UPDATED") {
+    return {
+      formError: formatFamilyRecipeFieldErrors(result.fieldErrors),
+      status: "VALIDATION_ERROR" as const,
+    };
+  }
+
+  return buildUpsertSuccessResult({
+    action: "updated",
+    familyId,
+    origin,
+    recipeId: input.recipeId,
+    title: values.title,
+    userId,
+  });
 }

--- a/app/lib/recipe-write.server.test.ts
+++ b/app/lib/recipe-write.server.test.ts
@@ -111,6 +111,7 @@ describe("recipe-write.server", () => {
         displayName: "Kjott og fisk",
         familyId: null,
         id: "category-meat",
+        key: "meat-fish",
       },
     ]);
     dbMock.store.findMany.mockResolvedValue([
@@ -179,6 +180,65 @@ describe("recipe-write.server", () => {
               displayName: "Kyllingfilet",
               sortOrder: 1,
             }),
+          ],
+        },
+      }),
+      select: {
+        id: true,
+        title: true,
+      },
+    });
+  });
+
+  it("creates a family recipe with ordered reminder suggestions", async () => {
+    dbMock.recipe.create.mockResolvedValue({
+      id: "recipe-1",
+      title: "Kyllingwok",
+    });
+
+    const result = await createFamilyRecipe({
+      familyId: "family-1",
+      userId: "user-1",
+      values: {
+        ...baseValues,
+        reminderSuggestions: [
+          {
+            note: "Ta ut kvelden før",
+            timingKind: "HOURS_BEFORE_16",
+            title: "Ta deigen ut av kjøleskapet",
+          },
+          {
+            note: "",
+            timingKind: "MORNING_OF",
+            title: "Sett ovnen på",
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      recipe: {
+        id: "recipe-1",
+        title: "Kyllingwok",
+      },
+      status: "CREATED",
+    });
+    expect(dbMock.recipe.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        reminderSuggestions: {
+          create: [
+            {
+              note: "Ta ut kvelden før",
+              sortOrder: 1,
+              timingKind: "HOURS_BEFORE_16",
+              title: "Ta deigen ut av kjøleskapet",
+            },
+            {
+              note: null,
+              sortOrder: 2,
+              timingKind: "MORNING_OF",
+              title: "Sett ovnen på",
+            },
           ],
         },
       }),

--- a/app/lib/recipe-write.server.ts
+++ b/app/lib/recipe-write.server.ts
@@ -237,6 +237,19 @@ export async function createFamilyRecipe({
         })),
       },
       prepMinutes: validation.parsed.prepMinutes,
+      reminderSuggestions:
+        validation.parsed.reminderSuggestions.length > 0
+          ? {
+              create: validation.parsed.reminderSuggestions.map(
+                (suggestion, index) => ({
+                  note: suggestion.note,
+                  sortOrder: index + 1,
+                  timingKind: suggestion.timingKind,
+                  title: suggestion.title,
+                }),
+              ),
+            }
+          : undefined,
       scope: RecipeScope.FAMILY,
       tags: validation.parsed.tags,
       title: validation.parsed.title,

--- a/app/lib/recipe.server.ts
+++ b/app/lib/recipe.server.ts
@@ -12,6 +12,7 @@ export const recipeIngredientSelect =
       select: {
         displayName: true,
         id: true,
+        key: true,
       },
     },
     categoryId: true,

--- a/app/lib/store.server.ts
+++ b/app/lib/store.server.ts
@@ -8,6 +8,7 @@ export const storeCategorySelect =
     displayName: true,
     familyId: true,
     id: true,
+    key: true,
   });
 
 export const managedStoreSectionSelect =

--- a/app/routes/family-meal-plan-store-mode.test.ts
+++ b/app/routes/family-meal-plan-store-mode.test.ts
@@ -128,6 +128,7 @@ describe("family store mode route", () => {
         displayName: "Meieri",
         familyId: null,
         id: "category-dairy",
+        key: "dairy",
       },
     ]);
     vi.mocked(listRecentManualShoppingItemsForFamily).mockResolvedValue([
@@ -275,6 +276,7 @@ describe("family store mode route", () => {
         displayName: "Meieri",
         familyId: null,
         id: "category-dairy",
+        key: "dairy",
       },
     ]);
     expect(result.shoppingHistory).toEqual([]);

--- a/app/routes/family-recipes.test.ts
+++ b/app/routes/family-recipes.test.ts
@@ -62,7 +62,7 @@ describe("family recipes route", () => {
   it("loads family and global recipe lists", async () => {
     vi.mocked(requireUser).mockResolvedValue(mockUser);
     vi.mocked(getRecipeManagementData).mockResolvedValue({
-      categories: [{ displayName: "Meieri", familyId: null, id: "category-dairy" }],
+      categories: [{ displayName: "Meieri", familyId: null, id: "category-dairy", key: "dairy" }],
       family: { id: "family-1", name: "Solberg" },
       familyRecipes: [
         {

--- a/app/routes/family-shopping-catalog.test.ts
+++ b/app/routes/family-shopping-catalog.test.ts
@@ -87,7 +87,7 @@ describe("family shopping catalog route", () => {
       userRole: "MEMBER",
     });
     vi.mocked(listIngredientCategories).mockResolvedValue([
-      { displayName: "Annet", familyId: null, id: "category-other" },
+      { displayName: "Annet", familyId: null, id: "category-other", key: "other" },
     ]);
 
     const result = await loader({

--- a/app/routes/family-stores.test.ts
+++ b/app/routes/family-stores.test.ts
@@ -55,6 +55,7 @@ describe("family stores route", () => {
           displayName: "Frukt og gront",
           familyId: null,
           id: "category-produce",
+          key: "produce",
         },
       ],
       family: {
@@ -98,6 +99,7 @@ describe("family stores route", () => {
           displayName: "Frukt og gront",
           familyId: null,
           id: "category-produce",
+          key: "produce",
         },
       ],
       family: {

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,7 +2,10 @@
 
 The app exposes a [Model Context Protocol](https://modelcontextprotocol.io) server on the same process as the website (`GET`/`POST` `/mcp`). Production transport is **Streamable HTTP**, not stdio.
 
-Most tools are read-only. `create_meal_plan_proposal` can store a **proposal** for a week; it never approves a live meal plan.
+Most tools are read-only. Two tools write family data:
+
+- `create_meal_plan_proposal` stores a **proposal** for a week; it never approves a live meal plan.
+- `upsert_recipe` creates or updates a **family** recipe. It cannot create or change global recipes, and it cannot upload a cover image (use the website for photos).
 
 ## Mint a token
 
@@ -39,17 +42,21 @@ You can also use [MCP Inspector](https://github.com/modelcontextprotocol/inspect
 Authenticated clients can call:
 
 - `list_recipes` — family and global recipes (title, description, image URL, tags, servings, prep)
-- `get_recipe` — one recipe including ingredients
+- `get_recipe` — one recipe including ingredients (category id/key/name, preferred store), tags, and reminder suggestions
+- `list_ingredient_categories` — global ingredient categories (`id`, `key`, `displayName`) for `upsert_recipe`
 - `get_current_week_meal_plan` — Europe/Oslo calendar week dinners (live DRAFT/APPROVED plans only)
 - `list_meal_plans` — plan summaries (excludes open proposals)
 - `get_shopping_list` — current family shopping projection
 - `get_recent_dinners` — recently used dinner recipes
 - `list_freezer_items` — freezer stock
 - `create_meal_plan_proposal` — create or replace a proposed dinner plan for a calendar week
+- `upsert_recipe` — create a family recipe, or update one by `recipeId`
 
 `create_meal_plan_proposal` defaults to **next** Europe/Oslo week (Monday–Sunday) when `weekStart` / `weekEnd` are omitted. Re-running for the same week updates the existing proposal in place and returns the same URL. It fails if a live DRAFT or APPROVED plan already covers that week.
 
 The tool returns `proposalUrl`. Put that in email as **Se forslaget i Mealplanner her**. Opening the link (after login) shows the proposal UI, where a family member can adjust dinners and approve. Approval turns the proposal into a live meal plan. MCP cannot approve or reopen plans.
+
+`upsert_recipe` without `recipeId` creates a family recipe (title and at least one ingredient required). With `recipeId`, it patches that family recipe: omitted fields stay unchanged. `tags`, `ingredients`, and `reminderSuggestions` **replace** the stored list when sent. Identify ingredient categories with `categoryKey` (preferred), `categoryId`, or category display name. If `defaultServings` or `prepMinutes` are omitted on create, the web-form defaults apply (2 servings, 45 minutes). Cover images stay in the web UI.
 
 The token is scoped to one family.
 


### PR DESCRIPTION
## Summary
- Adds `upsert_recipe` so an authenticated MCP client can create a family recipe or patch any writable field (title, description, servings, prep, tags, ingredients, reminders) with Zod validation.
- Adds `list_ingredient_categories` and returns category keys, store ids, and reminders from `get_recipe` so agents can round-trip edits without wiping stored data.
- Reuses `createFamilyRecipe` / `updateFamilyRecipe` (FAMILY only; cover images stay in the web UI).

## Related issue
Closes #246

## Test plan
- [x] Validation run locally: prisma:generate, lint, test:run, typecheck
- [ ] Call `list_ingredient_categories`, create a recipe with `upsert_recipe`, then `get_recipe`
- [ ] Patch tags only and confirm ingredients are unchanged on the family recipe page
- [ ] Confirm a GLOBAL recipe id is rejected

## Validation
- npm run prisma:generate
- npm run lint
- npm run test:run
- npm run typecheck